### PR TITLE
Group program db tests into classes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,17 +250,25 @@ def test_common_dao():
     if os.path.exists(TEST_COMMON_DB_PATH):
         os.remove(TEST_COMMON_DB_PATH)
 
+    # We create a new database for each class-level grouping of tests.  This
+    # should prevent errors (e.g., database locked) caused by attempting to
+    # access the database to0 rapidly from test-to-test.  PyTest causes each
+    # temporary directory to be deleted when it is finished with it.
+    tempdir = tempfile.TemporaryDirectory(prefix=TMP_DIR + '/')
+    tempdb = str(tempdir.name) + '/TestCommonDB.ramstk'
+    tempuri = 'sqlite:///' + tempdb
+
     # Create the test database.
     sql_file = open('./devtools/sqlite_test_common_db.sql', 'r')
     script_str = sql_file.read().strip()
-    conn = sqlite3.connect(TEST_COMMON_DB_PATH)
+    conn = sqlite3.connect(tempdb)
     conn.executescript(script_str)
     conn.commit()
     conn.close()
 
     # Use the RAMSTK DAO to connect to the fresh, new test database.
     dao = DAO()
-    dao.db_connect(TEST_COMMON_DB_URI)
+    dao.db_connect(tempuri)
 
     yield dao
 
@@ -287,17 +295,25 @@ def test_program_dao():
     if os.path.exists(TEMPDIR + '/_ramstk_program_db.ramstk'):
         os.remove(TEMPDIR + '/_ramstk_program_db.ramstk')
 
+    # We create a new database for each class-level grouping of tests.  This
+    # should prevent errors (e.g., database locked) caused by attempting to
+    # access the database to0 rapidly from test-to-test.  PyTest causes each
+    # temporary directory to be deleted when it is finished with it.
+    tempdir = tempfile.TemporaryDirectory(prefix=TMP_DIR + '/')
+    tempdb = str(tempdir.name) + '/TestProgramDB.ramstk'
+    tempuri = 'sqlite:///' + tempdb
+
     # Create the test database.
     sql_file = open('./devtools/sqlite_test_program_db.sql', 'r')
     script_str = sql_file.read().strip()
-    conn = sqlite3.connect(TEST_PROGRAM_DB_PATH)
+    conn = sqlite3.connect(tempdb)
     conn.executescript(script_str)
     conn.commit()
     conn.close()
 
     # Use the RAMSTK DAO to connect to the fresh, new test database.
     dao = DAO()
-    dao.db_connect(TEST_PROGRAM_DB_URI)
+    dao.db_connect(tempuri)
 
     yield dao
 

--- a/tests/models/programdb/test_ramstkaction.py
+++ b/tests/models/programdb/test_ramstkaction.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkaction.py is part of The RAMSTK
@@ -8,7 +9,7 @@
 """Test class for testing the RAMSTKAction module algorithms and models."""
 
 # Standard Library Imports
-from datetime import date, timedelta
+from datetime import date
 
 # Third Party Imports
 import pytest

--- a/tests/models/programdb/test_ramstkallocation.py
+++ b/tests/models/programdb/test_ramstkallocation.py
@@ -1,9 +1,11 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.dao.programdb.test_ramstkallocation.py is part of The RAMSTK Project
+#       tests.models.programdb.test_ramstkallocation.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
-""" Test class for testing the RAMSTKAllocation module algorithms and models. """
+""" Test class for testing RAMSTKAllocation module algorithms and models. """
 
 # Third Party Imports
 import pytest
@@ -36,108 +38,98 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkallocation_create(test_dao):
-    """__init__() should create an RAMSTKAllocation model."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKAllocation).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKAllocation():
+    """Class for testing the RAMSTKAllocation model."""
+    @pytest.mark.integration
+    def test_ramstkallocation_create(self, test_program_dao):
+        """__init__() should create an RAMSTKAllocation model."""
+        DUT = test_program_dao.session.query(RAMSTKAllocation).first()
 
-    assert isinstance(DUT, RAMSTKAllocation)
+        assert isinstance(DUT, RAMSTKAllocation)
 
-    # Verify class attributes are properly initialized.  Commented attribute
-    # values vary depending on whether this test file is run stand-alone or as
-    # a result of python setup.py test.
-    assert DUT.__tablename__ == 'ramstk_allocation'
-    assert DUT.revision_id == 1
-    assert DUT.hardware_id == 1
-    assert DUT.availability_alloc == 0.0
-    assert DUT.duty_cycle == 100.0
-    assert DUT.env_factor == 1
-    assert DUT.goal_measure_id == 1
-    assert DUT.hazard_rate_alloc == 0.0
-    assert DUT.hazard_rate_goal == 0.0
-    assert DUT.included == 1
-    assert DUT.int_factor == 1
-    assert DUT.allocation_method_id == 1
-    # assert DUT.mission_time == 100.0
-    assert DUT.mtbf_alloc == 0.0
-    assert DUT.mtbf_goal == 0.0
-    assert DUT.n_sub_systems == 1
-    assert DUT.n_sub_elements == 1
-    assert DUT.parent_id == 0
-    assert DUT.percent_weight_factor == 0.0
-    assert DUT.reliability_alloc == 1.0
-    assert DUT.reliability_goal == 1.0
-    assert DUT.op_time_factor == 1
-    assert DUT.soa_factor == 1
-    assert DUT.weight_factor == 1
-
-
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """get_attributes() should return a dict of attribute values."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKAllocation).first()
-
-    _attributes = DUT.get_attributes()
-
-    assert isinstance(_attributes, dict)
-
-    assert _attributes['hardware_id'] == 1
-    assert _attributes['availability_alloc'] == 0.0
-    assert _attributes['duty_cycle'] == 100.0
-    assert _attributes['env_factor'] == 1
-    assert _attributes['goal_measure_id'] == 1
-    assert _attributes['hazard_rate_alloc'] == 0.0
-    assert _attributes['hazard_rate_goal'] == 0.0
-    assert _attributes['included'] == 1
-    assert _attributes['int_factor'] == 1
-    assert _attributes['allocation_method_id'] == 1
-    # assert _attributes['mission_time'] == 100.0
-    assert _attributes['mtbf_alloc'] == 0.0
-    assert _attributes['mtbf_goal'] == 0.0
-    assert _attributes['n_sub_systems'] == 1
-    assert _attributes['n_sub_elements'] == 1
-    assert _attributes['parent_id'] == 0
-    assert _attributes['percent_weight_factor'] == 0.0
-    assert _attributes['reliability_alloc'] == 1.0
-    assert _attributes['reliability_goal'] == 1.0
-    assert _attributes['op_time_factor'] == 1
-    assert _attributes['soa_factor'] == 1
-    assert _attributes['weight_factor'] == 1
+        # Verify class attributes are properly initialized.  Commented attribute
+        # values vary depending on whether this test file is run stand-alone or as
+        # a result of python setup.py test.
+        assert DUT.__tablename__ == 'ramstk_allocation'
+        assert DUT.revision_id == 1
+        assert DUT.hardware_id == 1
+        assert DUT.availability_alloc == 0.0
+        assert DUT.duty_cycle == 100.0
+        assert DUT.env_factor == 1
+        assert DUT.goal_measure_id == 1
+        assert DUT.hazard_rate_alloc == 0.0
+        assert DUT.hazard_rate_goal == 0.0
+        assert DUT.included == 1
+        assert DUT.int_factor == 1
+        assert DUT.allocation_method_id == 1
+        # assert DUT.mission_time == 100.0
+        assert DUT.mtbf_alloc == 0.0
+        assert DUT.mtbf_goal == 0.0
+        assert DUT.n_sub_systems == 1
+        assert DUT.n_sub_elements == 1
+        assert DUT.parent_id == 0
+        assert DUT.percent_weight_factor == 0.0
+        assert DUT.reliability_alloc == 1.0
+        assert DUT.reliability_goal == 1.0
+        assert DUT.op_time_factor == 1
+        assert DUT.soa_factor == 1
+        assert DUT.weight_factor == 1
 
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """set_attributes() should return None on success."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKAllocation).first()
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """get_attributes() should return a dict of attribute values."""
+        DUT = test_program_dao.session.query(RAMSTKAllocation).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        _attributes = DUT.get_attributes()
 
+        assert isinstance(_attributes, dict)
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKAllocation).first()
+        assert _attributes['hardware_id'] == 1
+        assert _attributes['availability_alloc'] == 0.0
+        assert _attributes['duty_cycle'] == 100.0
+        assert _attributes['env_factor'] == 1
+        assert _attributes['goal_measure_id'] == 1
+        assert _attributes['hazard_rate_alloc'] == 0.0
+        assert _attributes['hazard_rate_goal'] == 0.0
+        assert _attributes['included'] == 1
+        assert _attributes['int_factor'] == 1
+        assert _attributes['allocation_method_id'] == 1
+        # assert _attributes['mission_time'] == 100.0
+        assert _attributes['mtbf_alloc'] == 0.0
+        assert _attributes['mtbf_goal'] == 0.0
+        assert _attributes['n_sub_systems'] == 1
+        assert _attributes['n_sub_elements'] == 1
+        assert _attributes['parent_id'] == 0
+        assert _attributes['percent_weight_factor'] == 0.0
+        assert _attributes['reliability_alloc'] == 1.0
+        assert _attributes['reliability_goal'] == 1.0
+        assert _attributes['op_time_factor'] == 1
+        assert _attributes['soa_factor'] == 1
+        assert _attributes['weight_factor'] == 1
 
-    ATTRIBUTES['reliability_alloc'] = None
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """set_attributes() should return None on success."""
+        DUT = test_program_dao.session.query(RAMSTKAllocation).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['reliability_alloc'] == 1.0
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKAllocation).first()
 
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKAllocation).first()
+        ATTRIBUTES['reliability_alloc'] = None
 
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['reliability_alloc'] == 1.0
+
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKAllocation).first()
+
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkcontrol.py
+++ b/tests/models/programdb/test_ramstkcontrol.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkcontrol.py is part of The RAMSTK

--- a/tests/models/programdb/test_ramstkdesignelectric.py
+++ b/tests/models/programdb/test_ramstkdesignelectric.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.dao.programdb.test_ramstkdesignelectric.py is part of The RAMSTK
@@ -70,174 +71,158 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkdesignelectric_create(test_dao):
-    """ __init__() should create an RAMSTKDesignElectric model. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignElectric).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKDesignElectric():
+    """Class for testing the RAMSTKDesignElectric model."""
+    @pytest.mark.integration
+    def test_ramstkdesignelectric_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKDesignElectric model. """
+        DUT = test_program_dao.session.query(RAMSTKDesignElectric).first()
 
-    assert isinstance(DUT, RAMSTKDesignElectric)
+        assert isinstance(DUT, RAMSTKDesignElectric)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_design_electric'
-    assert DUT.hardware_id == 1
-    assert DUT.application_id == 0
-    assert DUT.area == 0.0
-    assert DUT.capacitance == 0.0
-    assert DUT.configuration_id == 0
-    assert DUT.construction_id == 0
-    assert DUT.contact_form_id == 0
-    assert DUT.contact_gauge == 0
-    assert DUT.contact_rating_id == 0
-    assert DUT.current_operating == 0.0
-    assert DUT.current_rated == 0.0
-    assert DUT.current_ratio == 0.0
-    assert DUT.environment_active_id == 0
-    assert DUT.environment_dormant_id == 0
-    assert DUT.family_id == 0
-    assert DUT.feature_size == 0.0
-    assert DUT.frequency_operating == 0.0
-    assert DUT.insert_id == 0
-    assert DUT.insulation_id == 0
-    assert DUT.manufacturing_id == 0
-    assert DUT.matching_id == 0
-    assert DUT.n_active_pins == 0
-    assert DUT.n_circuit_planes == 1
-    assert DUT.n_cycles == 0
-    assert DUT.n_elements == 0
-    assert DUT.n_hand_soldered == 0
-    assert DUT.n_wave_soldered == 0
-    assert DUT.operating_life == 0.0
-    assert DUT.overstress == 0
-    assert DUT.package_id == 0
-    assert DUT.power_operating == 0.0
-    assert DUT.power_rated == 0.0
-    assert DUT.power_ratio == 0.0
-    assert DUT.reason == b''
-    assert DUT.resistance == 0.0
-    assert DUT.specification_id == 0
-    assert DUT.technology_id == 0
-    assert DUT.temperature_active == 35.0
-    assert DUT.temperature_case == 0.0
-    assert DUT.temperature_dormant == 25.0
-    assert DUT.temperature_hot_spot == 0.0
-    assert DUT.temperature_junction == 0.0
-    assert DUT.temperature_rated_max == 0.0
-    assert DUT.temperature_rated_min == 0.0
-    assert DUT.temperature_rise == 0.0
-    assert DUT.theta_jc == 0.0
-    assert DUT.type_id == 0
-    assert DUT.voltage_ac_operating == 0.0
-    assert DUT.voltage_dc_operating == 0.0
-    assert DUT.voltage_esd == 0.0
-    assert DUT.voltage_rated == 0.0
-    assert DUT.voltage_ratio == 0.0
-    assert DUT.weight == 0.0
-    assert DUT.years_in_production == 1
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_design_electric'
+        assert DUT.hardware_id == 1
+        assert DUT.application_id == 0
+        assert DUT.area == 0.0
+        assert DUT.capacitance == 0.0
+        assert DUT.configuration_id == 0
+        assert DUT.construction_id == 0
+        assert DUT.contact_form_id == 0
+        assert DUT.contact_gauge == 0
+        assert DUT.contact_rating_id == 0
+        assert DUT.current_operating == 0.0
+        assert DUT.current_rated == 0.0
+        assert DUT.current_ratio == 0.0
+        assert DUT.environment_active_id == 0
+        assert DUT.environment_dormant_id == 0
+        assert DUT.family_id == 0
+        assert DUT.feature_size == 0.0
+        assert DUT.frequency_operating == 0.0
+        assert DUT.insert_id == 0
+        assert DUT.insulation_id == 0
+        assert DUT.manufacturing_id == 0
+        assert DUT.matching_id == 0
+        assert DUT.n_active_pins == 0
+        assert DUT.n_circuit_planes == 1
+        assert DUT.n_cycles == 0
+        assert DUT.n_elements == 0
+        assert DUT.n_hand_soldered == 0
+        assert DUT.n_wave_soldered == 0
+        assert DUT.operating_life == 0.0
+        assert DUT.overstress == 0
+        assert DUT.package_id == 0
+        assert DUT.power_operating == 0.0
+        assert DUT.power_rated == 0.0
+        assert DUT.power_ratio == 0.0
+        assert DUT.reason == b''
+        assert DUT.resistance == 0.0
+        assert DUT.specification_id == 0
+        assert DUT.technology_id == 0
+        assert DUT.temperature_active == 35.0
+        assert DUT.temperature_case == 0.0
+        assert DUT.temperature_dormant == 25.0
+        assert DUT.temperature_hot_spot == 0.0
+        assert DUT.temperature_junction == 0.0
+        assert DUT.temperature_rated_max == 0.0
+        assert DUT.temperature_rated_min == 0.0
+        assert DUT.temperature_rise == 0.0
+        assert DUT.theta_jc == 0.0
+        assert DUT.type_id == 0
+        assert DUT.voltage_ac_operating == 0.0
+        assert DUT.voltage_dc_operating == 0.0
+        assert DUT.voltage_esd == 0.0
+        assert DUT.voltage_rated == 0.0
+        assert DUT.voltage_ratio == 0.0
+        assert DUT.weight == 0.0
+        assert DUT.years_in_production == 1
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a tuple of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKDesignElectric).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a tuple of attribute values. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignElectric).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
+        assert isinstance(_attributes, dict)
+        assert _attributes['voltage_ac_operating'] == 0.0
+        assert _attributes['frequency_operating'] == 0.0
+        assert _attributes['type_id'] == 0
+        assert _attributes['resistance'] == 0.0
+        assert _attributes['package_id'] == 0
+        assert _attributes['technology_id'] == 0
+        assert _attributes['n_cycles'] == 0
+        assert _attributes['n_circuit_planes'] == 1
+        assert _attributes['contact_gauge'] == 0
+        assert _attributes['current_operating'] == 0.0
+        assert _attributes['n_hand_soldered'] == 0
+        assert _attributes['contact_rating_id'] == 0
+        assert _attributes['area'] == 0.0
+        assert _attributes['contact_form_id'] == 0
+        assert _attributes['years_in_production'] == 1
+        assert _attributes['n_active_pins'] == 0
+        assert _attributes['capacitance'] == 0.0
+        assert _attributes['temperature_case'] == 0.0
+        assert _attributes['current_rated'] == 0.0
+        assert _attributes['power_operating'] == 0.0
+        assert _attributes['configuration_id'] == 0
+        assert _attributes['temperature_hot_spot'] == 0.0
+        assert _attributes['temperature_junction'] == 0.0
+        assert _attributes['current_ratio'] == 0.0
+        assert _attributes['insulation_id'] == 0
+        assert _attributes['construction_id'] == 0
+        assert _attributes['insert_id'] == 0
+        assert _attributes['theta_jc'] == 0.0
+        assert _attributes['voltage_dc_operating'] == 0.0
+        assert _attributes['power_ratio'] == 0.0
+        assert _attributes['family_id'] == 0
+        assert _attributes['overstress'] == 0
+        assert _attributes['voltage_rated'] == 0.0
+        assert _attributes['feature_size'] == 0.0
+        assert _attributes['operating_life'] == 0.0
+        assert _attributes['application_id'] == 0
+        assert _attributes['weight'] == 0.0
+        assert _attributes['temperature_rated_max'] == 0.0
+        assert _attributes['voltage_ratio'] == 0.0
+        assert _attributes['temperature_rated_min'] == 0.0
+        assert _attributes['power_rated'] == 0.0
+        assert _attributes['environment_active_id'] == 0
+        assert _attributes['hardware_id'] == 1
+        assert _attributes['specification_id'] == 0
+        assert _attributes['matching_id'] == 0
+        assert _attributes['n_elements'] == 0
+        assert _attributes['environment_dormant_id'] == 0
+        assert _attributes['reason'] == b''
+        assert _attributes['voltage_esd'] == 0.0
+        assert _attributes['manufacturing_id'] == 0
+        assert _attributes['n_wave_soldered'] == 0
+        assert _attributes['temperature_knee'] == 25.0
+        assert _attributes['temperature_rise'] == 0.0
+        assert _attributes['temperature_active'] == 35.0
+        assert _attributes['temperature_dormant'] == 25.0
 
-    assert isinstance(_attributes, dict)
-    assert _attributes['voltage_ac_operating'] == 0.0
-    assert _attributes['frequency_operating'] == 0.0
-    assert _attributes['type_id'] == 0
-    assert _attributes['resistance'] == 0.0
-    assert _attributes['package_id'] == 0
-    assert _attributes['technology_id'] == 0
-    assert _attributes['n_cycles'] == 0
-    assert _attributes['n_circuit_planes'] == 1
-    assert _attributes['contact_gauge'] == 0
-    assert _attributes['current_operating'] == 0.0
-    assert _attributes['n_hand_soldered'] == 0
-    assert _attributes['contact_rating_id'] == 0
-    assert _attributes['area'] == 0.0
-    assert _attributes['contact_form_id'] == 0
-    assert _attributes['years_in_production'] == 1
-    assert _attributes['n_active_pins'] == 0
-    assert _attributes['capacitance'] == 0.0
-    assert _attributes['temperature_case'] == 0.0
-    assert _attributes['current_rated'] == 0.0
-    assert _attributes['power_operating'] == 0.0
-    assert _attributes['configuration_id'] == 0
-    assert _attributes['temperature_hot_spot'] == 0.0
-    assert _attributes['temperature_junction'] == 0.0
-    assert _attributes['current_ratio'] == 0.0
-    assert _attributes['insulation_id'] == 0
-    assert _attributes['construction_id'] == 0
-    assert _attributes['insert_id'] == 0
-    assert _attributes['theta_jc'] == 0.0
-    assert _attributes['voltage_dc_operating'] == 0.0
-    assert _attributes['power_ratio'] == 0.0
-    assert _attributes['family_id'] == 0
-    assert _attributes['overstress'] == 0
-    assert _attributes['voltage_rated'] == 0.0
-    assert _attributes['feature_size'] == 0.0
-    assert _attributes['operating_life'] == 0.0
-    assert _attributes['application_id'] == 0
-    assert _attributes['weight'] == 0.0
-    assert _attributes['temperature_rated_max'] == 0.0
-    assert _attributes['voltage_ratio'] == 0.0
-    assert _attributes['temperature_rated_min'] == 0.0
-    assert _attributes['power_rated'] == 0.0
-    assert _attributes['environment_active_id'] == 0
-    assert _attributes['hardware_id'] == 1
-    assert _attributes['specification_id'] == 0
-    assert _attributes['matching_id'] == 0
-    assert _attributes['n_elements'] == 0
-    assert _attributes['environment_dormant_id'] == 0
-    assert _attributes['reason'] == b''
-    assert _attributes['voltage_esd'] == 0.0
-    assert _attributes['manufacturing_id'] == 0
-    assert _attributes['n_wave_soldered'] == 0
-    assert _attributes['temperature_knee'] == 25.0
-    assert _attributes['temperature_rise'] == 0.0
-    assert _attributes['temperature_active'] == 35.0
-    assert _attributes['temperature_dormant'] == 25.0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKDesignElectric).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignElectric).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKDesignElectric).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['type_id'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['type_id'] == 0
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignElectric).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKDesignElectric).first()
 
-    ATTRIBUTES['type_id'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['type_id'] == 0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignElectric).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkdesignmechanic.py
+++ b/tests/models/programdb/test_ramstkdesignmechanic.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.dao.programdb.test_ramstkdesignmechanic.py is part of The RAMSTK
@@ -68,170 +69,154 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkdesignmechanic_create(test_dao):
-    """ __init__() should create an RAMSTKDesignMechanic model. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignMechanic).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKDesignMechanic():
+    """Class for testing the RAMSTKDesignMechanic model."""
+    @pytest.mark.integration
+    def test_ramstkdesignmechanic_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKDesignMechanic model. """
+        DUT = test_program_dao.session.query(RAMSTKDesignMechanic).first()
 
-    assert isinstance(DUT, RAMSTKDesignMechanic)
+        assert isinstance(DUT, RAMSTKDesignMechanic)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_design_mechanic'
-    assert DUT.hardware_id == 1
-    assert DUT.altitude_operating == 0.0
-    assert DUT.application_id == 0
-    assert DUT.balance_id == 0
-    assert DUT.clearance == 0.0
-    assert DUT.casing_id == 0
-    assert DUT.contact_pressure == 0.0
-    assert DUT.deflection == 0.0
-    assert DUT.diameter_coil == 0.0
-    assert DUT.diameter_inner == 0.0
-    assert DUT.diameter_outer == 0.0
-    assert DUT.diameter_wire == 0.0
-    assert DUT.filter_size == 0.0
-    assert DUT.flow_design == 0.0
-    assert DUT.flow_operating == 0.0
-    assert DUT.frequency_operating == 0.0
-    assert DUT.friction == 0.0
-    assert DUT.impact_id == 0
-    assert DUT.leakage_allowable == 0.0
-    assert DUT.length == 0.0
-    assert DUT.length_compressed == 0.0
-    assert DUT.length_relaxed == 0.0
-    assert DUT.load_design == 0.0
-    assert DUT.load_id == 0
-    assert DUT.load_operating == 0.0
-    assert DUT.lubrication_id == 0
-    assert DUT.manufacturing_id == 0
-    assert DUT.material_id == 0
-    assert DUT.meyer_hardness == 0.0
-    assert DUT.misalignment_angle == 0.0
-    assert DUT.n_ten == 0
-    assert DUT.n_cycles == 0
-    assert DUT.n_elements == 0
-    assert DUT.offset == 0.0
-    assert DUT.particle_size == 0.0
-    assert DUT.pressure_contact == 0.0
-    assert DUT.pressure_delta == 0.0
-    assert DUT.pressure_downstream == 0.0
-    assert DUT.pressure_rated == 0.0
-    assert DUT.pressure_upstream == 0.0
-    assert DUT.rpm_design == 0.0
-    assert DUT.rpm_operating == 0.0
-    assert DUT.service_id == 0
-    assert DUT.spring_index == 0.0
-    assert DUT.surface_finish == 0.0
-    assert DUT.technology_id == 0
-    assert DUT.thickness == 0.0
-    assert DUT.torque_id == 0
-    assert DUT.type_id == 0
-    assert DUT.viscosity_design == 0.0
-    assert DUT.viscosity_dynamic == 0.0
-    assert DUT.water_per_cent == 0.0
-    assert DUT.width_minimum == 0.0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_design_mechanic'
+        assert DUT.hardware_id == 1
+        assert DUT.altitude_operating == 0.0
+        assert DUT.application_id == 0
+        assert DUT.balance_id == 0
+        assert DUT.clearance == 0.0
+        assert DUT.casing_id == 0
+        assert DUT.contact_pressure == 0.0
+        assert DUT.deflection == 0.0
+        assert DUT.diameter_coil == 0.0
+        assert DUT.diameter_inner == 0.0
+        assert DUT.diameter_outer == 0.0
+        assert DUT.diameter_wire == 0.0
+        assert DUT.filter_size == 0.0
+        assert DUT.flow_design == 0.0
+        assert DUT.flow_operating == 0.0
+        assert DUT.frequency_operating == 0.0
+        assert DUT.friction == 0.0
+        assert DUT.impact_id == 0
+        assert DUT.leakage_allowable == 0.0
+        assert DUT.length == 0.0
+        assert DUT.length_compressed == 0.0
+        assert DUT.length_relaxed == 0.0
+        assert DUT.load_design == 0.0
+        assert DUT.load_id == 0
+        assert DUT.load_operating == 0.0
+        assert DUT.lubrication_id == 0
+        assert DUT.manufacturing_id == 0
+        assert DUT.material_id == 0
+        assert DUT.meyer_hardness == 0.0
+        assert DUT.misalignment_angle == 0.0
+        assert DUT.n_ten == 0
+        assert DUT.n_cycles == 0
+        assert DUT.n_elements == 0
+        assert DUT.offset == 0.0
+        assert DUT.particle_size == 0.0
+        assert DUT.pressure_contact == 0.0
+        assert DUT.pressure_delta == 0.0
+        assert DUT.pressure_downstream == 0.0
+        assert DUT.pressure_rated == 0.0
+        assert DUT.pressure_upstream == 0.0
+        assert DUT.rpm_design == 0.0
+        assert DUT.rpm_operating == 0.0
+        assert DUT.service_id == 0
+        assert DUT.spring_index == 0.0
+        assert DUT.surface_finish == 0.0
+        assert DUT.technology_id == 0
+        assert DUT.thickness == 0.0
+        assert DUT.torque_id == 0
+        assert DUT.type_id == 0
+        assert DUT.viscosity_design == 0.0
+        assert DUT.viscosity_dynamic == 0.0
+        assert DUT.water_per_cent == 0.0
+        assert DUT.width_minimum == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a tuple of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKDesignMechanic).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a tuple of attribute values. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignMechanic).first()
+        _attributes = DUT.get_attributes()
+        assert isinstance(_attributes, dict)
+        assert _attributes['pressure_upstream'] == 0.0
+        assert _attributes['frequency_operating'] == 0.0
+        assert _attributes['surface_finish'] == 0.0
+        assert _attributes['friction'] == 0.0
+        assert _attributes['length_compressed'] == 0.0
+        assert _attributes['load_id'] == 0
+        assert _attributes['n_cycles'] == 0
+        assert _attributes['balance_id'] == 0
+        assert _attributes['lubrication_id'] == 0
+        assert _attributes['water_per_cent'] == 0.0
+        assert _attributes['misalignment_angle'] == 0.0
+        assert _attributes['type_id'] == 0
+        assert _attributes['rpm_design'] == 0.0
+        assert _attributes['pressure_downstream'] == 0.0
+        assert _attributes['diameter_coil'] == 0.0
+        assert _attributes['manufacturing_id'] == 0
+        assert _attributes['pressure_contact'] == 0.0
+        assert _attributes['meyer_hardness'] == 0.0
+        assert _attributes['rpm_operating'] == 0.0
+        assert _attributes['length_relaxed'] == 0.0
+        assert _attributes['impact_id'] == 0
+        assert _attributes['n_ten'] == 0
+        assert _attributes['material_id'] == 0
+        assert _attributes['technology_id'] == 0
+        assert _attributes['service_id'] == 0
+        assert _attributes['flow_design'] == 0.0
+        assert _attributes['application_id'] == 0
+        assert _attributes['diameter_wire'] == 0.0
+        assert _attributes['deflection'] == 0.0
+        assert _attributes['filter_size'] == 0.0
+        assert _attributes['diameter_inner'] == 0.0
+        assert _attributes['pressure_rated'] == 0.0
+        assert _attributes['hardware_id'] == 1
+        assert _attributes['altitude_operating'] == 0.0
+        assert _attributes['thickness'] == 0.0
+        assert _attributes['diameter_outer'] == 0.0
+        assert _attributes['n_elements'] == 0
+        assert _attributes['contact_pressure'] == 0.0
+        assert _attributes['particle_size'] == 0.0
+        assert _attributes['casing_id'] == 0
+        assert _attributes['viscosity_dynamic'] == 0.0
+        assert _attributes['viscosity_design'] == 0.0
+        assert _attributes['torque_id'] == 0
+        assert _attributes['leakage_allowable'] == 0.0
+        assert _attributes['offset'] == 0.0
+        assert _attributes['width_minimum'] == 0.0
+        assert _attributes['load_operating'] == 0.0
+        assert _attributes['spring_index'] == 0.0
+        assert _attributes['flow_operating'] == 0.0
+        assert _attributes['pressure_delta'] == 0.0
+        assert _attributes['length'] == 0.0
+        assert _attributes['load_design'] == 0.0
+        assert _attributes['clearance'] == 0.0
 
-    _attributes = DUT.get_attributes()
-    assert isinstance(_attributes, dict)
-    assert _attributes['pressure_upstream'] == 0.0
-    assert _attributes['frequency_operating'] == 0.0
-    assert _attributes['surface_finish'] == 0.0
-    assert _attributes['friction'] == 0.0
-    assert _attributes['length_compressed'] == 0.0
-    assert _attributes['load_id'] == 0
-    assert _attributes['n_cycles'] == 0
-    assert _attributes['balance_id'] == 0
-    assert _attributes['lubrication_id'] == 0
-    assert _attributes['water_per_cent'] == 0.0
-    assert _attributes['misalignment_angle'] == 0.0
-    assert _attributes['type_id'] == 0
-    assert _attributes['rpm_design'] == 0.0
-    assert _attributes['pressure_downstream'] == 0.0
-    assert _attributes['diameter_coil'] == 0.0
-    assert _attributes['manufacturing_id'] == 0
-    assert _attributes['pressure_contact'] == 0.0
-    assert _attributes['meyer_hardness'] == 0.0
-    assert _attributes['rpm_operating'] == 0.0
-    assert _attributes['length_relaxed'] == 0.0
-    assert _attributes['impact_id'] == 0
-    assert _attributes['n_ten'] == 0
-    assert _attributes['material_id'] == 0
-    assert _attributes['technology_id'] == 0
-    assert _attributes['service_id'] == 0
-    assert _attributes['flow_design'] == 0.0
-    assert _attributes['application_id'] == 0
-    assert _attributes['diameter_wire'] == 0.0
-    assert _attributes['deflection'] == 0.0
-    assert _attributes['filter_size'] == 0.0
-    assert _attributes['diameter_inner'] == 0.0
-    assert _attributes['pressure_rated'] == 0.0
-    assert _attributes['hardware_id'] == 1
-    assert _attributes['altitude_operating'] == 0.0
-    assert _attributes['thickness'] == 0.0
-    assert _attributes['diameter_outer'] == 0.0
-    assert _attributes['n_elements'] == 0
-    assert _attributes['contact_pressure'] == 0.0
-    assert _attributes['particle_size'] == 0.0
-    assert _attributes['casing_id'] == 0
-    assert _attributes['viscosity_dynamic'] == 0.0
-    assert _attributes['viscosity_design'] == 0.0
-    assert _attributes['torque_id'] == 0
-    assert _attributes['leakage_allowable'] == 0.0
-    assert _attributes['offset'] == 0.0
-    assert _attributes['width_minimum'] == 0.0
-    assert _attributes['load_operating'] == 0.0
-    assert _attributes['spring_index'] == 0.0
-    assert _attributes['flow_operating'] == 0.0
-    assert _attributes['pressure_delta'] == 0.0
-    assert _attributes['length'] == 0.0
-    assert _attributes['load_design'] == 0.0
-    assert _attributes['clearance'] == 0.0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKDesignMechanic).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignMechanic).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKDesignMechanic).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['type_id'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['type_id'] == 0.0
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignMechanic).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKDesignMechanic).first()
 
-    ATTRIBUTES['type_id'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['type_id'] == 0.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKDesignMechanic).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkenvironment.py
+++ b/tests/models/programdb/test_ramstkenvironment.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkenvironment.py is part of The RAMSTK
@@ -25,68 +26,68 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkenvironment_create(test_dao):
-    """__init__() should create an RAMSTKEnvironment model."""
-    DUT = test_dao.session.query(RAMSTKEnvironment).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKEnvironment():
+    """Class for testing the RAMSTKEnvironment model."""
+    @pytest.mark.integration
+    def test_ramstkenvironment_create(self, test_program_dao):
+        """__init__() should create an RAMSTKEnvironment model."""
+        DUT = test_program_dao.session.query(RAMSTKEnvironment).first()
 
-    assert isinstance(DUT, RAMSTKEnvironment)
+        assert isinstance(DUT, RAMSTKEnvironment)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_environment'
-    assert DUT.phase_id == 1
-    assert DUT.environment_id == 1
-    assert DUT.name == 'Condition Name'
-    assert DUT.units == 'Units'
-    assert DUT.minimum == 0.0
-    assert DUT.maximum == 0.0
-    assert DUT.mean == 0.0
-    assert DUT.variance == 0.0
-    assert DUT.ramp_rate == 0.0
-    assert DUT.low_dwell_time == 0.0
-    assert DUT.high_dwell_time == 0.0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_environment'
+        assert DUT.phase_id == 1
+        assert DUT.environment_id == 1
+        assert DUT.name == 'Condition Name'
+        assert DUT.units == 'Units'
+        assert DUT.minimum == 0.0
+        assert DUT.maximum == 0.0
+        assert DUT.mean == 0.0
+        assert DUT.variance == 0.0
+        assert DUT.ramp_rate == 0.0
+        assert DUT.low_dwell_time == 0.0
+        assert DUT.high_dwell_time == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a dict of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKEnvironment).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a dict of attribute values. """
-    DUT = test_dao.session.query(RAMSTKEnvironment).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
-    assert _attributes['high_dwell_time'] == 0.0
-    assert _attributes['low_dwell_time'] == 0.0
-    assert _attributes['maximum'] == 0.0
-    assert _attributes['mean'] == 0.0
-    assert _attributes['minimum'] == 0.0
-    assert _attributes['name'] == 'Condition Name'
-    assert _attributes['ramp_rate'] == 0.0
-    assert _attributes['units'] == 'Units'
-    assert _attributes['variance'] == 0.0
+        assert _attributes['high_dwell_time'] == 0.0
+        assert _attributes['low_dwell_time'] == 0.0
+        assert _attributes['maximum'] == 0.0
+        assert _attributes['mean'] == 0.0
+        assert _attributes['minimum'] == 0.0
+        assert _attributes['name'] == 'Condition Name'
+        assert _attributes['ramp_rate'] == 0.0
+        assert _attributes['units'] == 'Units'
+        assert _attributes['variance'] == 0.0
 
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKEnvironment).first()
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    DUT = test_dao.session.query(RAMSTKEnvironment).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKEnvironment).first()
 
+        ATTRIBUTES['mean'] = None
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKEnvironment).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['mean'] == 0.0
 
-    ATTRIBUTES['mean'] = None
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKEnvironment).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['mean'] == 0.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    DUT = test_dao.session.query(RAMSTKEnvironment).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkfailuredefinition.py
+++ b/tests/models/programdb/test_ramstkfailuredefinition.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkfailuredefinition.py is part of The
@@ -17,53 +18,52 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkfailuredefinition_create(test_dao):
-    """ __init__() should create an RAMSTKFailureDefinition model. """
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKFailureDefinition).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKFailureDefinition():
+    """Class for testing the RAMSTKFailureDefinition model."""
+    @pytest.mark.integration
+    def test_ramstkfailuredefinition_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKFailureDefinition model. """
+        DUT = test_program_dao.session.query(RAMSTKFailureDefinition).first()
 
-    assert isinstance(DUT, RAMSTKFailureDefinition)
+        assert isinstance(DUT, RAMSTKFailureDefinition)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_failure_definition'
-    assert DUT.revision_id == 1
-    assert DUT.definition_id == 1
-    assert DUT.definition == b'Failure Definition'
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_failure_definition'
+        assert DUT.revision_id == 1
+        assert DUT.definition_id == 1
+        assert DUT.definition == b'Failure Definition'
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a tuple of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKFailureDefinition).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a tuple of attribute values. """
-    DUT = test_dao.session.query(RAMSTKFailureDefinition).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
-    assert _attributes['definition'] == b'Failure Definition'
+        assert _attributes['definition'] == b'Failure Definition'
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    DUT = test_dao.session.query(RAMSTKFailureDefinition).first()
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKFailureDefinition).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKFailureDefinition).first()
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKFailureDefinition).first()
+        ATTRIBUTES['definition'] = None
 
-    ATTRIBUTES['definition'] = None
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['definition'] == b'Failure Definition'
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['definition'] == b'Failure Definition'
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKFailureDefinition).first()
 
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    DUT = test_dao.session.query(RAMSTKFailureDefinition).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkfunction.py
+++ b/tests/models/programdb/test_ramstkfunction.py
@@ -1,6 +1,8 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.models.programdb.test_ramstkfunction.py is part of The RAMSTK Project
+#       tests.models.programdb.test_ramstkfunction.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 # Copyright 2007 - 2019 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
@@ -36,93 +38,93 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkfunction_create(test_dao):
-    """ __init__() should create an RAMSTKFunction model. """
-    DUT = test_dao.session.query(RAMSTKFunction).filter(
-        RAMSTKFunction.function_id == 3).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKFunction():
+    """Class for testing the RAMSTKFunction model."""
+    @pytest.mark.integration
+    def test_ramstkfunction_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKFunction model. """
+        DUT = test_program_dao.session.query(RAMSTKFunction).filter(
+            RAMSTKFunction.function_id == 3).first()
 
-    assert isinstance(DUT, RAMSTKFunction)
+        assert isinstance(DUT, RAMSTKFunction)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_function'
-    assert DUT.revision_id == 1
-    assert DUT.function_id == 3
-    assert DUT.availability_logistics == 1.0
-    assert DUT.availability_mission == 1.0
-    assert DUT.cost == 0.0
-    assert DUT.function_code == 'FUNC-0003'
-    assert DUT.hazard_rate_logistics == 0.0
-    assert DUT.hazard_rate_mission == 0.0
-    assert DUT.level == 0
-    assert DUT.mmt == 0.0
-    assert DUT.mcmt == 0.0
-    assert DUT.mpmt == 0.0
-    assert DUT.mtbf_logistics == 0.0
-    assert DUT.mtbf_mission == 0.0
-    assert DUT.mttr == 0.0
-    assert DUT.name == 'Function Name'
-    assert DUT.parent_id == 0
-    assert DUT.remarks == b''
-    assert DUT.safety_critical == 0
-    assert DUT.total_mode_count == 0
-    assert DUT.total_part_count == 0
-    assert DUT.type_id == 0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_function'
+        assert DUT.revision_id == 1
+        assert DUT.function_id == 3
+        assert DUT.availability_logistics == 1.0
+        assert DUT.availability_mission == 1.0
+        assert DUT.cost == 0.0
+        assert DUT.function_code == 'FUNC-0003'
+        assert DUT.hazard_rate_logistics == 0.0
+        assert DUT.hazard_rate_mission == 0.0
+        assert DUT.level == 0
+        assert DUT.mmt == 0.0
+        assert DUT.mcmt == 0.0
+        assert DUT.mpmt == 0.0
+        assert DUT.mtbf_logistics == 0.0
+        assert DUT.mtbf_mission == 0.0
+        assert DUT.mttr == 0.0
+        assert DUT.name == 'Function Name'
+        assert DUT.parent_id == 0
+        assert DUT.remarks == b''
+        assert DUT.safety_critical == 0
+        assert DUT.total_mode_count == 0
+        assert DUT.total_part_count == 0
+        assert DUT.type_id == 0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a dict of {attribute name:attribute value} pairs. """
+        DUT = test_program_dao.session.query(RAMSTKFunction).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a dict of {attribute name:attribute value} pairs. """
-    DUT = test_dao.session.query(RAMSTKFunction).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
-    assert _attributes['revision_id'] == 1
-    assert _attributes['function_id'] == 1
-    assert _attributes['availability_logistics'] == 1.0
-    assert _attributes['availability_mission'] == 1.0
-    assert _attributes['cost'] == 0.0
-    #assert _attributes['function_code'] == 'FUNC-0001'
-    assert _attributes['hazard_rate_logistics'] == 0.0
-    assert _attributes['hazard_rate_mission'] == 0.0
-    assert _attributes['level'] == 0
-    assert _attributes['mmt'] == 0.0
-    assert _attributes['mcmt'] == 0.0
-    assert _attributes['mpmt'] == 0.0
-    assert _attributes['mtbf_logistics'] == 0.0
-    assert _attributes['mtbf_mission'] == 0.0
-    assert _attributes['mttr'] == 0.0
-    #assert _attributes['name'] == 'Function Name'
-    assert _attributes['parent_id'] == 0
-    assert _attributes['remarks'] == b''
-    assert _attributes['safety_critical'] == 0
-    assert _attributes['total_mode_count'] == 0
-    assert _attributes['total_part_count'] == 0
-    assert _attributes['type_id'] == 0
+        assert _attributes['revision_id'] == 1
+        assert _attributes['function_id'] == 1
+        assert _attributes['availability_logistics'] == 1.0
+        assert _attributes['availability_mission'] == 1.0
+        assert _attributes['cost'] == 0.0
+        # assert _attributes['function_code'] == 'FUNC-0001'
+        assert _attributes['hazard_rate_logistics'] == 0.0
+        assert _attributes['hazard_rate_mission'] == 0.0
+        assert _attributes['level'] == 0
+        assert _attributes['mmt'] == 0.0
+        assert _attributes['mcmt'] == 0.0
+        assert _attributes['mpmt'] == 0.0
+        assert _attributes['mtbf_logistics'] == 0.0
+        assert _attributes['mtbf_mission'] == 0.0
+        assert _attributes['mttr'] == 0.0
+        # assert _attributes['name'] == 'Function Name'
+        assert _attributes['parent_id'] == 0
+        assert _attributes['remarks'] == b''
+        assert _attributes['safety_critical'] == 0
+        assert _attributes['total_mode_count'] == 0
+        assert _attributes['total_part_count'] == 0
+        assert _attributes['type_id'] == 0
 
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKFunction).first()
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    DUT = test_dao.session.query(RAMSTKFunction).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKFunction).first()
 
+        ATTRIBUTES['total_mode_count'] = None
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKFunction).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['total_mode_count'] == 0
 
-    ATTRIBUTES['total_mode_count'] = None
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKFunction).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['total_mode_count'] == 0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    DUT = test_dao.session.query(RAMSTKFunction).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkhardware.py
+++ b/tests/models/programdb/test_ramstkhardware.py
@@ -1,6 +1,8 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.dao.programmdb.test_ramstkhardware.py is part of The RAMSTK Project
+#       tests.dao.programmdb.test_ramstkhardware.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 """Test class for testing the RAMSTKHardware module algorithms and models. """
@@ -51,134 +53,119 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkhardware_create(test_dao):
-    """ __init__() should create an RAMSTKHardware model. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKHardware).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKHardware():
+    """Class for testing the RAMSTKHardware model."""
+    @pytest.mark.integration
+    def test_ramstkhardware_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKHardware model. """
+        DUT = test_program_dao.session.query(RAMSTKHardware).first()
 
-    assert isinstance(DUT, RAMSTKHardware)
+        assert isinstance(DUT, RAMSTKHardware)
 
-    # Verify class attributes are properly initialized.  Commented attribute
-    # values vary depending on whether this test file is run stand-alone or as
-    # a results python setup.py test.
-    assert DUT.__tablename__ == 'ramstk_hardware'
-    assert DUT.revision_id == 1
-    assert DUT.hardware_id == 1
-    assert DUT.alt_part_number == ''
-    assert DUT.attachments == ''
-    assert DUT.cage_code == ''
-    assert DUT.comp_ref_des == 'S1'
-    assert DUT.category_id == 0
-    # assert DUT.cost == 0.0
-    assert DUT.cost_failure == 0.0
-    # assert DUT.cost_hour == 0.0
-    # assert DUT.cost_type_id == 0
-    assert DUT.description == 'Test System'
-    assert DUT.duty_cycle == 100.0
-    assert DUT.figure_number == ''
-    assert DUT.lcn == ''
-    assert DUT.level == 0
-    assert DUT.manufacturer_id == 0
-    # assert DUT.mission_time == 100.0
-    assert DUT.name == ''
-    assert DUT.nsn == ''
-    assert DUT.page_number == ''
-    assert DUT.parent_id == 0
-    assert DUT.part == 0
-    assert DUT.part_number == ''
-    assert DUT.quantity == 1
-    assert DUT.ref_des == 'S1'
-    assert DUT.remarks == b''
-    assert DUT.repairable == 0
-    assert DUT.specification_number == ''
-    assert DUT.subcategory_id == 0
-    assert DUT.tagged_part == 0
-    # assert DUT,total_cost == 0
-    # assert DUT.total_part_count == 0
-    assert DUT.total_power_dissipation == 0.0
-    assert DUT.year_of_manufacture == date.today().year
+        # Verify class attributes are properly initialized.  Commented attribute
+        # values vary depending on whether this test file is run stand-alone or as
+        # a results python setup.py test.
+        assert DUT.__tablename__ == 'ramstk_hardware'
+        assert DUT.revision_id == 1
+        assert DUT.hardware_id == 1
+        assert DUT.alt_part_number == ''
+        assert DUT.attachments == ''
+        assert DUT.cage_code == ''
+        assert DUT.comp_ref_des == 'S1'
+        assert DUT.category_id == 0
+        # assert DUT.cost == 0.0
+        assert DUT.cost_failure == 0.0
+        # assert DUT.cost_hour == 0.0
+        # assert DUT.cost_type_id == 0
+        assert DUT.description == 'Test System'
+        assert DUT.duty_cycle == 100.0
+        assert DUT.figure_number == ''
+        assert DUT.lcn == ''
+        assert DUT.level == 0
+        assert DUT.manufacturer_id == 0
+        # assert DUT.mission_time == 100.0
+        assert DUT.name == ''
+        assert DUT.nsn == ''
+        assert DUT.page_number == ''
+        assert DUT.parent_id == 0
+        assert DUT.part == 0
+        assert DUT.part_number == ''
+        assert DUT.quantity == 1
+        assert DUT.ref_des == 'S1'
+        assert DUT.remarks == b''
+        assert DUT.repairable == 0
+        assert DUT.specification_number == ''
+        assert DUT.subcategory_id == 0
+        assert DUT.tagged_part == 0
+        # assert DUT,total_cost == 0
+        # assert DUT.total_part_count == 0
+        assert DUT.total_power_dissipation == 0.0
+        assert DUT.year_of_manufacture == date.today().year
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a dict of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKHardware).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a dict of attribute values. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKHardware).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
-    assert isinstance(_attributes, dict)
-    assert _attributes['alt_part_number'] == ''
-    assert _attributes['attachments'] == ''
-    assert _attributes['cage_code'] == ''
-    assert _attributes['category_id'] == 0
-    assert _attributes['comp_ref_des'] == 'S1'
-    # assert _attributes['cost'] == 0.0
-    assert _attributes['cost_failure'] == 0.0
-    # assert _attributes['cost_hour'] == 0.0
-    # assert _attributes['cost_type_id'] == 0
-    assert _attributes['description'] == 'Test System'
-    assert _attributes['duty_cycle'] == 100.0
-    assert _attributes['figure_number'] == ''
-    assert _attributes['lcn'] == ''
-    assert _attributes['level'] == 0
-    assert _attributes['manufacturer_id'] == 0
-    # assert _attributes['mission_time'] == 100.0
-    assert _attributes['name'] == ''
-    assert _attributes['nsn'] == ''
-    assert _attributes['page_number'] == ''
-    assert _attributes['parent_id'] == 0
-    assert _attributes['part'] == 0
-    assert _attributes['part_number'] == ''
-    assert _attributes['quantity'] == 1
-    assert _attributes['ref_des'] == 'S1'
-    assert _attributes['remarks'] == b''
-    assert _attributes['repairable'] == 0
-    assert _attributes['specification_number'] == ''
-    assert _attributes['subcategory_id'] == 0
-    assert _attributes['tagged_part'] == 0
-    # assert _attributes['total_cost'] == 0.0
-    # assert _attributes['total_part_count'] == 0
-    assert _attributes['total_power_dissipation'] == 0.0
-    assert _attributes['year_of_manufacture'] == date.today().year
+        assert isinstance(_attributes, dict)
+        assert _attributes['alt_part_number'] == ''
+        assert _attributes['attachments'] == ''
+        assert _attributes['cage_code'] == ''
+        assert _attributes['category_id'] == 0
+        assert _attributes['comp_ref_des'] == 'S1'
+        # assert _attributes['cost'] == 0.0
+        assert _attributes['cost_failure'] == 0.0
+        # assert _attributes['cost_hour'] == 0.0
+        # assert _attributes['cost_type_id'] == 0
+        assert _attributes['description'] == 'Test System'
+        assert _attributes['duty_cycle'] == 100.0
+        assert _attributes['figure_number'] == ''
+        assert _attributes['lcn'] == ''
+        assert _attributes['level'] == 0
+        assert _attributes['manufacturer_id'] == 0
+        # assert _attributes['mission_time'] == 100.0
+        assert _attributes['name'] == ''
+        assert _attributes['nsn'] == ''
+        assert _attributes['page_number'] == ''
+        assert _attributes['parent_id'] == 0
+        assert _attributes['part'] == 0
+        assert _attributes['part_number'] == ''
+        assert _attributes['quantity'] == 1
+        assert _attributes['ref_des'] == 'S1'
+        assert _attributes['remarks'] == b''
+        assert _attributes['repairable'] == 0
+        assert _attributes['specification_number'] == ''
+        assert _attributes['subcategory_id'] == 0
+        assert _attributes['tagged_part'] == 0
+        # assert _attributes['total_cost'] == 0.0
+        # assert _attributes['total_part_count'] == 0
+        assert _attributes['total_power_dissipation'] == 0.0
+        assert _attributes['year_of_manufacture'] == date.today().year
 
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKHardware).first()
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKHardware).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKHardware).first()
 
+        ATTRIBUTES['nsn'] = None
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKHardware).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['nsn'] == ''
 
-    ATTRIBUTES['nsn'] = None
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKHardware).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['nsn'] == ''
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKHardware).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkhazardanalysis.py
+++ b/tests/models/programdb/test_ramstkhazardanalysis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -O
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.dao.programdb.test_ramstkhazardanalysis.py is part of The RAMSTK
@@ -55,133 +55,132 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkallocation_create(test_dao):
-    """__init__() should create an RAMSTKHazardAnalysis model."""
-    DUT = test_dao.session.query(RAMSTKHazardAnalysis).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKHazardAnalysis():
+    """Class for testing the RAMSTKHazardAnalysis model."""
+    @pytest.mark.integration
+    def test_ramstkallocation_create(self, test_program_dao):
+        """__init__() should create an RAMSTKHazardAnalysis model."""
+        DUT = test_program_dao.session.query(RAMSTKHazardAnalysis).first()
 
-    assert isinstance(DUT, RAMSTKHazardAnalysis)
+        assert isinstance(DUT, RAMSTKHazardAnalysis)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_hazard_analysis'
-    assert DUT.revision_id == 1
-    assert DUT.function_id == 1
-    assert DUT.hazard_id == 1
-    assert DUT.potential_hazard == ''
-    assert DUT.potential_cause == ''
-    assert DUT.assembly_effect == ''
-    #assert DUT.assembly_severity == 'Major'
-    #assert DUT.assembly_probability == 'Level A - Frequent'
-    #assert DUT.assembly_hri == 20
-    assert DUT.assembly_mitigation == b''
-    #assert DUT.assembly_severity_f == 'Major'
-    #assert DUT.assembly_probability_f == 'Level A - Frequent'
-    #assert DUT.assembly_hri_f == 20
-    #assert DUT.function_1 == ''
-    #assert DUT.function_2 == ''
-    #assert DUT.function_3 == ''
-    #assert DUT.function_4 == ''
-    #assert DUT.function_5 == ''
-    assert DUT.remarks == b''
-    #assert DUT.result_1 == 0.0
-    #assert DUT.result_2 == 0.0
-    #assert DUT.result_3 == 0.0
-    #assert DUT.result_4 == 0.0
-    #assert DUT.result_5 == 0.0
-    assert DUT.system_effect == ''
-    #assert DUT.system_severity == 'Major'
-    #assert DUT.system_probability == 'Level A - Frequent'
-    #assert DUT.system_hri == 20
-    assert DUT.system_mitigation == b''
-    #assert DUT.system_severity_f == 'Major'
-    #assert DUT.system_probability_f == 'Level A - Frequent'
-    #assert DUT.system_hri_f == 20
-    assert DUT.user_blob_1 == b''
-    assert DUT.user_blob_2 == b''
-    assert DUT.user_blob_3 == b''
-    #assert DUT.user_float_1 == 0.0
-    #assert DUT.user_float_2 == 0.0
-    #assert DUT.user_float_3 == 0.0
-    #assert DUT.user_int_1 == 0
-    #assert DUT.user_int_2 == 0
-    #assert DUT.user_int_3 == 0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_hazard_analysis'
+        assert DUT.revision_id == 1
+        assert DUT.function_id == 1
+        assert DUT.hazard_id == 1
+        assert DUT.potential_hazard == ''
+        assert DUT.potential_cause == ''
+        assert DUT.assembly_effect == ''
+        # assert DUT.assembly_severity == 'Major'
+        # assert DUT.assembly_probability == 'Level A - Frequent'
+        # assert DUT.assembly_hri == 20
+        assert DUT.assembly_mitigation == b''
+        # assert DUT.assembly_severity_f == 'Major'
+        # assert DUT.assembly_probability_f == 'Level A - Frequent'
+        # assert DUT.assembly_hri_f == 20
+        # assert DUT.function_1 == ''
+        # assert DUT.function_2 == ''
+        # assert DUT.function_3 == ''
+        # assert DUT.function_4 == ''
+        # assert DUT.function_5 == ''
+        assert DUT.remarks == b''
+        # assert DUT.result_1 == 0.0
+        # assert DUT.result_2 == 0.0
+        # assert DUT.result_3 == 0.0
+        # assert DUT.result_4 == 0.0
+        # assert DUT.result_5 == 0.0
+        assert DUT.system_effect == ''
+        # assert DUT.system_severity == 'Major'
+        # assert DUT.system_probability == 'Level A - Frequent'
+        # assert DUT.system_hri == 20
+        assert DUT.system_mitigation == b''
+        # assert DUT.system_severity_f == 'Major'
+        # assert DUT.system_probability_f == 'Level A - Frequent'
+        # assert DUT.system_hri_f == 20
+        assert DUT.user_blob_1 == b''
+        assert DUT.user_blob_2 == b''
+        assert DUT.user_blob_3 == b''
+        # assert DUT.user_float_1 == 0.0
+        # assert DUT.user_float_2 == 0.0
+        # assert DUT.user_float_3 == 0.0
+        # assert DUT.user_int_1 == 0
+        # assert DUT.user_int_2 == 0
+        # assert DUT.user_int_3 == 0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """get_attributes() should return a dict of attribute values."""
+        DUT = test_program_dao.session.query(RAMSTKHazardAnalysis).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """get_attributes() should return a dict of attribute values."""
-    DUT = test_dao.session.query(RAMSTKHazardAnalysis).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
+        assert isinstance(_attributes, dict)
 
-    assert isinstance(_attributes, dict)
+        assert _attributes['revision_id'] == 1
+        assert _attributes['function_id'] == 1
+        assert _attributes['hazard_id'] == 1
+        assert _attributes['potential_hazard'] == ''
+        assert _attributes['potential_cause'] == ''
+        assert _attributes['assembly_effect'] == ''
+        # assert _attributes['assembly_severity'] == 'Major'
+        # assert _attributes['assembly_probability'] == 'Level A - Frequent'
+        # assert _attributes['assembly_hri'] == 20
+        assert _attributes['assembly_mitigation'] == b''
+        # assert _attributes['assembly_severity_f'] == 'Major'
+        # assert _attributes['assembly_probability_f'] == 'Level A - Frequent'
+        # assert _attributes['assembly_hri_f'] == 20
+        # assert _attributes['function_1'] == ''
+        # assert _attributes['function_2'] == ''
+        # assert _attributes['function_3'] == ''
+        # assert _attributes['function_4'] == ''
+        # assert _attributes['function_5'] == ''
+        assert _attributes['remarks'] == b''
+        # assert _attributes['result_1'] == 0.0
+        # assert _attributes['result_2'] == 0.0
+        # assert _attributes['result_3'] == 0.0
+        # assert _attributes['result_4'] == 0.0
+        # assert _attributes['result_5'] == 0.0
+        assert _attributes['system_effect'] == ''
+        # assert _attributes['system_severity'] == 'Major'
+        # assert _attributes['system_probability'] == 'Level A - Frequent'
+        # assert _attributes['system_hri'] == 20
+        assert _attributes['system_mitigation'] == b''
+        # assert _attributes['system_severity_f'] == 'Major'
+        # assert _attributes['system_probability_f'] == 'Level A - Frequent'
+        # assert _attributes['system_hri_f'] == 20
+        assert _attributes['user_blob_1'] == b''
+        assert _attributes['user_blob_2'] == b''
+        assert _attributes['user_blob_3'] == b''
+        # assert _attributes['user_float_1'] == 0.0
+        # assert _attributes['user_float_2'] == 0.0
+        # assert _attributes['user_float_3'] == 0.0
+        # assert _attributes['user_int_1'] == 0
+        # assert _attributes['user_int_2'] == 0
+        # assert _attributes['user_int_3'] == 0
 
-    assert _attributes['revision_id'] == 1
-    assert _attributes['function_id'] == 1
-    assert _attributes['hazard_id'] == 1
-    assert _attributes['potential_hazard'] == ''
-    assert _attributes['potential_cause'] == ''
-    assert _attributes['assembly_effect'] == ''
-    #assert _attributes['assembly_severity'] == 'Major'
-    #assert _attributes['assembly_probability'] == 'Level A - Frequent'
-    #assert _attributes['assembly_hri'] == 20
-    assert _attributes['assembly_mitigation'] == b''
-    #assert _attributes['assembly_severity_f'] == 'Major'
-    #assert _attributes['assembly_probability_f'] == 'Level A - Frequent'
-    #assert _attributes['assembly_hri_f'] == 20
-    #assert _attributes['function_1'] == ''
-    #assert _attributes['function_2'] == ''
-    #assert _attributes['function_3'] == ''
-    #assert _attributes['function_4'] == ''
-    #assert _attributes['function_5'] == ''
-    assert _attributes['remarks'] == b''
-    #assert _attributes['result_1'] == 0.0
-    #assert _attributes['result_2'] == 0.0
-    #assert _attributes['result_3'] == 0.0
-    #assert _attributes['result_4'] == 0.0
-    #assert _attributes['result_5'] == 0.0
-    assert _attributes['system_effect'] == ''
-    #assert _attributes['system_severity'] == 'Major'
-    #assert _attributes['system_probability'] == 'Level A - Frequent'
-    #assert _attributes['system_hri'] == 20
-    assert _attributes['system_mitigation'] == b''
-    #assert _attributes['system_severity_f'] == 'Major'
-    #assert _attributes['system_probability_f'] == 'Level A - Frequent'
-    #assert _attributes['system_hri_f'] == 20
-    assert _attributes['user_blob_1'] == b''
-    assert _attributes['user_blob_2'] == b''
-    assert _attributes['user_blob_3'] == b''
-    #assert _attributes['user_float_1'] == 0.0
-    #assert _attributes['user_float_2'] == 0.0
-    #assert _attributes['user_float_3'] == 0.0
-    #assert _attributes['user_int_1'] == 0
-    #assert _attributes['user_int_2'] == 0
-    #assert _attributes['user_int_3'] == 0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """set_attributes() should return a zero error code on success."""
+        DUT = test_program_dao.session.query(RAMSTKHazardAnalysis).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """set_attributes() should return a zero error code on success."""
-    DUT = test_dao.session.query(RAMSTKHazardAnalysis).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKHazardAnalysis).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['remarks'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['remarks'] == b''
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKHazardAnalysis).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKHazardAnalysis).first()
 
-    ATTRIBUTES['remarks'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['remarks'] == b''
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    DUT = test_dao.session.query(RAMSTKHazardAnalysis).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkmatrix.py
+++ b/tests/models/programdb/test_ramstkmatrix.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.dao.programdb.test_ramstkmatrix.py is part of The RAMSTK Project
@@ -24,59 +25,51 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkmatrix_create(test_dao):
-    """__init__() should create an RAMSTKMatrix model."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKMatrix).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKMatrix():
+    """Class for testing the RAMSTKMatrix model."""
+    @pytest.mark.integration
+    def test_ramstkmatrix_create(self, test_program_dao):
+        """__init__() should create an RAMSTKMatrix model."""
+        DUT = test_program_dao.session.query(RAMSTKMatrix).first()
 
-    assert isinstance(DUT, RAMSTKMatrix)
+        assert isinstance(DUT, RAMSTKMatrix)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_matrix'
-    assert DUT.revision_id == 1
-    assert DUT.matrix_id == 1
-    assert DUT.column_id == 1
-    assert DUT.column_item_id == 1
-    assert DUT.matrix_type == 'fnctn_hrdwr'
-    assert DUT.parent_id == 0
-    assert DUT.row_id == 1
-    assert DUT.row_item_id == 1
-    assert DUT.value == 0.0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_matrix'
+        assert DUT.revision_id == 1
+        assert DUT.matrix_id == 1
+        assert DUT.column_id == 1
+        assert DUT.column_item_id == 1
+        assert DUT.matrix_type == 'fnctn_hrdwr'
+        assert DUT.parent_id == 0
+        assert DUT.row_id == 1
+        assert DUT.row_item_id == 1
+        assert DUT.value == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """get_attributes() should return a tuple of attribute values."""
+        DUT = test_program_dao.session.query(RAMSTKMatrix).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """get_attributes() should return a tuple of attribute values."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKMatrix).first()
+        assert DUT.get_attributes() == ATTRIBUTES
 
-    assert DUT.get_attributes() == ATTRIBUTES
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """set_attributes() should return a zero error code on success."""
+        DUT = test_program_dao.session.query(RAMSTKMatrix).first()
 
+        ATTRIBUTES.pop('revision_id')
+        ATTRIBUTES.pop('matrix_id')
+        ATTRIBUTES['value'] = None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """set_attributes() should return a zero error code on success."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKMatrix).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['value'] == 0
 
-    ATTRIBUTES.pop('revision_id')
-    ATTRIBUTES.pop('matrix_id')
-    ATTRIBUTES['value'] = None
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKMatrix).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['value'] == 0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKMatrix).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkmilhdbkf.py
+++ b/tests/models/programdb/test_ramstkmilhdbkf.py
@@ -1,7 +1,8 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.data.storage.programdb.test_ramstkmilhdbkf.py is part of The
-#       RAMSTK Project
+#       tests.models.programdb.test_ramstkmilhdbkf.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 """Test class for testing the RAMSTKMilHdbkF module algorithms and models. """
@@ -51,137 +52,121 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkmilhdbkf_create(test_dao):
-    """ __init__() should create an RAMSTKMilHdbkF model. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKMilHdbkF).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKMilHdbk217F():
+    """Class for testing the RAMSTKMilHdbk217F model."""
+    @pytest.mark.integration
+    def test_ramstkmilhdbkf_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKMilHdbkF model. """
+        DUT = test_program_dao.session.query(RAMSTKMilHdbkF).first()
 
-    assert isinstance(DUT, RAMSTKMilHdbkF)
+        assert isinstance(DUT, RAMSTKMilHdbkF)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_mil_hdbk_f'
-    assert DUT.hardware_id == 1
-    assert DUT.A1 == 0.0
-    assert DUT.A2 == 0.0
-    assert DUT.B1 == 0.0
-    assert DUT.B2 == 0.0
-    assert DUT.C1 == 0.0
-    assert DUT.C2 == 0.0
-    assert DUT.lambdaBD == 0.0
-    assert DUT.lambdaBP == 0.0
-    assert DUT.lambdaCYC == 0.0
-    assert DUT.lambdaEOS == 0.0
-    assert DUT.piA == 0.0
-    assert DUT.piC == 0.0
-    assert DUT.piCD == 0.0
-    assert DUT.piCF == 0.0
-    assert DUT.piCR == 0.0
-    assert DUT.piCV == 0.0
-    assert DUT.piCYC == 0.0
-    assert DUT.piE == 0.0
-    assert DUT.piF == 0.0
-    assert DUT.piI == 0.0
-    assert DUT.piK == 0.0
-    assert DUT.piL == 0.0
-    assert DUT.piM == 0.0
-    assert DUT.piMFG == 0.0
-    assert DUT.piN == 0.0
-    assert DUT.piNR == 0.0
-    assert DUT.piP == 0.0
-    assert DUT.piPT == 0.0
-    assert DUT.piQ == 0.0
-    assert DUT.piR == 0.0
-    assert DUT.piS == 0.0
-    assert DUT.piT == 0.0
-    assert DUT.piTAPS == 0.0
-    assert DUT.piU == 0.0
-    assert DUT.piV == 0.0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_mil_hdbk_f'
+        assert DUT.hardware_id == 1
+        assert DUT.A1 == 0.0
+        assert DUT.A2 == 0.0
+        assert DUT.B1 == 0.0
+        assert DUT.B2 == 0.0
+        assert DUT.C1 == 0.0
+        assert DUT.C2 == 0.0
+        assert DUT.lambdaBD == 0.0
+        assert DUT.lambdaBP == 0.0
+        assert DUT.lambdaCYC == 0.0
+        assert DUT.lambdaEOS == 0.0
+        assert DUT.piA == 0.0
+        assert DUT.piC == 0.0
+        assert DUT.piCD == 0.0
+        assert DUT.piCF == 0.0
+        assert DUT.piCR == 0.0
+        assert DUT.piCV == 0.0
+        assert DUT.piCYC == 0.0
+        assert DUT.piE == 0.0
+        assert DUT.piF == 0.0
+        assert DUT.piI == 0.0
+        assert DUT.piK == 0.0
+        assert DUT.piL == 0.0
+        assert DUT.piM == 0.0
+        assert DUT.piMFG == 0.0
+        assert DUT.piN == 0.0
+        assert DUT.piNR == 0.0
+        assert DUT.piP == 0.0
+        assert DUT.piPT == 0.0
+        assert DUT.piQ == 0.0
+        assert DUT.piR == 0.0
+        assert DUT.piS == 0.0
+        assert DUT.piT == 0.0
+        assert DUT.piTAPS == 0.0
+        assert DUT.piU == 0.0
+        assert DUT.piV == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a tuple of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKMilHdbkF).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a tuple of attribute values. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKMilHdbkF).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
+        assert isinstance(_attributes, dict)
+        assert _attributes['hardware_id'] == 1
+        assert _attributes['A1'] == 0.0
+        assert _attributes['A2'] == 0.0
+        assert _attributes['B1'] == 0.0
+        assert _attributes['B2'] == 0.0
+        assert _attributes['C1'] == 0.0
+        assert _attributes['C2'] == 0.0
+        assert _attributes['lambdaBD'] == 0.0
+        assert _attributes['lambdaBP'] == 0.0
+        assert _attributes['lambdaCYC'] == 0.0
+        assert _attributes['lambdaEOS'] == 0.0
+        assert _attributes['piA'] == 0.0
+        assert _attributes['piC'] == 0.0
+        assert _attributes['piCD'] == 0.0
+        assert _attributes['piCF'] == 0.0
+        assert _attributes['piCR'] == 0.0
+        assert _attributes['piCV'] == 0.0
+        assert _attributes['piCYC'] == 0.0
+        assert _attributes['piE'] == 0.0
+        assert _attributes['piF'] == 0.0
+        assert _attributes['piI'] == 0.0
+        assert _attributes['piK'] == 0.0
+        assert _attributes['piL'] == 0.0
+        assert _attributes['piM'] == 0.0
+        assert _attributes['piMFG'] == 0.0
+        assert _attributes['piN'] == 0.0
+        assert _attributes['piNR'] == 0.0
+        assert _attributes['piP'] == 0.0
+        assert _attributes['piPT'] == 0.0
+        assert _attributes['piQ'] == 0.0
+        assert _attributes['piR'] == 0.0
+        assert _attributes['piS'] == 0.0
+        assert _attributes['piT'] == 0.0
+        assert _attributes['piTAPS'] == 0.0
+        assert _attributes['piU'] == 0.0
+        assert _attributes['piV'] == 0.0
 
-    assert isinstance(_attributes, dict)
-    assert _attributes['hardware_id'] == 1
-    assert _attributes['A1'] == 0.0
-    assert _attributes['A2'] == 0.0
-    assert _attributes['B1'] == 0.0
-    assert _attributes['B2'] == 0.0
-    assert _attributes['C1'] == 0.0
-    assert _attributes['C2'] == 0.0
-    assert _attributes['lambdaBD'] == 0.0
-    assert _attributes['lambdaBP'] == 0.0
-    assert _attributes['lambdaCYC'] == 0.0
-    assert _attributes['lambdaEOS'] == 0.0
-    assert _attributes['piA'] == 0.0
-    assert _attributes['piC'] == 0.0
-    assert _attributes['piCD'] == 0.0
-    assert _attributes['piCF'] == 0.0
-    assert _attributes['piCR'] == 0.0
-    assert _attributes['piCV'] == 0.0
-    assert _attributes['piCYC'] == 0.0
-    assert _attributes['piE'] == 0.0
-    assert _attributes['piF'] == 0.0
-    assert _attributes['piI'] == 0.0
-    assert _attributes['piK'] == 0.0
-    assert _attributes['piL'] == 0.0
-    assert _attributes['piM'] == 0.0
-    assert _attributes['piMFG'] == 0.0
-    assert _attributes['piN'] == 0.0
-    assert _attributes['piNR'] == 0.0
-    assert _attributes['piP'] == 0.0
-    assert _attributes['piPT'] == 0.0
-    assert _attributes['piQ'] == 0.0
-    assert _attributes['piR'] == 0.0
-    assert _attributes['piS'] == 0.0
-    assert _attributes['piT'] == 0.0
-    assert _attributes['piTAPS'] == 0.0
-    assert _attributes['piU'] == 0.0
-    assert _attributes['piV'] == 0.0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKMilHdbkF).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKMilHdbkF).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKMilHdbkF).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['piA'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['piA'] == 0.0
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKMilHdbkF).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKMilHdbkF).first()
 
-    ATTRIBUTES['piA'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['piA'] == 0.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKMilHdbkF).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkmission.py
+++ b/tests/models/programdb/test_ramstkmission.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkmission.py is part of The RAMSTK
@@ -19,55 +20,55 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkmission_create(test_dao):
-    """ __init__() should create an RAMSTKMission model. """
-    DUT = test_dao.session.query(RAMSTKMission).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKMission():
+    """Class for testing the RAMSTKMission model."""
+    @pytest.mark.integration
+    def test_ramstkmission_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKMission model. """
+        DUT = test_program_dao.session.query(RAMSTKMission).first()
 
-    assert isinstance(DUT, RAMSTKMission)
+        assert isinstance(DUT, RAMSTKMission)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_mission'
-    assert DUT.revision_id == 1
-    assert DUT.mission_id == 1
-    assert DUT.description == b'Test Mission'
-    assert DUT.mission_time == 0.0
-    assert DUT.time_units == 'hours'
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_mission'
+        assert DUT.revision_id == 1
+        assert DUT.mission_id == 1
+        assert DUT.description == b'Test Mission'
+        assert DUT.mission_time == 0.0
+        assert DUT.time_units == 'hours'
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a tuple of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKMission).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a tuple of attribute values. """
-    DUT = test_dao.session.query(RAMSTKMission).first()
+        _attributes = DUT.get_attributes()
+        assert _attributes['description'] == b'Test Mission'
+        assert _attributes['mission_time'] == 0.0
+        assert _attributes['time_units'] == 'hours'
 
-    _attributes = DUT.get_attributes()
-    assert _attributes['description'] == b'Test Mission'
-    assert _attributes['mission_time'] == 0.0
-    assert _attributes['time_units'] == 'hours'
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKMission).first()
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    DUT = test_dao.session.query(RAMSTKMission).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKMission).first()
 
+        ATTRIBUTES['mission_time'] = None
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKMission).first()
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['mission_time'] == 0.0
 
-    ATTRIBUTES['mission_time'] = None
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKMission).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['mission_time'] == 0.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    DUT = test_dao.session.query(RAMSTKMission).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkmissionphase.py
+++ b/tests/models/programdb/test_ramstkmissionphase.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkmissionphase.py is part of The RAMSTK
@@ -20,60 +21,59 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkmissionphase_create(test_dao):
-    """ __init__() should create an RAMSTKPhase model. """
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKMissionPhase).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKMissionPhase():
+    """Class for testing the RAMSTKMissionPhase model."""
+    @pytest.mark.integration
+    def test_ramstkmissionphase_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKPhase model. """
+        _session = test_program_dao.RAMSTK_SESSION(
+            bind=test_program_dao.engine, autoflush=False, expire_on_commit=False)
+        DUT = _session.query(RAMSTKMissionPhase).first()
 
-    assert isinstance(DUT, RAMSTKMissionPhase)
+        assert isinstance(DUT, RAMSTKMissionPhase)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_mission_phase'
-    assert DUT.mission_id == 1
-    assert DUT.phase_id == 1
-    assert DUT.description == b'Test Mission Phase 1'
-    assert DUT.name == ''
-    assert DUT.phase_start == 0.0
-    assert DUT.phase_end == 0.0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_mission_phase'
+        assert DUT.mission_id == 1
+        assert DUT.phase_id == 1
+        assert DUT.description == b'Test Mission Phase 1'
+        assert DUT.name == ''
+        assert DUT.phase_start == 0.0
+        assert DUT.phase_end == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a tuple of attributes values on success. """
+        DUT = test_program_dao.session.query(RAMSTKMissionPhase).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a tuple of attributes values on success. """
-    DUT = test_dao.session.query(RAMSTKMissionPhase).first()
+        _attributes = DUT.get_attributes()
+        assert _attributes['description'] == b'Test Mission Phase 1'
+        assert _attributes['name'] == ''
+        assert _attributes['phase_start'] == 0.0
+        assert _attributes['phase_end'] == 0.0
 
-    _attributes = DUT.get_attributes()
-    assert _attributes['description'] == b'Test Mission Phase 1'
-    assert _attributes['name'] == ''
-    assert _attributes['phase_start'] == 0.0
-    assert _attributes['phase_end'] == 0.0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKMissionPhase).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    DUT = test_dao.session.query(RAMSTKMissionPhase).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKMissionPhase).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['name'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['name'] == ''
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKMissionPhase).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKMissionPhase).first()
 
-    ATTRIBUTES['name'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['name'] == ''
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    DUT = test_dao.session.query(RAMSTKMissionPhase).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkmode.py
+++ b/tests/models/programdb/test_ramstkmode.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.TestRAMSTKMode.py is part of The RAMSTK Project

--- a/tests/models/programdb/test_ramstknswc.py
+++ b/tests/models/programdb/test_ramstknswc.py
@@ -1,6 +1,7 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.data.storage.programdb.test_ramstknswc.py is part of The RAMSTK
+#       tests.models.programdb.test_ramstknswc.py is part of The RAMSTK
 #       Project
 #
 # All rights reserved.
@@ -73,175 +74,164 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstknswc_create(test_dao):
-    """ __init__() should create an RAMSTKNSWC model. """
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKNSWC).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKNSWC():
+    """Class for testing the RAMSTKNSWC model."""
+    @pytest.mark.integration
+    def test_ramstknswc_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKNSWC model. """
+        DUT = test_program_dao.session.query(RAMSTKNSWC).first()
 
-    assert isinstance(DUT, RAMSTKNSWC)
+        assert isinstance(DUT, RAMSTKNSWC)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_nswc'
-    assert DUT.hardware_id == 1
-    assert DUT.Cac == 0.0
-    assert DUT.Calt == 0.0
-    assert DUT.Cb == 0.0
-    assert DUT.Cbl == 0.0
-    assert DUT.Cbt == 0.0
-    assert DUT.Cbv == 0.0
-    assert DUT.Cc == 0.0
-    assert DUT.Ccf == 0.0
-    assert DUT.Ccp == 0.0
-    assert DUT.Ccs == 0.0
-    assert DUT.Ccv == 0.0
-    assert DUT.Ccw == 0.0
-    assert DUT.Cd == 0.0
-    assert DUT.Cdc == 0.0
-    assert DUT.Cdl == 0.0
-    assert DUT.Cdp == 0.0
-    assert DUT.Cds == 0.0
-    assert DUT.Cdt == 0.0
-    assert DUT.Cdw == 0.0
-    assert DUT.Cdy == 0.0
-    assert DUT.Ce == 0.0
-    assert DUT.Cf == 0.0
-    assert DUT.Cg == 0.0
-    assert DUT.Cga == 0.0
-    assert DUT.Cgl == 0.0
-    assert DUT.Cgp == 0.0
-    assert DUT.Cgs == 0.0
-    assert DUT.Cgt == 0.0
-    assert DUT.Cgv == 0.0
-    assert DUT.Ch == 0.0
-    assert DUT.Ci == 0.0
-    assert DUT.Ck == 0.0
-    assert DUT.Cl == 0.0
-    assert DUT.Clc == 0.0
-    assert DUT.Cm == 0.0
-    assert DUT.Cmu == 0.0
-    assert DUT.Cn == 0.0
-    assert DUT.Cnp == 0.0
-    assert DUT.Cnw == 0.0
-    assert DUT.Cp == 0.0
-    assert DUT.Cpd == 0.0
-    assert DUT.Cpf == 0.0
-    assert DUT.Cpv == 0.0
-    assert DUT.Cq == 0.0
-    assert DUT.Cr == 0.0
-    assert DUT.Crd == 0.0
-    assert DUT.Cs == 0.0
-    assert DUT.Csc == 0.0
-    assert DUT.Csf == 0.0
-    assert DUT.Cst == 0.0
-    assert DUT.Csv == 0.0
-    assert DUT.Csw == 0.0
-    assert DUT.Csz == 0.0
-    assert DUT.Ct == 0.0
-    assert DUT.Cv == 0.0
-    assert DUT.Cw == 0.0
-    assert DUT.Cy == 0.0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_nswc'
+        assert DUT.hardware_id == 1
+        assert DUT.Cac == 0.0
+        assert DUT.Calt == 0.0
+        assert DUT.Cb == 0.0
+        assert DUT.Cbl == 0.0
+        assert DUT.Cbt == 0.0
+        assert DUT.Cbv == 0.0
+        assert DUT.Cc == 0.0
+        assert DUT.Ccf == 0.0
+        assert DUT.Ccp == 0.0
+        assert DUT.Ccs == 0.0
+        assert DUT.Ccv == 0.0
+        assert DUT.Ccw == 0.0
+        assert DUT.Cd == 0.0
+        assert DUT.Cdc == 0.0
+        assert DUT.Cdl == 0.0
+        assert DUT.Cdp == 0.0
+        assert DUT.Cds == 0.0
+        assert DUT.Cdt == 0.0
+        assert DUT.Cdw == 0.0
+        assert DUT.Cdy == 0.0
+        assert DUT.Ce == 0.0
+        assert DUT.Cf == 0.0
+        assert DUT.Cg == 0.0
+        assert DUT.Cga == 0.0
+        assert DUT.Cgl == 0.0
+        assert DUT.Cgp == 0.0
+        assert DUT.Cgs == 0.0
+        assert DUT.Cgt == 0.0
+        assert DUT.Cgv == 0.0
+        assert DUT.Ch == 0.0
+        assert DUT.Ci == 0.0
+        assert DUT.Ck == 0.0
+        assert DUT.Cl == 0.0
+        assert DUT.Clc == 0.0
+        assert DUT.Cm == 0.0
+        assert DUT.Cmu == 0.0
+        assert DUT.Cn == 0.0
+        assert DUT.Cnp == 0.0
+        assert DUT.Cnw == 0.0
+        assert DUT.Cp == 0.0
+        assert DUT.Cpd == 0.0
+        assert DUT.Cpf == 0.0
+        assert DUT.Cpv == 0.0
+        assert DUT.Cq == 0.0
+        assert DUT.Cr == 0.0
+        assert DUT.Crd == 0.0
+        assert DUT.Cs == 0.0
+        assert DUT.Csc == 0.0
+        assert DUT.Csf == 0.0
+        assert DUT.Cst == 0.0
+        assert DUT.Csv == 0.0
+        assert DUT.Csw == 0.0
+        assert DUT.Csz == 0.0
+        assert DUT.Ct == 0.0
+        assert DUT.Cv == 0.0
+        assert DUT.Cw == 0.0
+        assert DUT.Cy == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a tuple of attribute values. """
+        DUT = test_program_dao.session.query(RAMSTKNSWC).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a tuple of attribute values. """
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKNSWC).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
+        assert isinstance(_attributes, dict)
+        assert _attributes['Clc'] == 0.0
+        assert _attributes['Crd'] == 0.0
+        assert _attributes['Cac'] == 0.0
+        assert _attributes['Cmu'] == 0.0
+        assert _attributes['Ck'] == 0.0
+        assert _attributes['Ci'] == 0.0
+        assert _attributes['Ch'] == 0.0
+        assert _attributes['Cn'] == 0.0
+        assert _attributes['Cm'] == 0.0
+        assert _attributes['Cl'] == 0.0
+        assert _attributes['Cc'] == 0.0
+        assert _attributes['Cb'] == 0.0
+        assert _attributes['Cg'] == 0.0
+        assert _attributes['Cf'] == 0.0
+        assert _attributes['Ce'] == 0.0
+        assert _attributes['Cd'] == 0.0
+        assert _attributes['Cy'] == 0.0
+        assert _attributes['Cbv'] == 0.0
+        assert _attributes['Cbt'] == 0.0
+        assert _attributes['Cs'] == 0.0
+        assert _attributes['Cr'] == 0.0
+        assert _attributes['Cq'] == 0.0
+        assert _attributes['Cp'] == 0.0
+        assert _attributes['Cw'] == 0.0
+        assert _attributes['Cv'] == 0.0
+        assert _attributes['Ct'] == 0.0
+        assert _attributes['Cnw'] == 0.0
+        assert _attributes['Cnp'] == 0.0
+        assert _attributes['Csf'] == 0.0
+        assert _attributes['Calt'] == 0.0
+        assert _attributes['Csc'] == 0.0
+        assert _attributes['Cbl'] == 0.0
+        assert _attributes['Csz'] == 0.0
+        assert _attributes['Cst'] == 0.0
+        assert _attributes['Csw'] == 0.0
+        assert _attributes['Csv'] == 0.0
+        assert _attributes['Cgl'] == 0.0
+        assert _attributes['Cga'] == 0.0
+        assert _attributes['Cgp'] == 0.0
+        assert _attributes['Cgs'] == 0.0
+        assert _attributes['Cgt'] == 0.0
+        assert _attributes['Cgv'] == 0.0
+        assert _attributes['Ccw'] == 0.0
+        assert _attributes['Ccv'] == 0.0
+        assert _attributes['Cpd'] == 0.0
+        assert _attributes['Ccp'] == 0.0
+        assert _attributes['Cpf'] == 0.0
+        assert _attributes['Ccs'] == 0.0
+        assert _attributes['Ccf'] == 0.0
+        assert _attributes['Cpv'] == 0.0
+        assert _attributes['Cdc'] == 0.0
+        assert _attributes['Cdl'] == 0.0
+        assert _attributes['Cdt'] == 0.0
+        assert _attributes['Cdw'] == 0.0
+        assert _attributes['Cdp'] == 0.0
+        assert _attributes['Cds'] == 0.0
+        assert _attributes['Cdy'] == 0.0
 
-    assert isinstance(_attributes, dict)
-    assert _attributes['Clc'] == 0.0
-    assert _attributes['Crd'] == 0.0
-    assert _attributes['Cac'] == 0.0
-    assert _attributes['Cmu'] == 0.0
-    assert _attributes['Ck'] == 0.0
-    assert _attributes['Ci'] == 0.0
-    assert _attributes['Ch'] == 0.0
-    assert _attributes['Cn'] == 0.0
-    assert _attributes['Cm'] == 0.0
-    assert _attributes['Cl'] == 0.0
-    assert _attributes['Cc'] == 0.0
-    assert _attributes['Cb'] == 0.0
-    assert _attributes['Cg'] == 0.0
-    assert _attributes['Cf'] == 0.0
-    assert _attributes['Ce'] == 0.0
-    assert _attributes['Cd'] == 0.0
-    assert _attributes['Cy'] == 0.0
-    assert _attributes['Cbv'] == 0.0
-    assert _attributes['Cbt'] == 0.0
-    assert _attributes['Cs'] == 0.0
-    assert _attributes['Cr'] == 0.0
-    assert _attributes['Cq'] == 0.0
-    assert _attributes['Cp'] == 0.0
-    assert _attributes['Cw'] == 0.0
-    assert _attributes['Cv'] == 0.0
-    assert _attributes['Ct'] == 0.0
-    assert _attributes['Cnw'] == 0.0
-    assert _attributes['Cnp'] == 0.0
-    assert _attributes['Csf'] == 0.0
-    assert _attributes['Calt'] == 0.0
-    assert _attributes['Csc'] == 0.0
-    assert _attributes['Cbl'] == 0.0
-    assert _attributes['Csz'] == 0.0
-    assert _attributes['Cst'] == 0.0
-    assert _attributes['Csw'] == 0.0
-    assert _attributes['Csv'] == 0.0
-    assert _attributes['Cgl'] == 0.0
-    assert _attributes['Cga'] == 0.0
-    assert _attributes['Cgp'] == 0.0
-    assert _attributes['Cgs'] == 0.0
-    assert _attributes['Cgt'] == 0.0
-    assert _attributes['Cgv'] == 0.0
-    assert _attributes['Ccw'] == 0.0
-    assert _attributes['Ccv'] == 0.0
-    assert _attributes['Cpd'] == 0.0
-    assert _attributes['Ccp'] == 0.0
-    assert _attributes['Cpf'] == 0.0
-    assert _attributes['Ccs'] == 0.0
-    assert _attributes['Ccf'] == 0.0
-    assert _attributes['Cpv'] == 0.0
-    assert _attributes['Cdc'] == 0.0
-    assert _attributes['Cdl'] == 0.0
-    assert _attributes['Cdt'] == 0.0
-    assert _attributes['Cdw'] == 0.0
-    assert _attributes['Cdp'] == 0.0
-    assert _attributes['Cds'] == 0.0
-    assert _attributes['Cdy'] == 0.0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKNSWC).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKNSWC).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKNSWC).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['Cpv'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['Cpv'] == 0.0
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKNSWC).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKNSWC).first()
 
-    ATTRIBUTES['Cpv'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['Cpv'] == 0.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKNSWC).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkopload.py
+++ b/tests/models/programdb/test_ramstkopload.py
@@ -1,7 +1,8 @@
 # pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.models.programdb.test_ramstkopload.py is part of The RAMSTK Project
+#       tests.models.programdb.test_ramstkopload.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 """Test class for testing the RAMSTKOpLoad module algorithms and models."""

--- a/tests/models/programdb/test_ramstkopstress.py
+++ b/tests/models/programdb/test_ramstkopstress.py
@@ -3,7 +3,6 @@
 #
 #       tests.models.programdb.test_ramstkopstress.py is part of The RAMSTK
 #       Project
-
 #
 # All rights reserved.
 """Test class for testing the RAMSTKOpStress module algorithms and models."""

--- a/tests/models/programdb/test_ramstkprogramstatus.py
+++ b/tests/models/programdb/test_ramstkprogramstatus.py
@@ -1,6 +1,8 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.moels.progrmdb.test_ramstkprogramstatus.py is part of The RAMSTK Project
+#       tests.models.progrmdb.test_ramstkprogramstatus.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 """Test class for testing RAMSTKProgramStatus module algorithms and models."""

--- a/tests/models/programdb/test_ramstkreliability.py
+++ b/tests/models/programdb/test_ramstkreliability.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.data.storage.programdb.test_ramstkreliability.py is part of The
@@ -56,137 +57,133 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkreliability_create(test_dao):
-    """__init__() should create an RAMSTKReliability model."""
-    DUT = test_dao.session.query(RAMSTKReliability).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKReliability():
+    """Class for testing the RAMSTKReliability model."""
+    @pytest.mark.integration
+    def test_ramstkreliability_create(self, test_program_dao):
+        """__init__() should create an RAMSTKReliability model."""
+        DUT = test_program_dao.session.query(RAMSTKReliability).first()
 
-    assert isinstance(DUT, RAMSTKReliability)
+        assert isinstance(DUT, RAMSTKReliability)
 
-    # Verify class attributes are properly initialized.  Commented attribute
-    # values vary depending on whether this test file is run stand-alone or as
-    # a result of python setup.py test.
-    assert DUT.__tablename__ == 'ramstk_reliability'
-    assert DUT.hardware_id == 1
-    assert DUT.add_adj_factor == 0.0
-    assert DUT.availability_logistics == 1.0
-    assert DUT.availability_mission == 1.0
-    assert DUT.avail_log_variance == 0.0
-    assert DUT.avail_mis_variance == 0.0
-    assert DUT.failure_distribution_id == 0
-    # assert DUT.hazard_rate_active == 0.0
-    assert DUT.hazard_rate_dormant == 0.0
-    # assert DUT.hazard_rate_logistics == 0.0
-    assert DUT.hazard_rate_method_id == 0
-    # assert DUT.hazard_rate_mission == 0.0
-    assert DUT.hazard_rate_model == ''
-    assert DUT.hazard_rate_percent == 0.0
-    assert DUT.hazard_rate_software == 0.0
-    assert DUT.hazard_rate_specified == 0.0
-    # assert DUT.hazard_rate_type_id == 0
-    # assert DUT.hr_active_variance == 0.0
-    assert DUT.hr_dormant_variance == 0.0
-    # assert DUT.hr_logistics_variance == 0.0
-    # assert DUT.hr_mission_variance == 0.0
-    # assert DUT.hr_specified_variance == 0.0
-    assert DUT.location_parameter == 0.0
-    # assert DUT.mtbf_logistics == 0.0
-    # assert DUT.mtbf_mission == 0.0
-    assert DUT.mtbf_specified == 0.0
-    # assert DUT.mtbf_logistics_variance == 0.0
-    # assert DUT.mtbf_mission_variance == 0.0
-    # assert DUT.mtbf_specified_variance == 0.0
-    assert DUT.mult_adj_factor == 1.0
-    assert DUT.quality_id == 0
-    #assert DUT.reliability_goal == 0.0
-    assert DUT.reliability_goal_measure_id == 0
-    # assert DUT.reliability_logistics == 1.0
-    # assert DUT.reliability_mission == 1.0
-    # assert DUT.reliability_log_variance == 0.0
-    # assert DUT.reliability_miss_variance == 0.0
-    assert DUT.scale_parameter == 0.0
-    assert DUT.shape_parameter == 0.0
-    assert DUT.survival_analysis_id == 0
-    assert DUT.lambda_b == 0.0
+        # Verify class attributes are properly initialized.  Commented attribute
+        # values vary depending on whether this test file is run stand-alone or as
+        # a result of python setup.py test.
+        assert DUT.__tablename__ == 'ramstk_reliability'
+        assert DUT.hardware_id == 1
+        assert DUT.add_adj_factor == 0.0
+        assert DUT.availability_logistics == 1.0
+        assert DUT.availability_mission == 1.0
+        assert DUT.avail_log_variance == 0.0
+        assert DUT.avail_mis_variance == 0.0
+        assert DUT.failure_distribution_id == 0
+        # assert DUT.hazard_rate_active == 0.0
+        assert DUT.hazard_rate_dormant == 0.0
+        # assert DUT.hazard_rate_logistics == 0.0
+        assert DUT.hazard_rate_method_id == 0
+        # assert DUT.hazard_rate_mission == 0.0
+        assert DUT.hazard_rate_model == ''
+        assert DUT.hazard_rate_percent == 0.0
+        assert DUT.hazard_rate_software == 0.0
+        assert DUT.hazard_rate_specified == 0.0
+        # assert DUT.hazard_rate_type_id == 0
+        # assert DUT.hr_active_variance == 0.0
+        assert DUT.hr_dormant_variance == 0.0
+        # assert DUT.hr_logistics_variance == 0.0
+        # assert DUT.hr_mission_variance == 0.0
+        # assert DUT.hr_specified_variance == 0.0
+        assert DUT.location_parameter == 0.0
+        # assert DUT.mtbf_logistics == 0.0
+        # assert DUT.mtbf_mission == 0.0
+        assert DUT.mtbf_specified == 0.0
+        # assert DUT.mtbf_logistics_variance == 0.0
+        # assert DUT.mtbf_mission_variance == 0.0
+        # assert DUT.mtbf_specified_variance == 0.0
+        assert DUT.mult_adj_factor == 1.0
+        assert DUT.quality_id == 0
+        #assert DUT.reliability_goal == 0.0
+        assert DUT.reliability_goal_measure_id == 0
+        # assert DUT.reliability_logistics == 1.0
+        # assert DUT.reliability_mission == 1.0
+        # assert DUT.reliability_log_variance == 0.0
+        # assert DUT.reliability_miss_variance == 0.0
+        assert DUT.scale_parameter == 0.0
+        assert DUT.shape_parameter == 0.0
+        assert DUT.survival_analysis_id == 0
+        assert DUT.lambda_b == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """get_attributes() should return a dict of attribute key:value pairs."""
+        DUT = test_program_dao.session.query(RAMSTKReliability).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """get_attributes() should return a dict of attribute key:value pairs."""
-    DUT = test_dao.session.query(RAMSTKReliability).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
+        assert isinstance(_attributes, dict)
+        assert _attributes['hardware_id'] == 1
+        assert _attributes['add_adj_factor'] == 0.0
+        assert _attributes['availability_logistics'] == 1.0
+        assert _attributes['availability_mission'] == 1.0
+        assert _attributes['avail_log_variance'] == 0.0
+        assert _attributes['avail_mis_variance'] == 0.0
+        assert _attributes['failure_distribution_id'] == 0
+        # assert _attributes['hazard_rate_active'] == 0.0
+        assert _attributes['hazard_rate_dormant'] == 0.0
+        # assert _attributes['hazard_rate_logistics'] == 0.0
+        assert _attributes['hazard_rate_method_id'] == 0
+        # assert _attributes['hazard_rate_mission'] == 0.0
+        assert _attributes['hazard_rate_model'] == ''
+        assert _attributes['hazard_rate_percent'] == 0.0
+        assert _attributes['hazard_rate_software'] == 0.0
+        assert _attributes['hazard_rate_specified'] == 0.0
+        # assert _attributes['hazard_rate_type_id'] == 0
+        # assert _attributes['hr_active_variance'] == 0.0
+        assert _attributes['hr_dormant_variance'] == 0.0
+        # assert _attributes['hr_logistics_variance'] == 0.0
+        # assert _attributes['hr_mission_variance'] == 0.0
+        # assert _attributes['hr_specified_variance'] == 0.0
+        assert _attributes['lambda_b'] == 0.0
+        assert _attributes['location_parameter'] == 0.0
+        # assert _attributes['mtbf_logistics'] == 0.0
+        # assert _attributes['mtbf_mission'] == 0.0
+        assert _attributes['mtbf_specified'] == 0.0
+        # assert _attributes['mtbf_logistics_variance'] == 0.0
+        # assert _attributes['mtbf_mission_variance'] == 0.0
+        # assert _attributes['mtbf_specified_variance'] == 0.0
+        assert _attributes['mult_adj_factor'] == 1.0
+        assert _attributes['quality_id'] == 0
+        #assert _attributes['reliability_goal'] == 0.0
+        assert _attributes['reliability_goal_measure_id'] == 0
+        # assert _attributes['reliability_logistics'] == 1.0
+        # assert _attributes['reliability_mission'] == 1.0
+        # assert _attributes['reliability_log_variance'] == 0.0
+        # assert _attributes['reliability_miss_variance'] == 0.0
+        assert _attributes['scale_parameter'] == 0.0
+        assert _attributes['shape_parameter'] == 0.0
+        assert _attributes['survival_analysis_id'] == 0
 
-    assert isinstance(_attributes, dict)
-    assert _attributes['hardware_id'] == 1
-    assert _attributes['add_adj_factor'] == 0.0
-    assert _attributes['availability_logistics'] == 1.0
-    assert _attributes['availability_mission'] == 1.0
-    assert _attributes['avail_log_variance'] == 0.0
-    assert _attributes['avail_mis_variance'] == 0.0
-    assert _attributes['failure_distribution_id'] == 0
-    # assert _attributes['hazard_rate_active'] == 0.0
-    assert _attributes['hazard_rate_dormant'] == 0.0
-    # assert _attributes['hazard_rate_logistics'] == 0.0
-    assert _attributes['hazard_rate_method_id'] == 0
-    # assert _attributes['hazard_rate_mission'] == 0.0
-    assert _attributes['hazard_rate_model'] == ''
-    assert _attributes['hazard_rate_percent'] == 0.0
-    assert _attributes['hazard_rate_software'] == 0.0
-    assert _attributes['hazard_rate_specified'] == 0.0
-    # assert _attributes['hazard_rate_type_id'] == 0
-    # assert _attributes['hr_active_variance'] == 0.0
-    assert _attributes['hr_dormant_variance'] == 0.0
-    # assert _attributes['hr_logistics_variance'] == 0.0
-    # assert _attributes['hr_mission_variance'] == 0.0
-    # assert _attributes['hr_specified_variance'] == 0.0
-    assert _attributes['lambda_b'] == 0.0
-    assert _attributes['location_parameter'] == 0.0
-    # assert _attributes['mtbf_logistics'] == 0.0
-    # assert _attributes['mtbf_mission'] == 0.0
-    assert _attributes['mtbf_specified'] == 0.0
-    # assert _attributes['mtbf_logistics_variance'] == 0.0
-    # assert _attributes['mtbf_mission_variance'] == 0.0
-    # assert _attributes['mtbf_specified_variance'] == 0.0
-    assert _attributes['mult_adj_factor'] == 1.0
-    assert _attributes['quality_id'] == 0
-    #assert _attributes['reliability_goal'] == 0.0
-    assert _attributes['reliability_goal_measure_id'] == 0
-    # assert _attributes['reliability_logistics'] == 1.0
-    # assert _attributes['reliability_mission'] == 1.0
-    # assert _attributes['reliability_log_variance'] == 0.0
-    # assert _attributes['reliability_miss_variance'] == 0.0
-    assert _attributes['scale_parameter'] == 0.0
-    assert _attributes['shape_parameter'] == 0.0
-    assert _attributes['survival_analysis_id'] == 0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """set_attributes() should return a zero error code on success."""
+        DUT = test_program_dao.session.query(RAMSTKReliability).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """set_attributes() should return a zero error code on success."""
-    DUT = test_dao.session.query(RAMSTKReliability).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKReliability).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['add_adj_factor'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['add_adj_factor'] == 0.0
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKReliability).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKReliability).first()
 
-    ATTRIBUTES['add_adj_factor'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['add_adj_factor'] == 0.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(bind=test_dao.engine,
-                                       autoflush=False,
-                                       expire_on_commit=False)
-    DUT = _session.query(RAMSTKReliability).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkrequirement.py
+++ b/tests/models/programdb/test_ramstkrequirement.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkrequirement.py is part of The RAMSTK

--- a/tests/models/programdb/test_ramstkrevision.py
+++ b/tests/models/programdb/test_ramstkrevision.py
@@ -1,6 +1,8 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.models.programdb.test_ramstkrevision.py is part of The RAMSTK Project
+#       tests.models.programdb.test_ramstkrevision.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 """Test class for testing the RAMSTKRevision module algorithms and models."""
@@ -41,102 +43,101 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstkrevision_create(test_dao):
-    """ __init__() should create an RAMSTKRevision model. """
-    DUT = test_dao.session.query(RAMSTKRevision).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKRevision():
+    """Class for testing the RAMSTKRevision model."""
+    @pytest.mark.integration
+    def test_ramstkrevision_create(self, test_program_dao):
+        """ __init__() should create an RAMSTKRevision model. """
+        DUT = test_program_dao.session.query(RAMSTKRevision).first()
 
-    assert isinstance(DUT, RAMSTKRevision)
+        assert isinstance(DUT, RAMSTKRevision)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_revision'
-    assert DUT.revision_id == 1
-    assert DUT.availability_logistics == 1.0
-    assert DUT.availability_mission == 1.0
-    assert DUT.cost == 0.0
-    assert DUT.cost_failure == 0.0
-    assert DUT.cost_hour == 0.0
-    assert DUT.hazard_rate_active == 0.0
-    assert DUT.hazard_rate_dormant == 0.0
-    assert DUT.hazard_rate_logistics == 0.0
-    assert DUT.hazard_rate_mission == 0.0
-    assert DUT.hazard_rate_software == 0.0
-    assert DUT.mmt == 0.0
-    assert DUT.mcmt == 0.0
-    assert DUT.mpmt == 0.0
-    assert DUT.mtbf_logistics == 0.0
-    assert DUT.mtbf_mission == 0.0
-    assert DUT.mttr == 0.0
-    assert DUT.name == 'Test Revision'
-    assert DUT.reliability_logistics == 1.0
-    assert DUT.reliability_mission == 1.0
-    assert DUT.remarks == b''
-    assert DUT.total_part_count == 1
-    assert DUT.revision_code == ''
-    assert DUT.program_time == 0.0
-    assert DUT.program_time_sd == 0.0
-    assert DUT.program_cost == 0.0
-    assert DUT.program_cost_sd == 0.0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_revision'
+        assert DUT.revision_id == 1
+        assert DUT.availability_logistics == 1.0
+        assert DUT.availability_mission == 1.0
+        assert DUT.cost == 0.0
+        assert DUT.cost_failure == 0.0
+        assert DUT.cost_hour == 0.0
+        assert DUT.hazard_rate_active == 0.0
+        assert DUT.hazard_rate_dormant == 0.0
+        assert DUT.hazard_rate_logistics == 0.0
+        assert DUT.hazard_rate_mission == 0.0
+        assert DUT.hazard_rate_software == 0.0
+        assert DUT.mmt == 0.0
+        assert DUT.mcmt == 0.0
+        assert DUT.mpmt == 0.0
+        assert DUT.mtbf_logistics == 0.0
+        assert DUT.mtbf_mission == 0.0
+        assert DUT.mttr == 0.0
+        assert DUT.name == 'Test Revision'
+        assert DUT.reliability_logistics == 1.0
+        assert DUT.reliability_mission == 1.0
+        assert DUT.remarks == b''
+        assert DUT.total_part_count == 1
+        assert DUT.revision_code == ''
+        assert DUT.program_time == 0.0
+        assert DUT.program_time_sd == 0.0
+        assert DUT.program_cost == 0.0
+        assert DUT.program_cost_sd == 0.0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """ get_attributes() should return a dict of {attr name:attr value} pairs. """
+        DUT = test_program_dao.session.query(RAMSTKRevision).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """ get_attributes() should return a dict of {attr name:attr value} pairs. """
-    DUT = test_dao.session.query(RAMSTKRevision).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
+        assert _attributes['availability_logistics'] == 1.0
+        assert _attributes['availability_mission'] == 1.0
+        assert _attributes['cost'] == 0.0
+        assert _attributes['cost_failure'] == 0.0
+        assert _attributes['cost_hour'] == 0.0
+        assert _attributes['hazard_rate_active'] == 0.0
+        assert _attributes['hazard_rate_dormant'] == 0.0
+        assert _attributes['hazard_rate_logistics'] == 0.0
+        assert _attributes['hazard_rate_mission'] == 0.0
+        assert _attributes['hazard_rate_software'] == 0.0
+        assert _attributes['mmt'] == 0.0
+        assert _attributes['mcmt'] == 0.0
+        assert _attributes['mpmt'] == 0.0
+        assert _attributes['mtbf_logistics'] == 0.0
+        assert _attributes['mtbf_mission'] == 0.0
+        assert _attributes['mttr'] == 0.0
+        assert _attributes['name'] == 'Test Revision'
+        assert _attributes['reliability_logistics'] == 1.0
+        assert _attributes['reliability_mission'] == 1.0
+        assert _attributes['remarks'] == b''
+        assert _attributes['total_part_count'] == 1
+        assert _attributes['revision_code'] == ''
+        assert _attributes['program_time'] == 0.0
+        assert _attributes['program_time_sd'] == 0.0
+        assert _attributes['program_cost'] == 0.0
+        assert _attributes['program_cost_sd'] == 0.0
 
-    assert _attributes['availability_logistics'] == 1.0
-    assert _attributes['availability_mission'] == 1.0
-    assert _attributes['cost'] == 0.0
-    assert _attributes['cost_failure'] == 0.0
-    assert _attributes['cost_hour'] == 0.0
-    assert _attributes['hazard_rate_active'] == 0.0
-    assert _attributes['hazard_rate_dormant'] == 0.0
-    assert _attributes['hazard_rate_logistics'] == 0.0
-    assert _attributes['hazard_rate_mission'] == 0.0
-    assert _attributes['hazard_rate_software'] == 0.0
-    assert _attributes['mmt'] == 0.0
-    assert _attributes['mcmt'] == 0.0
-    assert _attributes['mpmt'] == 0.0
-    assert _attributes['mtbf_logistics'] == 0.0
-    assert _attributes['mtbf_mission'] == 0.0
-    assert _attributes['mttr'] == 0.0
-    assert _attributes['name'] == 'Test Revision'
-    assert _attributes['reliability_logistics'] == 1.0
-    assert _attributes['reliability_mission'] == 1.0
-    assert _attributes['remarks'] == b''
-    assert _attributes['total_part_count'] == 1
-    assert _attributes['revision_code'] == ''
-    assert _attributes['program_time'] == 0.0
-    assert _attributes['program_time_sd'] == 0.0
-    assert _attributes['program_cost'] == 0.0
-    assert _attributes['program_cost_sd'] == 0.0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """ set_attributes() should return a zero error code on success. """
+        DUT = test_program_dao.session.query(RAMSTKRevision).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """ set_attributes() should return a zero error code on success. """
-    DUT = test_dao.session.query(RAMSTKRevision).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKRevision).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['mttr'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['mttr'] == 0.0
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    DUT = test_dao.session.query(RAMSTKRevision).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKRevision).first()
 
-    ATTRIBUTES['mttr'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['mttr'] == 0.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    DUT = test_dao.session.query(RAMSTKRevision).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstksimilaritem.py
+++ b/tests/models/programdb/test_ramstksimilaritem.py
@@ -1,7 +1,8 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.data.storage.programdb.test_ramstksimilaritem.py is part of The
-#       RAMSTK Project
+#       tests.models.programdb.test_ramstksimilaritem.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 """Test class for testing RAMSTKSimilarItem module algorithms and models."""
@@ -69,170 +70,159 @@ ATTRIBUTES = {
 }
 
 
-@pytest.mark.integration
-def test_ramstksimilaritem_create(test_dao):
-    """__init__() should create an RAMSTKSimilarItem model."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKSimilarItem).first()
+@pytest.mark.usefixtures('test_program_dao')
+class TestRAMSTKSimilarItem():
+    """Class for testing the RAMSTKSimilarItem model."""
+    @pytest.mark.integration
+    def test_ramstksimilaritem_create(self, test_program_dao):
+        """__init__() should create an RAMSTKSimilarItem model."""
+        DUT = test_program_dao.session.query(RAMSTKSimilarItem).first()
 
-    assert isinstance(DUT, RAMSTKSimilarItem)
+        assert isinstance(DUT, RAMSTKSimilarItem)
 
-    # Verify class attributes are properly initialized.
-    assert DUT.__tablename__ == 'ramstk_similar_item'
-    assert DUT.revision_id == 1
-    assert DUT.hardware_id == 1
-    assert DUT.change_description_1 == b''
-    assert DUT.change_description_2 == b''
-    assert DUT.change_description_3 == b''
-    assert DUT.change_description_4 == b''
-    assert DUT.change_description_5 == b''
-    assert DUT.change_description_6 == b''
-    assert DUT.change_description_7 == b''
-    assert DUT.change_description_8 == b''
-    assert DUT.change_description_9 == b''
-    assert DUT.change_description_10 == b''
-    assert DUT.change_factor_1 == 1.0
-    assert DUT.change_factor_2 == 1.0
-    assert DUT.change_factor_3 == 1.0
-    assert DUT.change_factor_4 == 1.0
-    assert DUT.change_factor_5 == 1.0
-    assert DUT.change_factor_6 == 1.0
-    assert DUT.change_factor_7 == 1.0
-    assert DUT.change_factor_8 == 1.0
-    assert DUT.change_factor_9 == 1.0
-    assert DUT.change_factor_10 == 1.0
-    assert DUT.environment_from_id == 0
-    assert DUT.environment_to_id == 0
-    assert DUT.function_1 == '0'
-    assert DUT.function_2 == '0'
-    assert DUT.function_3 == '0'
-    assert DUT.function_4 == '0'
-    assert DUT.function_5 == '0'
-    assert DUT.similar_item_method_id == 1
-    assert DUT.parent_id == 0
-    assert DUT.quality_from_id == 0
-    assert DUT.quality_to_id == 0
-    assert DUT.result_1 == 0.0
-    assert DUT.result_2 == 0.0
-    assert DUT.result_3 == 0.0
-    assert DUT.result_4 == 0.0
-    assert DUT.result_5 == 0.0
-    assert DUT.temperature_from == 30.0
-    assert DUT.temperature_to == 30.0
-    assert DUT.user_blob_1 == b''
-    assert DUT.user_blob_2 == b''
-    assert DUT.user_blob_3 == b''
-    assert DUT.user_blob_4 == b''
-    assert DUT.user_blob_5 == b''
-    assert DUT.user_float_1 == 0.0
-    assert DUT.user_float_2 == 0.0
-    assert DUT.user_float_3 == 0.0
-    assert DUT.user_float_4 == 0.0
-    assert DUT.user_float_5 == 0.0
-    assert DUT.user_int_1 == 0
-    assert DUT.user_int_2 == 0
-    assert DUT.user_int_3 == 0
-    assert DUT.user_int_4 == 0
-    assert DUT.user_int_5 == 0
+        # Verify class attributes are properly initialized.
+        assert DUT.__tablename__ == 'ramstk_similar_item'
+        assert DUT.revision_id == 1
+        assert DUT.hardware_id == 1
+        assert DUT.change_description_1 == b''
+        assert DUT.change_description_2 == b''
+        assert DUT.change_description_3 == b''
+        assert DUT.change_description_4 == b''
+        assert DUT.change_description_5 == b''
+        assert DUT.change_description_6 == b''
+        assert DUT.change_description_7 == b''
+        assert DUT.change_description_8 == b''
+        assert DUT.change_description_9 == b''
+        assert DUT.change_description_10 == b''
+        assert DUT.change_factor_1 == 1.0
+        assert DUT.change_factor_2 == 1.0
+        assert DUT.change_factor_3 == 1.0
+        assert DUT.change_factor_4 == 1.0
+        assert DUT.change_factor_5 == 1.0
+        assert DUT.change_factor_6 == 1.0
+        assert DUT.change_factor_7 == 1.0
+        assert DUT.change_factor_8 == 1.0
+        assert DUT.change_factor_9 == 1.0
+        assert DUT.change_factor_10 == 1.0
+        assert DUT.environment_from_id == 0
+        assert DUT.environment_to_id == 0
+        assert DUT.function_1 == '0'
+        assert DUT.function_2 == '0'
+        assert DUT.function_3 == '0'
+        assert DUT.function_4 == '0'
+        assert DUT.function_5 == '0'
+        assert DUT.similar_item_method_id == 1
+        assert DUT.parent_id == 0
+        assert DUT.quality_from_id == 0
+        assert DUT.quality_to_id == 0
+        assert DUT.result_1 == 0.0
+        assert DUT.result_2 == 0.0
+        assert DUT.result_3 == 0.0
+        assert DUT.result_4 == 0.0
+        assert DUT.result_5 == 0.0
+        assert DUT.temperature_from == 30.0
+        assert DUT.temperature_to == 30.0
+        assert DUT.user_blob_1 == b''
+        assert DUT.user_blob_2 == b''
+        assert DUT.user_blob_3 == b''
+        assert DUT.user_blob_4 == b''
+        assert DUT.user_blob_5 == b''
+        assert DUT.user_float_1 == 0.0
+        assert DUT.user_float_2 == 0.0
+        assert DUT.user_float_3 == 0.0
+        assert DUT.user_float_4 == 0.0
+        assert DUT.user_float_5 == 0.0
+        assert DUT.user_int_1 == 0
+        assert DUT.user_int_2 == 0
+        assert DUT.user_int_3 == 0
+        assert DUT.user_int_4 == 0
+        assert DUT.user_int_5 == 0
 
+    @pytest.mark.integration
+    def test_get_attributes(self, test_program_dao):
+        """get_attributes() should return a dict of attribute values."""
+        DUT = test_program_dao.session.query(RAMSTKSimilarItem).first()
 
-@pytest.mark.integration
-def test_get_attributes(test_dao):
-    """get_attributes() should return a dict of attribute values."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKSimilarItem).first()
+        _attributes = DUT.get_attributes()
 
-    _attributes = DUT.get_attributes()
+        assert isinstance(_attributes, dict)
 
-    assert isinstance(_attributes, dict)
+        assert _attributes['hardware_id'] == 1
+        assert _attributes['change_description_1'] == b''
+        assert _attributes['change_description_2'] == b''
+        assert _attributes['change_description_3'] == b''
+        assert _attributes['change_description_4'] == b''
+        assert _attributes['change_description_5'] == b''
+        assert _attributes['change_description_6'] == b''
+        assert _attributes['change_description_7'] == b''
+        assert _attributes['change_description_8'] == b''
+        assert _attributes['change_description_9'] == b''
+        assert _attributes['change_description_10'] == b''
+        assert _attributes['change_factor_1'] == 1.0
+        assert _attributes['change_factor_2'] == 1.0
+        assert _attributes['change_factor_3'] == 1.0
+        assert _attributes['change_factor_4'] == 1.0
+        assert _attributes['change_factor_5'] == 1.0
+        assert _attributes['change_factor_6'] == 1.0
+        assert _attributes['change_factor_7'] == 1.0
+        assert _attributes['change_factor_8'] == 1.0
+        assert _attributes['change_factor_9'] == 1.0
+        assert _attributes['change_factor_10'] == 1.0
+        assert _attributes['environment_from_id'] == 0
+        assert _attributes['environment_to_id'] == 0
+        assert _attributes['function_1'] == '0'
+        assert _attributes['function_2'] == '0'
+        assert _attributes['function_3'] == '0'
+        assert _attributes['function_4'] == '0'
+        assert _attributes['function_5'] == '0'
+        assert _attributes['similar_item_method_id'] == 1
+        assert _attributes['parent_id'] == 0
+        assert _attributes['quality_from_id'] == 0
+        assert _attributes['quality_to_id'] == 0
+        assert _attributes['result_1'] == 0.0
+        assert _attributes['result_2'] == 0.0
+        assert _attributes['result_3'] == 0.0
+        assert _attributes['result_4'] == 0.0
+        assert _attributes['result_5'] == 0.0
+        assert _attributes['temperature_from'] == 30.0
+        assert _attributes['temperature_to'] == 30.0
+        assert _attributes['user_blob_1'] == b''
+        assert _attributes['user_blob_2'] == b''
+        assert _attributes['user_blob_3'] == b''
+        assert _attributes['user_blob_4'] == b''
+        assert _attributes['user_blob_5'] == b''
+        assert _attributes['user_float_1'] == 0.0
+        assert _attributes['user_float_2'] == 0.0
+        assert _attributes['user_float_3'] == 0.0
+        assert _attributes['user_float_4'] == 0.0
+        assert _attributes['user_float_5'] == 0.0
+        assert _attributes['user_int_1'] == 0
+        assert _attributes['user_int_2'] == 0
+        assert _attributes['user_int_3'] == 0
+        assert _attributes['user_int_4'] == 0
+        assert _attributes['user_int_5'] == 0
 
-    assert _attributes['hardware_id'] == 1
-    assert _attributes['change_description_1'] == b''
-    assert _attributes['change_description_2'] == b''
-    assert _attributes['change_description_3'] == b''
-    assert _attributes['change_description_4'] == b''
-    assert _attributes['change_description_5'] == b''
-    assert _attributes['change_description_6'] == b''
-    assert _attributes['change_description_7'] == b''
-    assert _attributes['change_description_8'] == b''
-    assert _attributes['change_description_9'] == b''
-    assert _attributes['change_description_10'] == b''
-    assert _attributes['change_factor_1'] == 1.0
-    assert _attributes['change_factor_2'] == 1.0
-    assert _attributes['change_factor_3'] == 1.0
-    assert _attributes['change_factor_4'] == 1.0
-    assert _attributes['change_factor_5'] == 1.0
-    assert _attributes['change_factor_6'] == 1.0
-    assert _attributes['change_factor_7'] == 1.0
-    assert _attributes['change_factor_8'] == 1.0
-    assert _attributes['change_factor_9'] == 1.0
-    assert _attributes['change_factor_10'] == 1.0
-    assert _attributes['environment_from_id'] == 0
-    assert _attributes['environment_to_id'] == 0
-    assert _attributes['function_1'] == '0'
-    assert _attributes['function_2'] == '0'
-    assert _attributes['function_3'] == '0'
-    assert _attributes['function_4'] == '0'
-    assert _attributes['function_5'] == '0'
-    assert _attributes['similar_item_method_id'] == 1
-    assert _attributes['parent_id'] == 0
-    assert _attributes['quality_from_id'] == 0
-    assert _attributes['quality_to_id'] == 0
-    assert _attributes['result_1'] == 0.0
-    assert _attributes['result_2'] == 0.0
-    assert _attributes['result_3'] == 0.0
-    assert _attributes['result_4'] == 0.0
-    assert _attributes['result_5'] == 0.0
-    assert _attributes['temperature_from'] == 30.0
-    assert _attributes['temperature_to'] == 30.0
-    assert _attributes['user_blob_1'] == b''
-    assert _attributes['user_blob_2'] == b''
-    assert _attributes['user_blob_3'] == b''
-    assert _attributes['user_blob_4'] == b''
-    assert _attributes['user_blob_5'] == b''
-    assert _attributes['user_float_1'] == 0.0
-    assert _attributes['user_float_2'] == 0.0
-    assert _attributes['user_float_3'] == 0.0
-    assert _attributes['user_float_4'] == 0.0
-    assert _attributes['user_float_5'] == 0.0
-    assert _attributes['user_int_1'] == 0
-    assert _attributes['user_int_2'] == 0
-    assert _attributes['user_int_3'] == 0
-    assert _attributes['user_int_4'] == 0
-    assert _attributes['user_int_5'] == 0
+    @pytest.mark.integration
+    def test_set_attributes(self, test_program_dao):
+        """set_attributes() should return None on success."""
+        DUT = test_program_dao.session.query(RAMSTKSimilarItem).first()
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
 
-@pytest.mark.integration
-def test_set_attributes(test_dao):
-    """set_attributes() should return None on success."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKSimilarItem).first()
+    @pytest.mark.integration
+    def test_set_attributes_none_value(self, test_program_dao):
+        """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
+        DUT = test_program_dao.session.query(RAMSTKSimilarItem).first()
 
-    assert DUT.set_attributes(ATTRIBUTES) is None
+        ATTRIBUTES['change_factor_3'] = None
 
+        assert DUT.set_attributes(ATTRIBUTES) is None
+        assert DUT.get_attributes()['change_factor_3'] == 1.0
 
-@pytest.mark.integration
-def test_set_attributes_none_value(test_dao):
-    """set_attributes() should set an attribute to it's default value when the attribute is passed with a None value."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKSimilarItem).first()
+    @pytest.mark.integration
+    def test_set_attributes_unknown_attributes(self, test_program_dao):
+        """set_attributes() should raise an AttributeError when passed an unknown attribute."""
+        DUT = test_program_dao.session.query(RAMSTKSimilarItem).first()
 
-    ATTRIBUTES['change_factor_3'] = None
-
-    assert DUT.set_attributes(ATTRIBUTES) is None
-    assert DUT.get_attributes()['change_factor_3'] == 1.0
-
-
-@pytest.mark.integration
-def test_set_attributes_unknown_attributes(test_dao):
-    """set_attributes() should raise an AttributeError when passed an unknown attribute."""
-    _session = test_dao.RAMSTK_SESSION(
-        bind=test_dao.engine, autoflush=False, expire_on_commit=False)
-    DUT = _session.query(RAMSTKSimilarItem).first()
-
-    with pytest.raises(AttributeError):
-        DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})
+        with pytest.raises(AttributeError):
+            DUT.set_attributes({'shibboly-bibbly-boo': 0.9998})

--- a/tests/models/programdb/test_ramstkstakeholder.py
+++ b/tests/models/programdb/test_ramstkstakeholder.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
 #       tests.models.programdb.test_ramstkstakeholder.py is part of The RAMSTK

--- a/tests/models/programdb/test_ramstkvalidation.py
+++ b/tests/models/programdb/test_ramstkvalidation.py
@@ -1,6 +1,8 @@
+# pylint: disable=protected-access, no-self-use, missing-docstring
 # -*- coding: utf-8 -*-
 #
-#       tests.models.programdb.test_ramstkvalidation.py is part of The RAMSTK Project
+#       tests.models.programdb.test_ramstkvalidation.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
 """Test class for testing the RAMSTKValidation module algorithms and models."""


### PR DESCRIPTION
Group all program database table tests into a class for each model.
This allows the use of the class-based fixtures, primarily the test
database.

* conf.py creates a test database for each class in a unique temporary
directory rather than using the same name for each class.  Prevents
test failure due to locked databases and other problems caused by
'race' conditions.
* Add pylint disable statement to top of each test file.