### PR TITLE
Add target to docs/Makefile to auto publish gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ _templates/
 *.xls*
 .coverage
 _temp/
-Makefile
 pylintout
 coverage.xml
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,31 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+GH_PAGES_SOURCES = . Makefile
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+gh-pages:
+	git checkout gh-pages
+	rm -rf _build _sources _static
+	git checkout develop $(GH_PAGES_SOURCES
+	git reset HEAD
+	make html
+	mv -fv _build/html/* ./
+	rm -rf $(GH_PAGES_SOURCES) _build
+	git add -A
+	git ci -m "Generated gh-pages for `git log master -1 --pretty=short --abbrec-commit`" && git push origin gh-pages ; git checkout develop


### PR DESCRIPTION
This target should allow make gh-pages to build the documentation and push it to the gh-pages branch,