### PR TITLE
refactor: move failure definition do update

### DIFF
--- a/src/ramstk/controllers/failure_definition/datamanager.py
+++ b/src/ramstk/controllers/failure_definition/datamanager.py
@@ -28,7 +28,7 @@ class DataManager(RAMSTKDataManager):
     RAMSTKFailureDefinition data models.
     """
 
-    _tag = 'failure_definitions'
+    _tag = "failure_definitions"
 
     def __init__(self, **kwargs: Dict[Any, Any]) -> None:
         """Initialize a Failure Definition data manager instance."""
@@ -36,7 +36,7 @@ class DataManager(RAMSTKDataManager):
 
         # Initialize private dictionary attributes.
         self._pkey: Dict[str, List[str]] = {
-            'failure_definition': ['revision_id', 'definition_id']
+            "failure_definition": ["revision_id", "definition_id"]
         }
 
         # Initialize private list attributes.
@@ -50,22 +50,22 @@ class DataManager(RAMSTKDataManager):
         # Initialize public scalar attributes.
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(super().do_get_attributes,
-                      'request_get_failure_definition_attributes')
-        pub.subscribe(super().do_set_attributes,
-                      'request_set_failure_definition_attributes')
-        pub.subscribe(super().do_set_attributes,
-                      'lvw_editing_failure_definition')
-        pub.subscribe(super().do_update_all,
-                      'request_update_all_failure_definitionss')
+        pub.subscribe(
+            super().do_get_attributes, "request_get_failure_definition_attributes"
+        )
+        pub.subscribe(
+            super().do_set_attributes, "request_set_failure_definition_attributes"
+        )
+        pub.subscribe(super().do_set_attributes, "lvw_editing_failure_definition")
+        pub.subscribe(super().do_update, "request_update_failure_definition")
 
-        pub.subscribe(self.do_get_tree, 'request_get_failure_definition_tree')
-        pub.subscribe(self.do_select_all, 'selected_revision')
-        pub.subscribe(self.do_update, 'request_update_failure_definitions')
+        pub.subscribe(self.do_get_tree, "request_get_failure_definition_tree")
+        pub.subscribe(self.do_select_all, "selected_revision")
 
-        pub.subscribe(self._do_delete, 'request_delete_failure_definitions')
-        pub.subscribe(self._do_insert_failure_definition,
-                      'request_insert_failure_definitions')
+        pub.subscribe(self._do_delete, "request_delete_failure_definitions")
+        pub.subscribe(
+            self._do_insert_failure_definition, "request_insert_failure_definitions"
+        )
 
     def do_get_tree(self) -> None:
         """Retrieve the failure definition treelib Tree.
@@ -73,7 +73,7 @@ class DataManager(RAMSTKDataManager):
         :return: None
         :rtype: None
         """
-        pub.sendMessage('succeed_get_failure_definition_tree', tree=self.tree)
+        pub.sendMessage("succeed_get_failure_definition_tree", tree=self.tree)
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all Failure Definitions from the RAMSTK Program database.
@@ -82,90 +82,31 @@ class DataManager(RAMSTKDataManager):
         :return: None
         :rtype: None
         """
-        self._revision_id = attributes['revision_id']
+        self._revision_id = attributes["revision_id"]
 
         for _node in self.tree.children(self.tree.root):
             self.tree.remove_node(_node.identifier)
 
         for _failure_definition in self.dao.do_select_all(
-                RAMSTKFailureDefinition,
-                key=['revision_id'],
-                value=[self._revision_id],
-                order=RAMSTKFailureDefinition.definition_id):
+            RAMSTKFailureDefinition,
+            key=["revision_id"],
+            value=[self._revision_id],
+            order=RAMSTKFailureDefinition.definition_id,
+        ):
 
             self.tree.create_node(
-                tag='definition',
+                tag="definition",
                 identifier=_failure_definition.definition_id,
                 parent=self._root,
-                data={'failure_definition': _failure_definition})
+                data={"failure_definition": _failure_definition},
+            )
 
         self.last_id = max(self.tree.nodes.keys())
 
         pub.sendMessage(
-            'succeed_retrieve_failure_definitions',
+            "succeed_retrieve_failure_definitions",
             tree=self.tree,
         )
-
-    def do_update(self, node_id: int) -> None:
-        """Update the failure definition associated with node ID in database.
-
-        :param node_id: the node (failure definition) ID of the failure
-            definition to save.
-        :return: None
-        :rtype: None
-        """
-        _method_name: str = inspect.currentframe(  # type: ignore
-        ).f_code.co_name
-
-        try:
-            self.dao.do_update(
-                self.tree.get_node(node_id).data['failure_definition'])
-
-            pub.sendMessage(
-                'succeed_update_failure_definitions',
-                tree=self.tree,
-            )
-        except AttributeError:
-            _error_msg: str = (
-                '{1}: Attempted to save non-existent failure definition with '
-                'failure definition ID {0}.').format(str(node_id),
-                                                     _method_name)
-            pub.sendMessage(
-                'do_log_debug',
-                logger_name='DEBUG',
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                'fail_update_failure_definition',
-                error_message=_error_msg,
-            )
-        except KeyError:
-            _error_msg = (
-                '{1}: No data package found for failure definition ID {0}.'
-            ).format(str(node_id), _method_name)
-            pub.sendMessage(
-                'do_log_debug',
-                logger_name='DEBUG',
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                'fail_update_failure_definition',
-                error_message=_error_msg,
-            )
-        except (DataAccessError, TypeError):
-            if node_id != 0:
-                _error_msg = ('{1}: The value for one or more attributes for '
-                              'failure definition ID {0} was the wrong '
-                              'type.').format(str(node_id), _method_name)
-                pub.sendMessage(
-                    'do_log_debug',
-                    logger_name='DEBUG',
-                    message=_error_msg,
-                )
-                pub.sendMessage(
-                    'fail_update_failure_definition',
-                    error_message=_error_msg,
-                )
 
     def _do_delete(self, node_id: int) -> None:
         """Remove a failure definition.
@@ -174,28 +115,28 @@ class DataManager(RAMSTKDataManager):
         :return: None
         """
         try:
-            super().do_delete(node_id, 'failure_definition')
+            super().do_delete(node_id, "failure_definition")
 
             self.tree.remove_node(node_id)
             self.last_id = max(self.tree.nodes.keys())
 
             pub.sendMessage(
-                'succeed_delete_failure_definition',
+                "succeed_delete_failure_definition",
                 tree=self.tree,
             )
         except (AttributeError, DataAccessError, NodeIDAbsentError):
-            _method_name: str = inspect.currentframe(  # type: ignore
-            ).f_code.co_name
-            _error_msg: str = ('{1}: Attempted to delete non-existent failure '
-                               'definition ID {0}.'.format(
-                                   str(node_id), _method_name))
+            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
+            _error_msg: str = (
+                "{1}: Attempted to delete non-existent failure "
+                "definition ID {0}.".format(str(node_id), _method_name)
+            )
             pub.sendMessage(
-                'do_log_debug',
-                logger_name='DEBUG',
+                "do_log_debug",
+                logger_name="DEBUG",
                 message=_error_msg,
             )
             pub.sendMessage(
-                'fail_delete_failure_definition',
+                "fail_delete_failure_definition",
                 error_message=_error_msg,
             )
 
@@ -220,26 +161,26 @@ class DataManager(RAMSTKDataManager):
             self.last_id = _failure_definition.definition_id
 
             self.tree.create_node(
-                tag='definition',
+                tag="definition",
                 identifier=self.last_id,
                 parent=self._root,
-                data={'failure_definition': _failure_definition},
+                data={"failure_definition": _failure_definition},
             )
 
             pub.sendMessage(
-                'succeed_insert_failure_definition',
+                "succeed_insert_failure_definition",
                 node_id=self.last_id,
                 tree=self.tree,
             )
         except DataAccessError:
-            _method_name: str = inspect.currentframe(  # type: ignore
-            ).f_code.co_name
+            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
             _error_msg: str = (
-                '{1}: Attempting to add failure definition to non-existent '
-                'revision {0}.'.format(self._revision_id, _method_name))
+                "{1}: Attempting to add failure definition to non-existent "
+                "revision {0}.".format(self._revision_id, _method_name)
+            )
             pub.sendMessage(
-                'do_log_debug',
-                logger_name='DEBUG',
+                "do_log_debug",
+                logger_name="DEBUG",
                 message=_error_msg,
             )
             pub.sendMessage(

--- a/src/ramstk/controllers/failure_definition/datamanager.pyi
+++ b/src/ramstk/controllers/failure_definition/datamanager.pyi
@@ -4,9 +4,7 @@ from typing import Any, Dict
 # RAMSTK Package Imports
 from ramstk.controllers import RAMSTKDataManager as RAMSTKDataManager
 from ramstk.exceptions import DataAccessError as DataAccessError
-from ramstk.models.programdb import (
-    RAMSTKFailureDefinition as RAMSTKFailureDefinition
-)
+from ramstk.models.programdb import RAMSTKFailureDefinition as RAMSTKFailureDefinition
 
 class DataManager(RAMSTKDataManager):
     _tag: str = ...
@@ -22,9 +20,6 @@ class DataManager(RAMSTKDataManager):
     last_id: Any = ...
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
-        ...
-
-    def do_update(self, node_id: int) -> None:
         ...
 
     def _do_delete(self, node_id: int) -> None:

--- a/tests/controllers/failure_definition/failure_definition_integration_test.py
+++ b/tests/controllers/failure_definition/failure_definition_integration_test.py
@@ -12,109 +12,113 @@
 # Third Party Imports
 import pytest
 from pubsub import pub
+from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.controllers import dmFailureDefinition
 
 
-@pytest.mark.usefixtures('test_program_dao')
+@pytest.mark.usefixtures("test_program_dao")
 class TestInsertMethods:
     """Class to test data controller insert methods using actual database."""
-    def on_fail_insert_failure_definition(self, error_message):
+
+    def on_fail_insert_no_revision(self, error_message):
         assert error_message == (
-            '_do_insert_failure_definition: Attempting to add failure '
-            'definition to non-existent revision 40.')
+            "_do_insert_failure_definition: Attempting to add failure "
+            "definition to non-existent revision 40."
+        )
         print("\033[35m\nfail_insert_function topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_insert_failure_definition_no_revision(self, test_program_dao):
+    def test_do_insert_no_revision(self, test_program_dao):
         """do_insert() should send the fail_insert_failure_definition message
         when attempting to insert a new failure definition with a non-existent
         revision ID."""
-        pub.subscribe(self.on_fail_insert_failure_definition,
-                      'fail_insert_failure_definition')
+        pub.subscribe(self.on_fail_insert_no_revision, "fail_insert_failure_definition")
 
         DUT = dmFailureDefinition()
         DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
         DUT._revision_id = 40
         DUT._do_insert_failure_definition()
 
-        pub.unsubscribe(self.on_fail_insert_failure_definition,
-                        'fail_insert_failure_definition')
+        pub.unsubscribe(
+            self.on_fail_insert_no_revision, "fail_insert_failure_definition"
+        )
 
 
-@pytest.mark.usefixtures('test_program_dao')
+@pytest.mark.usefixtures("test_program_dao")
 class TestUpdateMethods:
     """Class to test data controller update methods using actual database."""
-    def on_succeed_update_failure_definition(self, tree):
-        assert isinstance(tree, Tree)
-        print(
-            "\033[36m\nsucceed_update_failure_definition topic was broadcast")
 
-    def on_fail_update_failure_definition_wrong_data_type(self, error_message):
+    def on_succeed_update(self, tree):
+        assert isinstance(tree, Tree)
+        print("\033[36m\nsucceed_update_failure_definition topic was broadcast")
+
+    def on_fail_update_wrong_data_type(self, error_message):
         assert error_message == (
-            'do_update: The value for one or more attributes for failure '
-            'definition ID 1 was the wrong type.')
+            "do_update: The value for one or more attributes for failure "
+            "definition ID 1 was the wrong type."
+        )
         print("\033[35m\nfail_update_failure_definition topic was broadcast")
 
     @pytest.mark.integration
-    def test_do_update_failure_definition(self, test_program_dao):
+    def test_do_update(self, test_program_dao):
         """do_update() should send the succeed_update_failure_definition on
         success."""
-        pub.subscribe(self.on_succeed_update_failure_definition,
-                      'succeed_update_failure_definition')
+        pub.subscribe(self.on_succeed_update, "succeed_update_failure_definition")
 
         DUT = dmFailureDefinition()
         DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
-        _failure_definition = DUT.do_select(1, table='failure_definition')
-        _failure_definition.definition = 'Big test definition'
+        _failure_definition = DUT.do_select(1, table="failure_definition")
+        _failure_definition.definition = "Big test definition"
 
-        DUT.do_update(1)
-        _failure_definition = DUT.do_select(1, table='failure_definition')
+        DUT.do_update(1, table="failure_definition")
+        _failure_definition = DUT.do_select(1, table="failure_definition")
 
-        assert _failure_definition.definition == 'Big test definition'
+        assert _failure_definition.definition == "Big test definition"
 
-        pub.unsubscribe(self.on_succeed_update_failure_definition,
-                        'succeed_update_failure_definition')
+        pub.unsubscribe(self.on_succeed_update, "succeed_update_failure_definition")
 
     @pytest.mark.integration
-    def test_do_update_failure_definition_all(self, test_program_dao):
+    def test_do_update_all(self, test_program_dao):
         """do_update_all failure_definition() should return None on success."""
         DUT = dmFailureDefinition()
         DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
-        _failure_definition = DUT.do_select(1, table='failure_definition')
-        _failure_definition.definition = 'Big test definition #1'
-        _failure_definition = DUT.do_select(2, table='failure_definition')
-        _failure_definition.definition = 'Big test definition #2'
+        _failure_definition = DUT.do_select(1, table="failure_definition")
+        _failure_definition.definition = "Big test definition #1"
+        _failure_definition = DUT.do_select(2, table="failure_definition")
+        _failure_definition.definition = "Big test definition #2"
 
-        assert DUT.do_update_all() is None
+        pub.sendMessage("request_update_all_failure_definitions")
 
-        _failure_definition = DUT.do_select(1, table='failure_definition')
-        assert _failure_definition.definition == 'Big test definition #1'
+        _failure_definition = DUT.do_select(1, table="failure_definition")
+        assert _failure_definition.definition == "Big test definition #1"
 
-        _failure_definition = DUT.do_select(2, table='failure_definition')
-        assert _failure_definition.definition == 'Big test definition #2'
+        _failure_definition = DUT.do_select(2, table="failure_definition")
+        assert _failure_definition.definition == "Big test definition #2"
 
     @pytest.mark.integration
-    def test_do_update_failure_definition_wrong_type(self, test_program_dao):
+    def test_do_update_wrong_data_type(self, test_program_dao):
         """do_update() should send the succeed_update_failure_definition on
         success."""
-        pub.subscribe(self.on_fail_update_failure_definition_wrong_data_type,
-                      'fail_update_failure_definition')
+        pub.subscribe(
+            self.on_fail_update_wrong_data_type, "fail_update_failure_definition"
+        )
 
         DUT = dmFailureDefinition()
         DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
-        DUT.tree.get_node(1).data['failure_definition'].definition = {
-            1: 'Big test definition',
+        DUT.do_select_all(attributes={"revision_id": 1})
+        DUT.tree.get_node(1).data["failure_definition"].definition = {
+            1: "Big test definition",
         }
 
-        DUT.do_update(1)
+        DUT.do_update(1, table="failure_definition")
 
-        pub.unsubscribe(self.on_fail_update_failure_definition_wrong_data_type,
-                        'fail_update_failure_definition')
+        pub.unsubscribe(
+            self.on_fail_update_wrong_data_type, "fail_update_failure_definition"
+        )

--- a/tests/controllers/failure_definition/failure_definition_unit_test.py
+++ b/tests/controllers/failure_definition/failure_definition_unit_test.py
@@ -11,6 +11,7 @@
 
 # Third Party Imports
 import pytest
+
 # noinspection PyUnresolvedReferences
 from mocks import MockDAO
 from pubsub import pub
@@ -27,12 +28,12 @@ def mock_program_dao(monkeypatch):
     _definition_1 = RAMSTKFailureDefinition()
     _definition_1.revision_id = 1
     _definition_1.definition_id = 1
-    _definition_1.definition = 'Mock Failure Definition 1'
+    _definition_1.definition = "Mock Failure Definition 1"
 
     _definition_2 = RAMSTKFailureDefinition()
     _definition_2.revision_id = 1
     _definition_2.definition_id = 2
-    _definition_2.definition = 'Mock Failure Definition 2'
+    _definition_2.definition = "Mock Failure Definition 2"
 
     DAO = MockDAO()
     DAO.table = [
@@ -45,78 +46,80 @@ def mock_program_dao(monkeypatch):
 
 class TestCreateControllers:
     """Class for controller initialization test suite."""
+
     @pytest.mark.unit
-    def test_data_manager(self):
+    def test_data_manager_create(self):
         """__init__() should return a Revision data manager."""
         DUT = dmFailureDefinition()
 
         assert isinstance(DUT, dmFailureDefinition)
         assert isinstance(DUT.tree, Tree)
         assert isinstance(DUT.dao, BaseDatabase)
-        assert DUT._tag == 'failure_definitions'
+        assert DUT._tag == "failure_definitions"
         assert DUT._root == 0
         assert DUT._revision_id == 0
-        assert pub.isSubscribed(DUT.do_get_attributes,
-                                'request_get_failure_definition_attributes')
-        assert pub.isSubscribed(DUT.do_select_all, 'selected_revision')
-        assert pub.isSubscribed(DUT.do_update,
-                                'request_update_failure_definitions')
-        assert pub.isSubscribed(DUT.do_update_all,
-                                'request_update_all_failure_definitionss')
-        assert pub.isSubscribed(DUT.do_get_tree,
-                                'request_get_failure_definition_tree')
-        assert pub.isSubscribed(DUT.do_set_attributes,
-                                'request_set_failure_definition_attributes')
-        assert pub.isSubscribed(DUT.do_set_attributes,
-                                'lvw_editing_failure_definition')
-        assert pub.isSubscribed(DUT._do_delete,
-                                'request_delete_failure_definitions')
-        assert pub.isSubscribed(DUT._do_insert_failure_definition,
-                                'request_insert_failure_definitions')
+        assert pub.isSubscribed(
+            DUT.do_get_attributes, "request_get_failure_definition_attributes"
+        )
+        assert pub.isSubscribed(DUT.do_select_all, "selected_revision")
+        assert pub.isSubscribed(DUT.do_update, "request_update_failure_definition")
+        assert pub.isSubscribed(
+            DUT.do_update_all, "request_update_all_failure_definitions"
+        )
+        assert pub.isSubscribed(DUT.do_get_tree, "request_get_failure_definition_tree")
+        assert pub.isSubscribed(
+            DUT.do_set_attributes, "request_set_failure_definition_attributes"
+        )
+        assert pub.isSubscribed(DUT.do_set_attributes, "lvw_editing_failure_definition")
+        assert pub.isSubscribed(DUT._do_delete, "request_delete_failure_definitions")
+        assert pub.isSubscribed(
+            DUT._do_insert_failure_definition, "request_insert_failure_definitions"
+        )
 
 
 class TestSelectMethods:
     """Class for testing data manager select_all() and select() methods."""
+
     @pytest.mark.unit
     def test_do_select_all(self, mock_program_dao):
         """do_select_all() should return a Tree() object populated with
         RAMSTKFailureDefinition instances on success."""
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
         assert isinstance(DUT.tree, Tree)
         assert isinstance(
-            DUT.tree.get_node(1).data['failure_definition'],
-            RAMSTKFailureDefinition)
+            DUT.tree.get_node(1).data["failure_definition"], RAMSTKFailureDefinition
+        )
 
     @pytest.mark.unit
-    def test_do_select_all_tree_loaded(self, mock_program_dao):
+    def test_do_select_all_populated_tree(self, mock_program_dao):
         """do_select_all() should return a Tree() object populated with
         RAMSTKFailureDefinition instances on success when there is already a
         tree of definitions."""
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
         assert isinstance(DUT.tree, Tree)
         assert isinstance(
-            DUT.tree.get_node(1).data['failure_definition'],
-            RAMSTKFailureDefinition)
+            DUT.tree.get_node(1).data["failure_definition"], RAMSTKFailureDefinition
+        )
 
     @pytest.mark.unit
-    def test_do_select_failure_definition(self, mock_program_dao):
+    def test_do_select(self, mock_program_dao):
         """do_select() should return an instance of RAMSTKFailureDefinition on
         success."""
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
-        _failure_definition = DUT.do_select(1, table='failure_definition')
+        _failure_definition = DUT.do_select(1, table="failure_definition")
 
         assert isinstance(_failure_definition, RAMSTKFailureDefinition)
-        assert _failure_definition.definition == 'Mock Failure Definition 1'
+        assert _failure_definition.definition == "Mock Failure Definition 1"
 
     @pytest.mark.unit
     def test_do_select_unknown_table(self, mock_program_dao):
@@ -124,10 +127,10 @@ class TestSelectMethods:
         requested."""
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
         with pytest.raises(KeyError):
-            DUT.do_select(1, table='scibbidy-bibbidy-doo')
+            DUT.do_select(1, table="scibbidy-bibbidy-doo")
 
     @pytest.mark.unit
     def test_do_select_non_existent_id(self, mock_program_dao):
@@ -135,194 +138,205 @@ class TestSelectMethods:
         requested."""
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
-        assert DUT.do_select(100, table='failure_definition') is None
+        assert DUT.do_select(100, table="failure_definition") is None
 
 
-class TestDeleteMethods():
+class TestDeleteMethods:
     """Class for testing the data manager delete() method."""
-    def on_succeed_delete_failure_definition(self, tree):
-        assert isinstance(tree, Tree)
-        print(
-            "\033[36m\nsucceed_delete_failure_definition topic was broadcast.")
 
-    def on_fail_delete_failure_definition(self, error_message):
+    def on_succeed_delete(self, tree):
+        assert isinstance(tree, Tree)
+        print("\033[36m\nsucceed_delete_failure_definition topic was broadcast.")
+
+    def on_fail_delete_non_existent_id(self, error_message):
         assert error_message == (
-            '_do_delete: Attempted to delete non-existent failure '
-            'definition ID 10.')
+            "_do_delete: Attempted to delete non-existent failure " "definition ID 10."
+        )
         print("\033[35m\nfail_delete_failure_definition topic was broadcast.")
 
     @pytest.mark.unit
-    def test_do_delete_failure_definition(self, mock_program_dao):
+    def test_do_delete(self, mock_program_dao):
         """_do_delete_failure_definition() should send the success message
         after successfully deleting a definition."""
-        pub.subscribe(self.on_succeed_delete_failure_definition,
-                      'succeed_delete_failure_definition')
+        pub.subscribe(self.on_succeed_delete, "succeed_delete_failure_definition")
 
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
         DUT._do_delete(1)
 
         with pytest.raises(AttributeError):
-            __ = DUT.tree.get_node(1).data['failure_definition']
+            __ = DUT.tree.get_node(1).data["failure_definition"]
 
-        pub.unsubscribe(self.on_succeed_delete_failure_definition,
-                        'succeed_delete_failure_definition')
+        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_failure_definition")
 
     @pytest.mark.unit
-    def test_do_delete_failure_definition_non_existent_id(
-            self, mock_program_dao):
+    def test_do_delete_non_existent_id(self, mock_program_dao):
         """_do_delete_failure_definition() should send the fail message when
         attempting to delete a non-existent failure definition."""
-        pub.subscribe(self.on_fail_delete_failure_definition,
-                      'fail_delete_failure_definition')
+        pub.subscribe(
+            self.on_fail_delete_non_existent_id, "fail_delete_failure_definition"
+        )
 
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
         DUT._do_delete(10)
 
-        pub.unsubscribe(self.on_fail_delete_failure_definition,
-                        'fail_delete_failure_definition')
+        pub.unsubscribe(
+            self.on_fail_delete_non_existent_id, "fail_delete_failure_definition"
+        )
 
 
-class TestGetterSetter():
+class TestGetterSetter:
     """Class for testing methods that get or set."""
-    def on_succeed_get_failure_definition_attrs(self, attributes):
-        assert isinstance(attributes, dict)
-        assert attributes['revision_id'] == 1
-        assert attributes['definition'] == 'Mock Failure Definition 1'
-        print("\033[36m\nsucceed_get_failure_definition_attributes topic was "
-              "broadcast")
 
-    def on_succeed_get_failure_definition_tree(self, tree):
+    def on_succeed_get_attributes(self, attributes):
+        assert isinstance(attributes, dict)
+        assert attributes["revision_id"] == 1
+        assert attributes["definition"] == "Mock Failure Definition 1"
+        print(
+            "\033[36m\nsucceed_get_failure_definition_attributes topic was " "broadcast"
+        )
+
+    def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(
-            tree.get_node(1).data['failure_definition'],
-            RAMSTKFailureDefinition)
-        print(
-            "\033[36m\nsucceed_get_failure_definition_tree topic was broadcast"
+            tree.get_node(1).data["failure_definition"], RAMSTKFailureDefinition
         )
+        print("\033[36m\nsucceed_get_failure_definition_tree topic was broadcast")
 
     @pytest.mark.unit
     def test_do_get_attributes(self, mock_program_dao):
         """_do_get_attributes() should return a dict of failure definition
         records on success."""
-        pub.subscribe(self.on_succeed_get_failure_definition_attrs,
-                      'succeed_get_failure_definition_attributes')
+        pub.subscribe(
+            self.on_succeed_get_attributes, "succeed_get_failure_definition_attributes"
+        )
 
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
-        DUT.do_get_attributes(1, 'failure_definition')
+        DUT.do_select_all(attributes={"revision_id": 1})
+        DUT.do_get_attributes(1, "failure_definition")
 
-        pub.unsubscribe(self.on_succeed_get_failure_definition_attrs,
-                        'succeed_get_failure_definition_attributes')
+        pub.unsubscribe(
+            self.on_succeed_get_attributes, "succeed_get_failure_definition_attributes"
+        )
 
     @pytest.mark.unit
     def test_do_set_attributes(self, mock_program_dao):
         """do_set_attributes() should send the success message."""
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
 
-        pub.sendMessage('request_set_failure_definition_attributes',
-                        node_id=[1, 1, ''],
-                        package={'definition': 'Test Description'})
+        DUT.do_set_attributes(
+            node_id=[1, 1, ""], package={"definition": "Test Description"}
+        )
 
-        assert DUT.do_select(
-            1, table='failure_definition').definition == 'Test Description'
+        assert (
+            DUT.do_select(1, table="failure_definition").definition
+            == "Test Description"
+        )
 
     @pytest.mark.unit
-    def test_on_get_tree(self, mock_program_dao):
+    def test_on_get_data_manager_tree(self, mock_program_dao):
         """on_get_tree() should return the failure definition treelib Tree."""
-        pub.subscribe(self.on_succeed_get_failure_definition_tree,
-                      'succeed_get_failure_definition_tree')
+        pub.subscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_failure_definition_tree"
+        )
 
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
         DUT.do_get_tree()
 
-        pub.unsubscribe(self.on_succeed_get_failure_definition_tree,
-                        'succeed_get_failure_definition_tree')
+        pub.unsubscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_failure_definition_tree"
+        )
 
 
-@pytest.mark.usefixtures('mock_program_dao')
-class TestInsertMethods():
+class TestInsertMethods:
     """Class for testing the data manager insert() method."""
-    def on_succeed_insert_failure_definition(self, node_id, tree):
+
+    def on_succeed_insert_sibling(self, node_id, tree):
         assert node_id == 3
         assert isinstance(tree, Tree)
-        assert isinstance(tree[3].data['failure_definition'],
-                          RAMSTKFailureDefinition)
-        print(
-            "\033[36m\nsucceed_insert_failure_definition topic was broadcast")
+        assert isinstance(tree[3].data["failure_definition"], RAMSTKFailureDefinition)
+        print("\033[36m\nsucceed_insert_failure_definition topic was broadcast")
 
     @pytest.mark.unit
-    def test_do_insert(self, mock_program_dao):
+    def test_do_insert_sibling(self, mock_program_dao):
         """do_insert() should send the success message after successfully
         inserting a new failure definition."""
-        pub.subscribe(self.on_succeed_insert_failure_definition,
-                      'succeed_insert_failure_definition')
+        pub.subscribe(
+            self.on_succeed_insert_sibling, "succeed_insert_failure_definition"
+        )
 
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
+        DUT.do_select_all(attributes={"revision_id": 1})
         DUT._do_insert_failure_definition()
 
         assert isinstance(
-            DUT.tree.get_node(1).data['failure_definition'],
-            RAMSTKFailureDefinition)
+            DUT.tree.get_node(1).data["failure_definition"], RAMSTKFailureDefinition
+        )
 
-        pub.unsubscribe(self.on_succeed_insert_failure_definition,
-                        'succeed_insert_failure_definition')
+        pub.unsubscribe(
+            self.on_succeed_insert_sibling, "succeed_insert_failure_definition"
+        )
 
 
-@pytest.mark.usefixtures('mock_program_dao')
-class TestUpdateMethods():
+class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
-    def on_fail_update_failure_definition_non_existent_id(self, error_message):
+
+    def on_fail_update_non_existent_id(self, error_message):
         assert error_message == (
-            'do_update: Attempted to save non-existent failure definition '
-            'with failure definition ID 100.')
+            "do_update: Attempted to save non-existent failure definition "
+            "with failure definition ID 100."
+        )
         print("\033[35m\nfail_update_failure_definition topic was broadcast")
 
-    def on_fail_update_failure_definition_no_data_package(self, error_message):
+    def on_fail_update_no_data_package(self, error_message):
         assert error_message == (
-            'do_update: No data package found for failure definition ID 1.')
+            "do_update: No data package found for failure definition ID 1."
+        )
         print("\033[35m\nfail_update_failure_definition topic was broadcast")
 
     @pytest.mark.unit
     def test_do_update_non_existent_id(self, mock_program_dao):
         """do_update_failure_definition() should broadcast the fail message
         when attempting to save a non-existent ID."""
-        pub.subscribe(self.on_fail_update_failure_definition_non_existent_id,
-                      'fail_update_failure_definition')
+        pub.subscribe(
+            self.on_fail_update_non_existent_id, "fail_update_failure_definition"
+        )
 
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
-        DUT.do_update(100)
+        DUT.do_select_all(attributes={"revision_id": 1})
+        DUT.do_update(100, table="failure_definitions")
 
-        pub.unsubscribe(self.on_fail_update_failure_definition_non_existent_id,
-                        'fail_update_failure_definition')
+        pub.unsubscribe(
+            self.on_fail_update_non_existent_id, "fail_update_failure_definition"
+        )
 
     @pytest.mark.unit
     def test_do_update_no_data_package(self, mock_program_dao):
         """do_update() should return a non-zero error code when passed a
         Function ID that has no data package."""
-        pub.subscribe(self.on_fail_update_failure_definition_no_data_package,
-                      'fail_update_failure_definition')
+        pub.subscribe(
+            self.on_fail_update_no_data_package, "fail_update_failure_definition"
+        )
 
         DUT = dmFailureDefinition()
         DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={'revision_id': 1})
-        DUT.tree.get_node(1).data.pop('failure_definition')
+        DUT.do_select_all(attributes={"revision_id": 1})
+        DUT.tree.get_node(1).data.pop("failure_definition")
 
-        DUT.do_update(1)
+        DUT.do_update(1, table="failure_definition")
 
-        pub.unsubscribe(self.on_fail_update_failure_definition_no_data_package,
-                        'fail_update_failure_definition')
+        pub.unsubscribe(
+            self.on_fail_update_no_data_package, "fail_update_failure_definition"
+        )


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.
  - [x] Followed in new code.
  - [x] Corrected in existing code whenever possible.
  - [x] Spelling and English grammar errors have been eliminated.
  - [x] Attribute and variable names make sense.
  - [x] Stub files created or updated.
  - [x] New code is readable.
  - [x] Execute 'make maintain' before committing changes and fix any issues.
  - [x] Code is not overly complicated; refactor if it is.
  - [x] Debugging, including print(), statements have been removed.

- Tests
  - [x] At least one test for all newly created functions/methods?
  - [x] Tests capture key use cases.
  - [x] Enough edge cases covered for comfort.
  - [x] Code coverage has not decreased.

- Documentation
  - [x] Update api documentation to reflect the changes made.
  - [x] Update the user documentation to reflect the changes made.

- Chores
  - [x] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [x] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [x] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [x] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [x] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
