### PR TITLE
test: cleanup mode test suite

### DIFF
--- a/tests/controllers/mission_phase/mission_phase_integration_test.py
+++ b/tests/controllers/mission_phase/mission_phase_integration_test.py
@@ -137,12 +137,11 @@ class TestDeleteMethods:
         pub.unsubscribe(self.on_succeed_delete, "succeed_delete_mission_phase")
 
     @pytest.mark.integration
-    def test_do_delete_mission_phase_non_existent_id(self, test_datamanager):
+    def test_do_delete_non_existent_id(self, test_datamanager):
         """_do_delete_mission_phase() should send the fail message when
         attempting to delete a non-existent mission phase ID."""
         pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_mission_phase")
 
-        test_datamanager.do_select_all(attributes={"revision_id": 1})
         test_datamanager._do_delete(10)
 
         pub.unsubscribe(
@@ -156,7 +155,6 @@ class TestDeleteMethods:
         database."""
         pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_mission_phase")
 
-        test_datamanager.do_select_all(attributes={"revision_id": 1})
         test_datamanager.tree.remove_node(2)
         test_datamanager._do_delete(2)
 
@@ -195,7 +193,7 @@ class TestUpdateMethods:
 
     def on_fail_update_no_data_package(self, error_message):
         assert error_message == (
-            "do_update: No data package found for mission phase " "ID 1."
+            "do_update: No data package found for mission phase ID 1."
         )
         print("\033[35m\nfail_update_mission_phase topic was broadcast")
 

--- a/tests/controllers/mode/mode_integration_test.py
+++ b/tests/controllers/mode/mode_integration_test.py
@@ -15,6 +15,7 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.controllers import dmMode
+from ramstk.models.programdb import RAMSTKMode
 
 
 @pytest.fixture(scope="class")
@@ -42,16 +43,36 @@ def test_datamanager(test_program_dao):
 
 
 @pytest.mark.usefixtures("test_datamanager")
+class TestSelectMethods:
+    """Class for testing data manager select_all() and select() methods."""
+
+    def on_succeed_select_all(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data["mode"], MockRAMSTKMode)
+        print("\033[36m\nsucceed_retrieve_mode topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_select_all_populated_tree(self, test_datamanager):
+        """do_select_all() should clear out an existing tree and build a new
+        one when called on a populated Mission Phase data manager."""
+        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_mission_phases")
+
+        test_datamanager.do_select_all({"revision_id": 1, "hardware_id": 1})
+
+        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_mission_phases")
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
 
-    def on_fail_insert_no_parent(self, error_message):
-        assert error_message == (
-            "do_insert: Database error when attempting to add a record.  Database "
-            "returned:\n\tKey (fld_revision_id, fld_hardware_id)=(1, 100) is not "
-            'present in table "ramstk_hardware".'
-        )
-        print("\033[35m\nfail_insert_mechanism topic was broadcast.")
+    def on_succeed_insert_sibling(self, node_id, tree):
+        assert node_id == 3
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(3).data["mode"], RAMSTKMode)
+        assert tree.get_node(3).data["mode"].mode_id == 3
+        assert tree.get_node(3).data["mode"].description is None
+        print("\033[36m\nsucceed_insert_mode topic was broadcast.")
 
     def on_fail_insert_no_revision(self, error_message):
         assert error_message == (
@@ -60,7 +81,26 @@ class TestInsertMethods:
             "fld_hardware_id)=(4, 100) is not present in table "
             '"ramstk_hardware".'
         )
-        print("\033[35m\nfail_insert_opstress topic was broadcast.")
+        print("\033[35m\nfail_insert_mode topic was broadcast.")
+
+    def on_fail_insert_no_parent(self, error_message):
+        assert error_message == (
+            "do_insert: Database error when attempting to add a record.  Database "
+            "returned:\n\tKey (fld_revision_id, fld_hardware_id)=(1, 100) is not "
+            'present in table "ramstk_hardware".'
+        )
+        print("\033[35m\nfail_insert_mode topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_insert_sibling(self, test_datamanager):
+        """do_insert() should send the success message with the ID of the newly
+        inserted node and the data manager's tree after successfully inserting
+        a new mission."""
+        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_mission_phase")
+
+        pub.sendMessage("request_insert_mode")
+
+        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_mission_phase")
 
     @pytest.mark.integration
     def test_do_insert_no_parent(self, test_datamanager):
@@ -86,6 +126,60 @@ class TestInsertMethods:
 
 
 @pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
+
+    def on_succeed_delete(self, tree):
+        assert isinstance(tree, Tree)
+        assert tree.get_node(4) is None
+        print("\033[36m\nsucceed_delete_mode topic was broadcast.")
+
+    def on_fail_delete_non_existent_id(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent mode ID 300."
+        )
+        print("\033[35m\nfail_delete_mode topic was broadcast.")
+
+    def on_fail_delete_not_in_tree(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent mode ID 5."
+        )
+        print("\033[35m\nfail_delete_mode topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should send the success message with the treelib Tree
+        when successfully deleting a test method."""
+        pub.subscribe(self.on_succeed_delete, "succeed_delete_mode")
+
+        test_datamanager._do_delete(4)
+
+        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_mode")
+
+    @pytest.mark.integration
+    def test_do_delete_non_existent_id(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to delete
+        a node ID that doesn't exist in the tree."""
+        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_mode")
+
+        test_datamanager._do_delete(300)
+
+        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_mode")
+
+    @pytest.mark.integration
+    def test_do_delete_not_in_tree(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to remove
+        a node that doesn't exist from the tree even if it exists in the
+        database."""
+        pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_mode")
+
+        test_datamanager.tree.remove_node(5)
+        test_datamanager._do_delete(5)
+
+        pub.unsubscribe(self.on_fail_delete_not_in_tree, "fail_delete_mode")
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
@@ -97,12 +191,32 @@ class TestUpdateMethods:
         )
         print("\033[36m\nsucceed_update_mode topic was broadcast")
 
+    def on_succeed_update_all(self):
+        print("\033[36m\nsucceed_update_all topic was broadcast")
+
     def on_fail_update_wrong_data_type(self, error_message):
         assert error_message == (
             "do_update: The value for one or more attributes for mode ID 4 was the "
             "wrong type."
         )
         print("\033[35m\nfail_update_mode topic was broadcast")
+
+    def on_fail_update_root_node_wrong_data_type(self, error_message):
+        assert error_message == ("do_update: Attempting to update the root node 0.")
+        print("\033[35m\nfail_update_mission_phase topic was broadcast")
+
+    def on_fail_update_non_existent_id(self, error_message):
+        assert error_message == (
+            "do_update: Attempted to save non-existent mission phase with mission "
+            "phase ID 10."
+        )
+        print("\033[35m\nfail_update_mission_phase topic was broadcast")
+
+    def on_fail_update_no_data_package(self, error_message):
+        assert error_message == (
+            "do_update: No data package found for mission phase " "ID 1."
+        )
+        print("\033[35m\nfail_update_mission_phase topic was broadcast")
 
     @pytest.mark.integration
     def test_do_update(self, test_datamanager):
@@ -113,14 +227,19 @@ class TestUpdateMethods:
         test_datamanager.tree.get_node(4).data[
             "mode"
         ].operator_actions = "Take evasive actions."
-        test_datamanager.do_update(4, table="mode")
+
+        pub.sendMessage("request_update_mode", node_id=4, table="mode")
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_mode")
 
     @pytest.mark.integration
     def test_do_update_all(self, test_datamanager):
         """do_update_all() should broadcast the succeed message on success."""
+        pub.subscribe(self.on_succeed_update_all, "succeed_update_all")
+
         pub.sendMessage("request_update_all_modes")
+
+        pub.unsubscribe(self.on_succeed_update_all, "succeed_update_all")
 
     @pytest.mark.integration
     def test_do_update_wrong_data_type(self, test_datamanager):
@@ -131,15 +250,98 @@ class TestUpdateMethods:
         _mode = test_datamanager.do_select(4, table="mode")
         _mode.mode_criticality = {1: 2}
 
-        test_datamanager.do_update(4, table="mode")
+        pub.sendMessage("request_update_mode", node_id=4, table="mode")
 
         pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_mode")
 
     @pytest.mark.integration
-    def test_do_update_root_node(self, test_datamanager):
+    def test_do_update_root_node_wrong_data_type(self, test_datamanager):
         """do_update() should return a non-zero error code when passed a
         Requirement ID that doesn't exist."""
+        pub.subscribe(self.on_fail_update_root_node_wrong_data_type, "fail_update_mode")
+
         _mode = test_datamanager.do_select(4, table="mode")
         _mode.mode_criticality = {1: 2}
 
-        test_datamanager.do_update(0, table="mode")
+        pub.sendMessage("request_update_mode", node_id=0, table="mode")
+
+        pub.unsubscribe(
+            self.on_fail_update_root_node_wrong_data_type, "fail_update_mode"
+        )
+
+    @pytest.mark.integration
+    def test_do_update_non_existent_id(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a PoF ID
+        that doesn't exist."""
+        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_mode")
+
+        pub.sendMessage("request_update_mission_phase", node_id=100, table="mode")
+
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_mode")
+
+    @pytest.mark.integration
+    def test_do_update_no_data_package(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a FMEA
+        ID that has no data package."""
+        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_mode")
+
+        test_datamanager.tree.get_node(4).data.pop("mode")
+        pub.sendMessage("request_update_mission_phase", node_id=4, table="mode")
+
+        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_mode")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestGetterSetter:
+    """Class for testing methods that get or set."""
+
+    def on_succeed_get_attributes(self, attributes):
+        assert isinstance(attributes, dict)
+        assert attributes["mode_id"] == 2
+        assert attributes["description"] == "Test Failure Mode #2"
+        print("\033[36m\nsucceed_get_mode_attributes topic was broadcast.")
+
+    def on_succeed_get_data_manager_tree(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(4).data["mode"], RAMSTKMode)
+        assert isinstance(tree.get_node(5).data["mode"], RAMSTKMode)
+        assert isinstance(tree.get_node(6).data["mode"], RAMSTKMode)
+        print("\033[36m\nsucceed_get_mode_tree topic was broadcast")
+
+    def on_succeed_set_attributes(self, tree):
+        assert isinstance(tree, Tree)
+        assert tree.get_node(4).data["mode"].description == "Jared Kushner"
+        print("\033[36m\nsucceed_get_mode_tree topic was broadcast")
+
+    @pytest.mark.integration
+    def test_do_get_attributes(self, test_datamanager):
+        """do_get_attributes() should return a dict of mode attributes on
+        success."""
+        pub.subscribe(self.on_succeed_get_attributes, "succeed_get_mode_attributes")
+
+        pub.sendMessage("request_get_mode_attributes", node_id=2, table="mode")
+
+        pub.unsubscribe(self.on_succeed_get_attributes, "succeed_get_mode_attributes")
+
+    @pytest.mark.integration
+    def test_on_get_data_manager_tree(self, test_datamanager):
+        """on_get_tree() should return the PoF treelib Tree."""
+        pub.subscribe(self.on_succeed_get_data_manager_tree, "succeed_get_mode_tree")
+
+        pub.sendMessage("request_get_mode_tree")
+
+        pub.unsubscribe(self.on_succeed_get_data_manager_tree, "succeed_get_mode_tree")
+
+    @pytest.mark.integration
+    def test_do_set_attributes(self, test_datamanager):
+        """do_set_attributes() should return None when successfully setting
+        operating load attributes."""
+        pub.subscribe(self.on_succeed_set_attributes, "succeed_get_mode_tree")
+
+        pub.sendMessage(
+            "request_set_mode_attributes",
+            node_id=[4, ""],
+            package={"description": "Jared Kushner"},
+        )
+
+        pub.unsubscribe(self.on_succeed_set_attributes, "succeed_get_mode_tree")

--- a/tests/controllers/mode/mode_integration_test.py
+++ b/tests/controllers/mode/mode_integration_test.py
@@ -17,7 +17,31 @@ from treelib import Tree
 from ramstk.controllers import dmMode
 
 
-@pytest.mark.usefixtures("test_program_dao")
+@pytest.fixture(scope="class")
+def test_datamanager(test_program_dao):
+    """Get a data manager instance for each test class."""
+    # Create the device under test (dut) and connect to the database.
+    dut = dmMode()
+    dut.do_connect(test_program_dao)
+    dut.do_select_all(attributes={"revision_id": 1, "hardware_id": 1})
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_mode_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_mode_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_mode")
+    pub.unsubscribe(dut.do_update, "request_update_mode")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_get_tree, "request_get_mode_tree")
+    pub.unsubscribe(dut._do_delete, "request_delete_mode")
+    pub.unsubscribe(dut._do_insert_mode, "request_insert_mode")
+
+    # Delete the device under test.
+    del dut
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
 
@@ -33,41 +57,35 @@ class TestInsertMethods:
         assert error_message == (
             "do_insert: Database error when attempting to add a "
             "record.  Database returned:\n\tKey (fld_revision_id, "
-            "fld_hardware_id)=(4, 1) is not present in table "
+            "fld_hardware_id)=(4, 100) is not present in table "
             '"ramstk_hardware".'
         )
         print("\033[35m\nfail_insert_opstress topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_insert_no_parent(self, test_program_dao):
+    def test_do_insert_no_parent(self, test_datamanager):
         """_do_insert_mechanism() should send the fail message if attempting to
         add an operating load to a non-existent mechanism ID."""
         pub.subscribe(self.on_fail_insert_no_parent, "fail_insert_mode")
 
-        DUT = dmMode()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all({"revision_id": 1, "hardware_id": 1})
-        DUT._parent_id = 100
-        DUT._do_insert_mode()
+        test_datamanager._parent_id = 100
+        test_datamanager._do_insert_mode()
 
         pub.unsubscribe(self.on_fail_insert_no_parent, "fail_insert_mode")
 
     @pytest.mark.integration
-    def test_do_insert_no_revision(self, test_program_dao):
+    def test_do_insert_no_revision(self, test_datamanager):
         """_do_insert_mode() should send the fail message if attempting to add
         a mode to a non-existent Revision ID."""
         pub.subscribe(self.on_fail_insert_no_revision, "fail_insert_mode")
 
-        DUT = dmMode()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all({"revision_id": 1, "hardware_id": 1})
-        DUT._revision_id = 4
-        DUT._do_insert_mode()
+        test_datamanager._revision_id = 4
+        test_datamanager._do_insert_mode()
 
         pub.unsubscribe(self.on_fail_insert_no_revision, "fail_insert_mode")
 
 
-@pytest.mark.usefixtures("test_program_dao")
+@pytest.mark.usefixtures("test_datamanager")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
@@ -87,55 +105,41 @@ class TestUpdateMethods:
         print("\033[35m\nfail_update_mode topic was broadcast")
 
     @pytest.mark.integration
-    def test_do_update(self, test_program_dao):
+    def test_do_update(self, test_datamanager):
         """do_update() should return a zero error code on success."""
         pub.subscribe(self.on_succeed_update, "succeed_update_mode")
 
-        DUT = dmMode()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all({"revision_id": 1, "hardware_id": 1})
-
-        DUT.tree.get_node(4).data["mode"].description = "Test failure mode"
-        DUT.tree.get_node(4).data["mode"].operator_actions = "Take evasive actions."
-        DUT.do_update(4, table="mode")
+        test_datamanager.tree.get_node(4).data["mode"].description = "Test failure mode"
+        test_datamanager.tree.get_node(4).data[
+            "mode"
+        ].operator_actions = "Take evasive actions."
+        test_datamanager.do_update(4, table="mode")
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_mode")
 
     @pytest.mark.integration
-    def test_do_update_all(self, test_program_dao):
+    def test_do_update_all(self, test_datamanager):
         """do_update_all() should broadcast the succeed message on success."""
-        DUT = dmMode()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all({"revision_id": 1, "hardware_id": 1})
-
         pub.sendMessage("request_update_all_modes")
 
     @pytest.mark.integration
-    def test_do_update_wrong_data_type(self, test_program_dao):
+    def test_do_update_wrong_data_type(self, test_datamanager):
         """do_update() should return a non-zero error code when passed a
         Requirement ID that doesn't exist."""
         pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_mode")
 
-        DUT = dmMode()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all({"revision_id": 1, "hardware_id": 1})
-
-        _mode = DUT.do_select(4, table="mode")
+        _mode = test_datamanager.do_select(4, table="mode")
         _mode.mode_criticality = {1: 2}
 
-        DUT.do_update(4, table="mode")
+        test_datamanager.do_update(4, table="mode")
 
         pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_mode")
 
     @pytest.mark.integration
-    def test_do_update_root_node(self, test_program_dao):
+    def test_do_update_root_node(self, test_datamanager):
         """do_update() should return a non-zero error code when passed a
         Requirement ID that doesn't exist."""
-        DUT = dmMode()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all({"revision_id": 1, "hardware_id": 1})
-
-        _mode = DUT.do_select(4, table="mode")
+        _mode = test_datamanager.do_select(4, table="mode")
         _mode.mode_criticality = {1: 2}
 
-        DUT.do_update(0, table="mode")
+        test_datamanager.do_update(0, table="mode")

--- a/tests/controllers/mode/mode_unit_test.py
+++ b/tests/controllers/mode/mode_unit_test.py
@@ -12,7 +12,7 @@
 import pytest
 
 # noinspection PyUnresolvedReferences
-from mocks import MockDAO
+from mocks import MockDAO, MockRAMSTKMode
 from pubsub import pub
 from treelib import Tree
 
@@ -24,7 +24,7 @@ from ramstk.models.programdb import RAMSTKMode
 
 @pytest.fixture
 def mock_program_dao(monkeypatch):
-    _mode_1 = RAMSTKMode()
+    _mode_1 = MockRAMSTKMode()
     _mode_1.revision_id = 1
     _mode_1.hardware_id = 1
     _mode_1.mode_id = 1
@@ -54,7 +54,7 @@ def mock_program_dao(monkeypatch):
     _mode_1.mode_op_time = 0.0
     _mode_1.effect_probability = 0.8
 
-    _mode_2 = RAMSTKMode()
+    _mode_2 = MockRAMSTKMode()
     _mode_2.revision_id = 1
     _mode_2.hardware_id = 1
     _mode_2.mode_id = 2
@@ -124,7 +124,7 @@ class TestSelectMethods:
 
     def on_succeed_select_all(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["mode"], RAMSTKMode)
+        assert isinstance(tree.get_node(1).data["mode"], MockRAMSTKMode)
         print("\033[36m\nsucceed_retrieve_mode topic was broadcast.")
 
     @pytest.mark.unit
@@ -164,7 +164,7 @@ class TestSelectMethods:
 
         _mode = DUT.do_select(1, table="mode")
 
-        assert isinstance(_mode, RAMSTKMode)
+        assert isinstance(_mode, MockRAMSTKMode)
         assert _mode.effect_probability == 0.8
         assert _mode.description == "Test Failure Mode #1"
 
@@ -266,8 +266,8 @@ class TestGetterSetter:
 
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["mode"], RAMSTKMode)
-        assert isinstance(tree.get_node(2).data["mode"], RAMSTKMode)
+        assert isinstance(tree.get_node(1).data["mode"], MockRAMSTKMode)
+        assert isinstance(tree.get_node(2).data["mode"], MockRAMSTKMode)
         print("\033[36m\nsucceed_get_mode_tree topic was broadcast")
 
     @pytest.mark.unit

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -21,5 +21,6 @@ from .mock_ramstkhazardanalysis import MockRAMSTKHazardAnalysis
 from .mock_ramstkmechanism import MockRAMSTKMechanism
 from .mock_ramstkmission import MockRAMSTKMission
 from .mock_ramstkmissionphase import MockRAMSTKMissionPhase
+from .mock_ramstkmode import MockRAMSTKMode
 from .mock_ramstkrevision import MockRAMSTKRevision
 from .MockDAO import MockDAO

--- a/tests/mocks/mock_ramstkmode.py
+++ b/tests/mocks/mock_ramstkmode.py
@@ -1,0 +1,105 @@
+# RAMSTK Local Imports
+from . import MockRAMSTKBaseTable
+
+
+class MockRAMSTKMode(MockRAMSTKBaseTable):
+    __defaults__ = {
+        "critical_item": 0,
+        "description": "",
+        "design_provisions": "",
+        "detection_method": "",
+        "effect_end": "",
+        "effect_local": "",
+        "effect_next": "",
+        "effect_probability": 0.0,
+        "hazard_rate_source": "",
+        "isolation_method": "",
+        "mission": "Default Mission",
+        "mission_phase": "",
+        "mode_criticality": 0.0,
+        "mode_hazard_rate": 0.0,
+        "mode_op_time": 0.0,
+        "mode_probability": "",
+        "mode_ratio": 0.0,
+        "operator_actions": "",
+        "other_indications": "",
+        "remarks": "",
+        "rpn_severity": 1,
+        "rpn_severity_new": 1,
+        "severity_class": "",
+        "single_point": 0,
+        "type_id": 0,
+    }
+
+    def __init__(self):
+        self.revision_id = 0
+        self.hardware_id = 0
+        self.mode_id = 0
+        self.critical_item = self.__defaults__["critical_item"]
+        self.description = self.__defaults__["description"]
+        self.design_provisions = self.__defaults__["design_provisions"]
+        self.detection_method = self.__defaults__["detection_method"]
+        self.effect_end = self.__defaults__["effect_end"]
+        self.effect_local = self.__defaults__["effect_local"]
+        self.effect_next = self.__defaults__["effect_next"]
+        self.effect_probability = self.__defaults__["effect_probability"]
+        self.hazard_rate_source = self.__defaults__["hazard_rate_source"]
+        self.isolation_method = self.__defaults__["isolation_method"]
+        self.mission = self.__defaults__["mission"]
+        self.mission_phase = self.__defaults__["mission_phase"]
+        self.mode_criticality = self.__defaults__["mode_criticality"]
+        self.mode_hazard_rate = self.__defaults__["mode_hazard_rate"]
+        self.mode_op_time = self.__defaults__["mode_op_time"]
+        self.mode_probability = self.__defaults__["mode_probability"]
+        self.mode_ratio = self.__defaults__["mode_ratio"]
+        self.operator_actions = self.__defaults__["operator_actions"]
+        self.other_indications = self.__defaults__["other_indications"]
+        self.remarks = self.__defaults__["remarks"]
+        self.rpn_severity = self.__defaults__["rpn_severity"]
+        self.rpn_severity_new = self.__defaults__["rpn_severity_new"]
+        self.severity_class = self.__defaults__["severity_class"]
+        self.single_point = self.__defaults__["single_point"]
+        self.type_id = self.__defaults__["type_id"]
+
+        self.is_mode = True
+        self.is_mechanism = False
+        self.is_cause = False
+        self.is_control = False
+        self.is_action = False
+        self.is_opload = False
+        self.is_opstress = False
+        self.is_testmethod = False
+
+    def get_attributes(self):
+        _attributes = {
+            "revision_id": self.revision_id,
+            "hardware_id": self.hardware_id,
+            "mode_id": self.mode_id,
+            "critical_item": self.critical_item,
+            "description": self.description,
+            "design_provisions": self.design_provisions,
+            "detection_method": self.detection_method,
+            "effect_end": self.effect_end,
+            "effect_local": self.effect_local,
+            "effect_next": self.effect_next,
+            "effect_probability": self.effect_probability,
+            "hazard_rate_source": self.hazard_rate_source,
+            "isolation_method": self.isolation_method,
+            "mission": self.mission,
+            "mission_phase": self.mission_phase,
+            "mode_criticality": self.mode_criticality,
+            "mode_hazard_rate": self.mode_hazard_rate,
+            "mode_op_time": self.mode_op_time,
+            "mode_probability": self.mode_probability,
+            "mode_ratio": self.mode_ratio,
+            "operator_actions": self.operator_actions,
+            "other_indications": self.other_indications,
+            "remarks": self.remarks,
+            "rpn_severity": self.rpn_severity,
+            "rpn_severity_new": self.rpn_severity_new,
+            "severity_class": self.severity_class,
+            "single_point": self.single_point,
+            "type_id": self.type_id,
+        }
+
+        return _attributes


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.
  - [ ] Followed in new code.
  - [ ] Corrected in existing code whenever possible.
  - [ ] Spelling and English grammar errors have been eliminated.
  - [ ] Attribute and variable names make sense.
  - [ ] Stub files created or updated.
  - [ ] New code is readable.
  - [ ] Execute 'make maintain' before committing changes and fix any issues.
  - [ ] Code is not overly complicated; refactor if it is.
  - [ ] Debugging, including print(), statements have been removed.

- Tests
  - [ ] At least one test for all newly created functions/methods?
  - [ ] Tests capture key use cases.
  - [ ] Enough edge cases covered for comfort.
  - [ ] Code coverage has not decreased.

- Documentation
  - [ ] Update api documentation to reflect the changes made.
  - [ ] Update the user documentation to reflect the changes made.

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [ ] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [ ] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [ ] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [ ] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
