### PR TITLE
fix: allow mission and mission phase to load in form

### DIFF
--- a/src/ramstk/views/gtk3/fmea/workview.py
+++ b/src/ramstk/views/gtk3/fmea/workview.py
@@ -874,7 +874,7 @@ class FMEAPanel(RAMSTKPanel):
         self._lst_missions = []
         _model.append([""])
         for _node in tree.children(tree.root):
-            _lst_phases: List[str] = []
+            _lst_phases: List[str] = ['']
 
             _mission = _node.data['usage_profile'].get_attributes(
             )['description']
@@ -926,19 +926,15 @@ class FMEAPanel(RAMSTKPanel):
         _icon = GdkPixbuf.Pixbuf.new_from_file_at_size(self.dic_icons["mode"],
                                                        22, 22)
 
-        _mission = self._lst_missions[int(_entity.mission) - 1]
-        _mission_phase = self._dic_mission_phases[_mission][
-            int(_entity.mission_phase) - 1]
-
         _attributes = [
-            node.identifier, _entity.description, _mission, _mission_phase,
-            _entity.effect_local, _entity.effect_next, _entity.effect_end,
-            _entity.detection_method, _entity.other_indications,
-            _entity.isolation_method, _entity.design_provisions,
-            _entity.operator_actions, _entity.severity_class,
-            _entity.hazard_rate_source, _entity.mode_probability,
-            _entity.effect_probability, _entity.mode_ratio,
-            _entity.mode_hazard_rate, _entity.mode_op_time,
+            node.identifier, _entity.description, _entity.mission,
+            _entity.mission_phase, _entity.effect_local, _entity.effect_next,
+            _entity.effect_end, _entity.detection_method,
+            _entity.other_indications, _entity.isolation_method,
+            _entity.design_provisions, _entity.operator_actions,
+            _entity.severity_class, _entity.hazard_rate_source,
+            _entity.mode_probability, _entity.effect_probability,
+            _entity.mode_ratio, _entity.mode_hazard_rate, _entity.mode_op_time,
             _entity.mode_criticality, "", _severity, "", "", 0, "", "", "", "",
             "", 0, "", 0, "", _severity_new, "", "", 0, _entity.critical_item,
             _entity.single_point, 0, _entity.remarks, _icon


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.
  - [x] Followed in new code.
  - [x] Corrected in existing code whenever possible.
  - [ ] Spelling and English grammar errors have been eliminated.
  - [ ] Attribute and variable names make sense.
  - [x] Stub files created or updated.
  - [x] New code is readable.
  - [x] Execute 'make maintain' before committing changes and fix any issues.
  - [x] Code is not overly complicated; refactor if it is.
  - [x] Debugging, including print(), statements have been removed.

- Tests
  - [x] At least one test for all newly created functions/methods?
  - [x] Tests capture key use cases.
  - [x] Enough edge cases covered for comfort.
  - [x] Code coverage has not decreased.

- Documentation
  - [ ] Update api documentation to reflect the changes made.
  - [ ] Update the user documentation to reflect the changes made.

- Chores
  - [x] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [x] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [x] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [x] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [x] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
