### PR TITLE
test: cleanup mission phase test suite

### DIFF
--- a/tests/controllers/mission/mission_integration_test.py
+++ b/tests/controllers/mission/mission_integration_test.py
@@ -22,7 +22,6 @@ from ramstk.models.programdb import RAMSTKMission
 @pytest.fixture(scope="class")
 def test_datamanager(test_program_dao):
     """Get a data manager instance for each test class."""
-    """Get a data manager instance for each test function."""
     # Create the device under test (dut) and connect to the database.
     dut = dmMission()
     dut.do_connect(test_program_dao)
@@ -57,9 +56,8 @@ class TestSelectMethods:
 
     @pytest.mark.integration
     def test_do_select_all_populated_tree(self, test_datamanager):
-        """do_select_all() should return a Tree() object populated with
-        RAMSTKMission, RAMSTKMissionPhase, and RAMSTKMission instances on
-        success."""
+        """do_select_all() should clear out an existing tree and build a new
+        one when called on a populated Mission data manager."""
         pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_missions")
 
         test_datamanager.do_select_all(attributes={"revision_id": 1})
@@ -327,10 +325,10 @@ class TestGetterSetter:
     @pytest.mark.integration
     def test_do_set_attributes(self, test_datamanager):
         """do_set_attributes() should send the success message."""
-        pub.subscribe(self.on_succeed_set_attributes, "succeed_set_attributes")
+        pub.subscribe(self.on_succeed_set_attributes, "succeed_get_mission_tree")
 
         test_datamanager.do_set_attributes(
             node_id=[1, ""], package={"mission_time": 12.86}
         )
 
-        pub.unsubscribe(self.on_succeed_set_attributes, "succeed_set_attributes")
+        pub.unsubscribe(self.on_succeed_set_attributes, "succeed_get_mission_tree")

--- a/tests/controllers/mission/mission_unit_test.py
+++ b/tests/controllers/mission/mission_unit_test.py
@@ -50,7 +50,6 @@ def mock_program_dao(monkeypatch):
 
 @pytest.fixture(scope="function")
 def test_datamanager(mock_program_dao):
-    """Get a data manager instance for each test class."""
     """Get a data manager instance for each test function."""
     # Create the device under test (dut) and connect to the database.
     dut = dmMission()
@@ -110,8 +109,7 @@ class TestSelectMethods:
 
     @pytest.mark.unit
     def test_do_select_all(self, test_datamanager):
-        """do_select_all() should return a Tree() object when the tree is
-        already populated."""
+        """do_select_all() should return a Tree() object on success."""
         test_datamanager.do_select_all(attributes={"revision_id": 1})
 
         assert isinstance(test_datamanager.tree, Tree)
@@ -151,20 +149,6 @@ class TestSelectMethods:
 
 
 @pytest.mark.usefixtures("test_datamanager")
-class TestDeleteMethods:
-    """Class for testing the data manager delete() method."""
-
-    @pytest.mark.unit
-    def test_do_delete(self, test_datamanager):
-        """_do_delete_mission() should send the success message after
-        successfully deleting a mission."""
-        test_datamanager.do_select_all(attributes={"revision_id": 1})
-        test_datamanager._do_delete(1)
-
-        assert test_datamanager.tree.get_node(1) is None
-
-
-@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
 
@@ -179,3 +163,17 @@ class TestInsertMethods:
         assert isinstance(
             test_datamanager.tree.get_node(3).data["mission"], RAMSTKMission
         )
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
+
+    @pytest.mark.unit
+    def test_do_delete(self, test_datamanager):
+        """_do_delete_mission() should send the success message after
+        successfully deleting a mission."""
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+        test_datamanager._do_delete(1)
+
+        assert test_datamanager.tree.get_node(1) is None

--- a/tests/controllers/mission_phase/mission_phase_unit_test.py
+++ b/tests/controllers/mission_phase/mission_phase_unit_test.py
@@ -13,7 +13,7 @@
 import pytest
 
 # noinspection PyUnresolvedReferences
-from mocks import MockDAO
+from mocks import MockDAO, MockRAMSTKMissionPhase
 from pubsub import pub
 from treelib import Tree
 
@@ -25,7 +25,7 @@ from ramstk.models.programdb import RAMSTKMissionPhase
 
 @pytest.fixture
 def mock_program_dao(monkeypatch):
-    _mission_phase_1 = RAMSTKMissionPhase()
+    _mission_phase_1 = MockRAMSTKMissionPhase()
     _mission_phase_1.revision_id = 1
     _mission_phase_1.mission_id = 1
     _mission_phase_1.phase_id = 1
@@ -34,7 +34,7 @@ def mock_program_dao(monkeypatch):
     _mission_phase_1.phase_start = 0.0
     _mission_phase_1.phase_end = 0.0
 
-    _mission_phase_2 = RAMSTKMissionPhase()
+    _mission_phase_2 = MockRAMSTKMissionPhase()
     _mission_phase_2.revision_id = 1
     _mission_phase_2.mission_id = 1
     _mission_phase_2.phase_id = 2
@@ -43,7 +43,7 @@ def mock_program_dao(monkeypatch):
     _mission_phase_2.phase_start = 0.0
     _mission_phase_2.phase_end = 0.0
 
-    _mission_phase_3 = RAMSTKMissionPhase()
+    _mission_phase_3 = MockRAMSTKMissionPhase()
     _mission_phase_3.revision_id = 1
     _mission_phase_3.mission_id = 1
     _mission_phase_3.phase_id = 3
@@ -95,8 +95,12 @@ class TestSelectMethods:
 
     def on_succeed_select_all(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["mission_phase"], RAMSTKMissionPhase)
-        assert isinstance(tree.get_node(2).data["mission_phase"], RAMSTKMissionPhase)
+        assert isinstance(
+            tree.get_node(1).data["mission_phase"], MockRAMSTKMissionPhase
+        )
+        assert isinstance(
+            tree.get_node(2).data["mission_phase"], MockRAMSTKMissionPhase
+        )
         print("\033[36m\nsucceed_retrieve_mission_phases topic was broadcast.")
 
     @pytest.mark.unit
@@ -126,15 +130,14 @@ class TestSelectMethods:
 
     @pytest.mark.unit
     def test_do_select(self, mock_program_dao):
-        """do_select() should return the RAMSTKMission instance on
-        success."""
+        """do_select() should return the RAMSTKMission instance on success."""
         DUT = dmMissionPhase()
         DUT.do_connect(mock_program_dao)
         DUT.do_select_all(attributes={"revision_id": 1})
 
         _mission_phase = DUT.do_select(1, table="mission_phase")
 
-        assert isinstance(_mission_phase, RAMSTKMissionPhase)
+        assert isinstance(_mission_phase, MockRAMSTKMissionPhase)
         assert _mission_phase.phase_id == 1
 
     @pytest.mark.unit
@@ -194,8 +197,8 @@ class TestDeleteMethods:
 
     @pytest.mark.unit
     def test_do_delete_mission_phase_non_existent_id(self, mock_program_dao):
-        """_do_delete_mission_phase() should send the sfail message when attempting
-        to delete a non-existent mission phase ID."""
+        """_do_delete_mission_phase() should send the sfail message when
+        attempting to delete a non-existent mission phase ID."""
         pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_mission_phase")
 
         DUT = dmMissionPhase()
@@ -236,7 +239,9 @@ class TestGetterSetter:
 
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["mission_phase"], RAMSTKMissionPhase)
+        assert isinstance(
+            tree.get_node(1).data["mission_phase"], MockRAMSTKMissionPhase
+        )
         print("\033[36m\nsucceed_get_mission_phase_tree topic was broadcast")
 
     @pytest.mark.unit

--- a/tests/controllers/mission_phase/mission_phase_unit_test.py
+++ b/tests/controllers/mission_phase/mission_phase_unit_test.py
@@ -62,6 +62,30 @@ def mock_program_dao(monkeypatch):
     yield DAO
 
 
+@pytest.fixture(scope="function")
+def test_datamanager(mock_program_dao):
+    """Get a data manager instance for each test class."""
+    """Get a data manager instance for each test function."""
+    # Create the device under test (dut) and connect to the database.
+    dut = dmMissionPhase()
+    dut.do_connect(mock_program_dao)
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_mission_phase_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_mission_phase_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "lvw_editing_mission_phase")
+    pub.unsubscribe(dut.do_update, "request_update_mission_phase")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_get_tree, "request_get_mission_phase_tree")
+    pub.unsubscribe(dut._do_delete, "request_delete_mission_phase")
+    pub.unsubscribe(dut._do_insert_mission_phase, "request_insert_mission_phase")
+
+    # Delete the device under test.
+    del dut
+
+
 class TestCreateControllers:
     """Class for controller initialization test suite."""
 
@@ -88,274 +112,89 @@ class TestCreateControllers:
             DUT._do_insert_mission_phase, "request_insert_mission_phase"
         )
 
+        pub.unsubscribe(DUT.do_get_attributes, "request_get_mission_phase_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "request_set_mission_phase_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "lvw_editing_mission_phase")
+        pub.unsubscribe(DUT.do_update, "request_update_mission_phase")
+        pub.unsubscribe(DUT.do_select_all, "selected_revision")
+        pub.unsubscribe(DUT.do_get_tree, "request_get_mission_phase_tree")
+        pub.unsubscribe(DUT._do_delete, "request_delete_mission_phase")
+        pub.unsubscribe(DUT._do_insert_mission_phase, "request_insert_mission_phase")
 
-@pytest.mark.usefixtures("mock_program_dao")
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestSelectMethods:
     """Class for testing data manager select_all() and select() methods."""
 
-    def on_succeed_select_all(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(
-            tree.get_node(1).data["mission_phase"], MockRAMSTKMissionPhase
-        )
-        assert isinstance(
-            tree.get_node(2).data["mission_phase"], MockRAMSTKMissionPhase
-        )
-        print("\033[36m\nsucceed_retrieve_mission_phases topic was broadcast.")
-
     @pytest.mark.unit
-    def test_do_select_all(self, mock_program_dao):
+    def test_do_select_all(self, test_datamanager):
         """do_select_all() should return a Tree() object populated with
         RAMSTKMissionPhase instances on success."""
-        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_mission_phases")
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_mission_phases")
-
-    @pytest.mark.unit
-    def test_do_select_all_populated_tree(self, mock_program_dao):
-        """do_select_all() should return a Tree() object when the tree is
-        already populated."""
-        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_mission_phases")
-
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_mission_phases")
+        assert isinstance(test_datamanager.tree, Tree)
+        assert isinstance(
+            test_datamanager.tree.get_node(1).data["mission_phase"],
+            MockRAMSTKMissionPhase,
+        )
+        assert isinstance(
+            test_datamanager.tree.get_node(2).data["mission_phase"],
+            MockRAMSTKMissionPhase,
+        )
 
     @pytest.mark.unit
-    def test_do_select(self, mock_program_dao):
+    def test_do_select(self, test_datamanager):
         """do_select() should return the RAMSTKMission instance on success."""
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
-        _mission_phase = DUT.do_select(1, table="mission_phase")
+        _mission_phase = test_datamanager.do_select(1, table="mission_phase")
 
         assert isinstance(_mission_phase, MockRAMSTKMissionPhase)
         assert _mission_phase.phase_id == 1
 
     @pytest.mark.unit
-    def test_do_select_unknown_table(self, mock_program_dao):
+    def test_do_select_unknown_table(self, test_datamanager):
         """do_select() should raise a KeyError when an unknown table name is
         requested."""
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
         with pytest.raises(KeyError):
-            DUT.do_select(1, table="scibbidy-bibbidy-doo")
+            test_datamanager.do_select(1, table="scibbidy-bibbidy-doo")
 
     @pytest.mark.unit
-    def test_do_select_non_existent_id(self, mock_program_dao):
+    def test_do_select_non_existent_id(self, test_datamanager):
         """do_select() should return None when a non-existent Revision ID is
         requested."""
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
-        assert DUT.do_select(100, table="mission_phase") is None
+        assert test_datamanager.do_select(100, table="mission_phase") is None
 
 
-@pytest.mark.usefixtures("mock_program_dao")
-class TestDeleteMethods:
-    """Class for testing the data manager delete() method."""
-
-    def on_succeed_delete(self, tree):
-        assert isinstance(tree, Tree)
-        print("\033[36m\nsucceed_delete_mission_phase topic was broadcast.")
-
-    def on_fail_delete_non_existent_id(self, error_message):
-        assert error_message == (
-            "_do_delete: Attempted to delete non-existent mission phase ID " "10."
-        )
-        print("\033[35m\nfail_delete_mission_phase topic was broadcast.")
-
-    def on_fail_delete_not_in_tree(self, error_message):
-        assert error_message == (
-            "_do_delete: Attempted to delete non-existent mission phase ID 2."
-        )
-        print("\033[35m\nfail_delete_mission_phase topic was broadcast.")
-
-    @pytest.mark.unit
-    def test_do_delete(self, mock_program_dao):
-        """_do_delete_mission_phase() should send the success message after
-        successfully deleting a mission phase."""
-        pub.subscribe(self.on_succeed_delete, "succeed_delete_mission_phase")
-
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_delete(1)
-
-        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_mission_phase")
-
-    @pytest.mark.unit
-    def test_do_delete_mission_phase_non_existent_id(self, mock_program_dao):
-        """_do_delete_mission_phase() should send the sfail message when
-        attempting to delete a non-existent mission phase ID."""
-        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_mission_phase")
-
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_delete(10)
-
-        pub.unsubscribe(
-            self.on_fail_delete_non_existent_id, "fail_delete_mission_phase"
-        )
-
-    @pytest.mark.unit
-    def test_do_delete_not_in_tree(self, mock_program_dao):
-        """_do_delete() should send the fail message when attempting to remove
-        a node that doesn't exist from the tree even if it exists in the
-        database."""
-        pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_mission_phase")
-
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.tree.remove_node(2)
-        DUT._do_delete(2)
-
-        pub.unsubscribe(self.on_fail_delete_not_in_tree, "fail_delete_mission_phase")
-
-
-@pytest.mark.usefixtures("mock_program_dao")
-class TestGetterSetter:
-    """Class for testing methods that get or set."""
-
-    def on_succeed_get_attributes(self, attributes):
-        assert isinstance(attributes, dict)
-        assert attributes["mission_id"] == 1
-        assert attributes["phase_id"] == 1
-        assert attributes["description"] == "Phase #1 for mission #1"
-        print("\033[36m\nsucceed_get_mission_phase_attributes topic was broadcast")
-
-    def on_succeed_get_data_manager_tree(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(
-            tree.get_node(1).data["mission_phase"], MockRAMSTKMissionPhase
-        )
-        print("\033[36m\nsucceed_get_mission_phase_tree topic was broadcast")
-
-    @pytest.mark.unit
-    def test_do_get_attributes(self, mock_program_dao):
-        """_do_get_attributes() should return treelib Tree() on success."""
-        pub.subscribe(
-            self.on_succeed_get_attributes, "succeed_get_mission_phase_attributes"
-        )
-
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_get_attributes(1, "mission_phase")
-
-        pub.unsubscribe(
-            self.on_succeed_get_attributes, "succeed_get_mission_phase_attributes"
-        )
-
-    @pytest.mark.unit
-    def test_do_set_attributes(self, mock_program_dao):
-        """do_set_attributes() should send the success message."""
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        DUT.do_set_attributes(node_id=[1, ""], package={"phase_start": 12.86})
-
-        assert DUT.do_select(1, table="mission_phase").phase_start == 12.86
-
-    @pytest.mark.unit
-    def test_on_get_tree(self, mock_program_dao):
-        """on_get_tree() should return the revision treelib Tree."""
-        pub.subscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_mission_phase_tree"
-        )
-
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_get_tree()
-
-        pub.unsubscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_mission_phase_tree"
-        )
-
-
-@pytest.mark.usefixtures("mock_program_dao")
+@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
 
-    def on_succeed_insert_sibling(self, node_id, tree):
-        assert node_id == 4
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(4).data["mission_phase"], RAMSTKMissionPhase)
-        print("\033[36m\nsucceed_insert_mission_phase topic was broadcast")
-
     @pytest.mark.unit
-    def test_do_insert_sibling(self, mock_program_dao):
+    def test_do_insert_sibling(self, test_datamanager):
         """do_insert() should send the success message after successfully
-        inserting a new mission_phase."""
-        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_mission_phase")
+        inserting a new mission."""
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+        test_datamanager._do_insert_mission_phase(mission_id=1)
 
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_insert_mission_phase(1)
-
-        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_mission_phase")
-
-
-@pytest.mark.usefixtures("mock_program_dao")
-class TestUpdateMethods:
-    """Class for testing update() and update_all() methods."""
-
-    def on_fail_update_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_update: Attempted to save non-existent mission phase with "
-            "mission phase ID 10."
+        assert isinstance(test_datamanager.tree, Tree)
+        assert isinstance(
+            test_datamanager.tree.get_node(4).data["mission_phase"], RAMSTKMissionPhase
         )
-        print("\033[35m\nfail_update_mission_phase topic was broadcast")
 
-    def on_fail_update_no_data_package(self, error_message):
-        assert error_message == (
-            "do_update: No data package found for mission phase ID 1."
-        )
-        print("\033[35m\nfail_update_mission_phase topic was broadcast")
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
 
     @pytest.mark.unit
-    def test_do_update_non_existent_id(self, mock_program_dao):
-        """do_update_usage_profile() should broadcast the fail message when
-        attempting to save a non-existent ID."""
-        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_mission_phase")
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should remove the passed mission phase ID."""
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+        test_datamanager._do_delete(1)
 
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_update(10, table="mission_phase")
-
-        pub.unsubscribe(
-            self.on_fail_update_non_existent_id, "fail_update_mission_phase"
-        )
-
-    @pytest.mark.unit
-    def test_do_update_no_data_package(self, mock_program_dao):
-        """do_update_usage_profile() should broadcast the fail message when
-        attempting to save a non-existent ID."""
-        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_mission_phase")
-
-        DUT = dmMissionPhase()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.tree.get_node(1).data.pop("mission_phase")
-        DUT.do_update(1, table="mission_phase")
-
-        pub.unsubscribe(
-            self.on_fail_update_no_data_package, "fail_update_mission_phase"
-        )
+        assert test_datamanager.tree.get_node(1) is None

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -20,5 +20,6 @@ from .mock_ramstkfunction import MockRAMSTKFunction
 from .mock_ramstkhazardanalysis import MockRAMSTKHazardAnalysis
 from .mock_ramstkmechanism import MockRAMSTKMechanism
 from .mock_ramstkmission import MockRAMSTKMission
+from .mock_ramstkmissionphase import MockRAMSTKMissionPhase
 from .mock_ramstkrevision import MockRAMSTKRevision
 from .MockDAO import MockDAO

--- a/tests/mocks/mock_ramstkmissionphase.py
+++ b/tests/mocks/mock_ramstkmissionphase.py
@@ -1,0 +1,31 @@
+# RAMSTK Local Imports
+from . import MockRAMSTKBaseTable
+
+
+class MockRAMSTKMissionPhase(MockRAMSTKBaseTable):
+    __defaults__ = {"description": "", "name": "", "phase_start": 0.0, "phase_end": 0.0}
+
+    def __init__(self):
+        self.revision_id = 0
+        self.mission_id = 0
+        self.phase_id = 0
+        self.description = self.__defaults__["description"]
+        self.name = self.__defaults__["name"]
+        self.phase_start = self.__defaults__["phase_start"]
+        self.phase_end = self.__defaults__["phase_end"]
+
+        self.is_mission = False
+        self.is_phase = True
+        self.is_env = False
+
+    def get_attributes(self):
+        _attributes = {
+            "mission_id": self.mission_id,
+            "phase_id": self.phase_id,
+            "description": self.description,
+            "name": self.name,
+            "phase_start": self.phase_start,
+            "phase_end": self.phase_end,
+        }
+
+        return _attributes


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.
  - [ ] Followed in new code.
  - [ ] Corrected in existing code whenever possible.
  - [ ] Spelling and English grammar errors have been eliminated.
  - [ ] Attribute and variable names make sense.
  - [ ] Stub files created or updated.
  - [ ] New code is readable.
  - [ ] Execute 'make maintain' before committing changes and fix any issues.
  - [ ] Code is not overly complicated; refactor if it is.
  - [ ] Debugging, including print(), statements have been removed.

- Tests
  - [ ] At least one test for all newly created functions/methods?
  - [ ] Tests capture key use cases.
  - [ ] Enough edge cases covered for comfort.
  - [ ] Code coverage has not decreased.

- Documentation
  - [ ] Update api documentation to reflect the changes made.
  - [ ] Update the user documentation to reflect the changes made.

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [ ] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [ ] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [ ] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [ ] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
