### PR TITLE
test: cleanup opstress test suite

### DIFF
--- a/tests/controllers/opstress/opstress_integration_test.py
+++ b/tests/controllers/opstress/opstress_integration_test.py
@@ -16,11 +16,79 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.controllers import dmOpStress
+from ramstk.models.programdb import RAMSTKOpStress
 
 
-@pytest.mark.usefixtures("test_program_dao")
+@pytest.fixture(scope="class")
+def test_datamanager(test_program_dao):
+    """Get a data manager instance for each test class."""
+    # Create the device under test (dut) and connect to the database.
+    dut = dmOpStress()
+    dut.do_connect(test_program_dao)
+    dut.do_select_all(
+        {
+            "revision_id": 1,
+            "hardware_id": 1,
+            "mode_id": 6,
+            "mechanism_id": 1,
+            "load_id": 1,
+        }
+    )
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_opstress_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_opstress_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_opstress")
+    pub.unsubscribe(dut.do_update, "request_update_opstress")
+    pub.unsubscribe(dut.do_select_all, "selected_load")
+    pub.unsubscribe(dut.do_get_tree, "request_get_opstress_tree")
+    pub.unsubscribe(dut._do_delete, "request_delete_opstress")
+    pub.unsubscribe(dut._do_insert_opstress, "request_insert_opstress")
+
+    # Delete the device under test.
+    del dut
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestSelectMethods:
+    """Class for testing data manager select_all() and select() methods."""
+
+    def on_succeed_select_all(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data["opstress"], RAMSTKOpStress)
+        print("\033[36m\nsucceed_retrieve_opstress topic was broadcast.")
+
+    @pytest.mark.pof
+    @pytest.mark.integration
+    def test_do_select_all_populated_tree(self, test_datamanager):
+        """do_select_all() should return a Tree() object populated with
+        RAMSTKOpStress instances on success."""
+        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_opstress")
+
+        test_datamanager.do_select_all(
+            {
+                "revision_id": 1,
+                "hardware_id": 1,
+                "mode_id": 6,
+                "mechanism_id": 1,
+                "load_id": 1,
+            }
+        )
+
+        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_opstress")
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
+
+    def on_succeed_insert_sibling(self, node_id, tree):
+        assert node_id == 3
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(3).data["opstress"], RAMSTKOpStress)
+        print("\033[36m\nsucceed_insert_opstress topic was broadcast.")
 
     def on_fail_insert_no_parent(self, error_message):
         assert error_message == (
@@ -40,64 +108,115 @@ class TestInsertMethods:
         )
         print("\033[35m\nfail_insert_opstress topic was broadcast.")
 
+    @pytest.mark.integration
+    def test_do_insert_sibling(self, test_datamanager):
+        """do_insert() should send the success message with the ID of the newly
+        inserted node and the data manager's tree after successfully inserting
+        a new opstress."""
+        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_mission_phase")
+
+        pub.sendMessage("request_insert_opstress", parent_id=2)
+
+        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_mission_phase")
+
     @pytest.mark.pof
     @pytest.mark.integration
-    def test_do_insert_no_parent(self, test_program_dao):
+    def test_do_insert_no_parent(self, test_datamanager):
         """_do_insert_opstress() should send the fail message if attempting to
         add an operating load to a non-existent opstress ID."""
         pub.subscribe(self.on_fail_insert_no_parent, "fail_insert_opstress")
 
-        DUT = dmOpStress()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT._parent_id = 100
-        DUT._do_insert_opstress(100)
+        test_datamanager._parent_id = 100
+        pub.sendMessage("request_insert_opstress", parent_id=100)
 
         pub.unsubscribe(self.on_fail_insert_no_parent, "fail_insert_opstress")
 
     @pytest.mark.pof
     @pytest.mark.integration
-    def test_do_insert_no_revision(self, test_program_dao):
+    def test_do_insert_no_revision(self, test_datamanager):
         """_do_insert_opstress() should send the success message after
         successfully inserting an operating stress."""
         pub.subscribe(self.on_fail_insert_no_revision, "fail_insert_opstress")
 
-        DUT = dmOpStress()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT._revision_id = 10
-        DUT._do_insert_opstress(1)
+        test_datamanager._revision_id = 10
+        pub.sendMessage("request_insert_opstress", parent_id=1)
 
         pub.unsubscribe(self.on_fail_insert_no_revision, "fail_insert_opstress")
 
 
-@pytest.mark.usefixtures("test_program_dao")
+@pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
+
+    def on_succeed_delete(self, tree):
+        assert isinstance(tree, Tree)
+        print(
+            "\033[36m\nsucceed_delete_opstress topic was broadcast when deleting "
+            "a failure mode."
+        )
+
+    def on_fail_delete_non_existent_id(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent OpStress ID 300."
+        )
+        print("\033[35m\nfail_delete_opstress topic was broadcast.")
+
+    def on_fail_delete_not_in_tree(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent OpStress ID 1."
+        )
+        print("\033[35m\nfail_delete_opstress topic was broadcast.")
+
+    @pytest.mark.pof
+    @pytest.mark.integration
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should send the success message with the treelib Tree
+        when successfully deleting a test method."""
+        pub.subscribe(self.on_succeed_delete, "succeed_delete_opstress")
+
+        test_datamanager._do_delete(2)
+
+        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_opstress")
+
+    @pytest.mark.pof
+    @pytest.mark.integration
+    def test_do_delete_non_existent_id(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to delete
+        a node ID that doesn't exist in the tree."""
+        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_opstress")
+
+        test_datamanager._do_delete(300)
+
+        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_opstress")
+
+    @pytest.mark.pof
+    @pytest.mark.integration
+    def test_do_delete_not_in_tree(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to remove
+        a node that doesn't exist from the tree even if it exists in the
+        database."""
+        pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_opstress")
+
+        test_datamanager.tree.remove_node(1)
+        test_datamanager._do_delete(1)
+
+        pub.unsubscribe(self.on_fail_delete_not_in_tree, "fail_delete_opstress")
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
     def on_succeed_update(self, tree):
         assert isinstance(tree, Tree)
-        assert tree.get_node(1).data["opstress"].description == ("Big test opstress.")
-        assert tree.get_node(1).data["opstress"].load_history == (
-            "Big test load history."
+        assert tree.get_node(1).data["opstress"].description == (
+            "Test failure " "opstress"
         )
+        assert tree.get_node(1).data["opstress"].rpn_detection == 4
         print("\033[36m\nsucceed_update_opstress topic was broadcast")
+
+    def on_succeed_update_all(self):
+        print("\033[36m\nsucceed_update_all topic was broadcast")
 
     def on_fail_update_wrong_data_type(self, error_message):
         assert error_message == (
@@ -106,92 +225,159 @@ class TestUpdateMethods:
         )
         print("\033[35m\nfail_update_opstress topic was broadcast")
 
+    def on_fail_update_root_node_wrong_data_type(self, error_message):
+        assert error_message == ("do_update: Attempting to update the root node 0.")
+        print("\033[35m\nfail_update_opstress topic was broadcast")
+
+    def on_fail_update_non_existent_id(self, error_message):
+        assert error_message == (
+            "do_update: Attempted to save non-existent opstress with opstress ID 100."
+        )
+        print("\033[35m\nfail_update_opstress topic was broadcast")
+
+    def on_fail_update_no_data_package(self, error_message):
+        assert error_message == ("do_update: No data package found for opstress ID 1.")
+        print("\033[35m\nfail_update_opstress topic was broadcast")
+
     @pytest.mark.pof
     @pytest.mark.integration
-    def test_do_update(self, test_program_dao):
+    def test_do_update(self, test_datamanager):
         """do_update() should return a zero error code on success."""
         pub.subscribe(self.on_succeed_update, "succeed_update_opstress")
 
-        DUT = dmOpStress()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
+        test_datamanager.tree.get_node(1).data[
+            "opstress"
+        ].description = "Test failure opstress"
+        test_datamanager.tree.get_node(1).data["opstress"].rpn_detection = 4
 
-        DUT.tree.get_node(1).data["opstress"].description = "Big test opstress."
-        DUT.tree.get_node(1).data["opstress"].load_history = "Big test load history."
-        DUT.do_update(1, table="opstress")
+        pub.sendMessage("request_update_opstress", node_id=1, table="opstress")
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_opstress")
 
     @pytest.mark.pof
     @pytest.mark.integration
-    def test_do_update_all(self, test_program_dao):
+    def test_do_update_all(self, test_datamanager):
         """do_update_all() should broadcast the succeed message on success."""
-        DUT = dmOpStress()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
+        pub.subscribe(self.on_succeed_update_all, "succeed_update_all")
 
         pub.sendMessage("request_update_all_opstresss")
 
+        pub.unsubscribe(self.on_succeed_update_all, "succeed_update_all")
+
     @pytest.mark.pof
     @pytest.mark.integration
-    def test_do_update_wrong_data_type(self, test_program_dao):
+    def test_do_update_wrong_data_type(self, test_datamanager):
         """do_update() should return a non-zero error code when passed a
         Requirement ID that doesn't exist."""
         pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_opstress")
 
-        DUT = dmOpStress()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-
-        _opstress = DUT.do_select(1, table="opstress")
+        _opstress = test_datamanager.do_select(1, table="opstress")
         _opstress.rpn_detection = {1: 2}
 
-        DUT.do_update(1, table="opstress")
+        pub.sendMessage("request_update_opstress", node_id=1, table="opstress")
 
         pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_opstress")
 
     @pytest.mark.pof
     @pytest.mark.integration
-    def test_do_update_root_node(self, test_program_dao):
+    def test_do_update_root_node_wrong_data_type(self, test_datamanager):
         """do_update() should return a non-zero error code when passed a
         Requirement ID that doesn't exist."""
-        DUT = dmOpStress()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
+        pub.subscribe(
+            self.on_fail_update_root_node_wrong_data_type, "fail_update_opstress"
         )
 
-        _opstress = DUT.do_select(1, table="opstress")
+        _opstress = test_datamanager.do_select(1, table="opstress")
         _opstress.rpn_detection_new = {1: 2}
 
-        DUT.do_update(0, table="opstress")
+        pub.sendMessage("request_update_opstress", node_id=0, table="opstress")
+
+        pub.unsubscribe(
+            self.on_fail_update_root_node_wrong_data_type, "fail_update_opstress"
+        )
+
+    @pytest.mark.integration
+    def test_do_update_non_existent_id(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed an OpStress ID
+        that doesn't exist."""
+        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_opstress")
+
+        pub.sendMessage("request_update_opstress", node_id=100, table="opstress")
+
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_opstress")
+
+    @pytest.mark.integration
+    def test_do_update_no_data_package(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a FMEA
+        ID that has no data package."""
+        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_opstress")
+
+        test_datamanager.tree.get_node(1).data.pop("opstress")
+        pub.sendMessage("request_update_opstress", node_id=1, table="opstress")
+
+        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_opstress")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestGetterSetter:
+    """Class for testing methods that get or set."""
+
+    def on_succeed_get_attributes(self, attributes):
+        assert isinstance(attributes, dict)
+        assert attributes["load_id"] == 1
+        assert attributes["description"] == "System Test Failure Mode #2"
+        print("\033[36m\nsucceed_get_mode_attributes topic was broadcast.")
+
+    def on_succeed_get_data_manager_tree(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data["opstress"], RAMSTKOpStress)
+        print("\033[36m\nsucceed_get_opstress_tree topic was broadcast")
+
+    def on_succeed_set_attributes(self, tree):
+        assert isinstance(tree, Tree)
+        assert tree.get_node(1).data["opstress"].description == "Jared Kushner"
+        print("\033[36m\nsucceed_get_opstress_tree topic was broadcast")
+
+    @pytest.mark.pof
+    @pytest.mark.integration
+    def test_do_get_attributes(self, test_datamanager):
+        """do_get_attributes() should return a dict of mode attributes on
+        success."""
+        pub.subscribe(self.on_succeed_get_attributes, "succeed_get_mode_attributes")
+
+        pub.sendMessage("request_get_opstress_attributes", node_id=1, table="opstress")
+
+        pub.unsubscribe(self.on_succeed_get_attributes, "succeed_get_mode_attributes")
+
+    @pytest.mark.pof
+    @pytest.mark.integration
+    def test_on_get_tree_data_manager(self, test_datamanager):
+        """on_get_tree() should return the PoF treelib Tree."""
+        pub.subscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_opstress_tree"
+        )
+
+        pub.sendMessage("request_get_opstress_tree")
+
+        pub.unsubscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_opstress_tree"
+        )
+
+    @pytest.mark.pof
+    @pytest.mark.integration
+    def test_do_set_attributes(self, test_datamanager):
+        """do_set_attributes() should return None when successfully setting
+        operating load attributes."""
+        pub.subscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_opstress_tree"
+        )
+
+        pub.sendMessage(
+            "request_set_opstress_attributes",
+            node_id=[1, ""],
+            package={"description": "Big test operating load."},
+        )
+
+        pub.unsubscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_opstress_tree"
+        )

--- a/tests/controllers/opstress/opstress_unit_test.py
+++ b/tests/controllers/opstress/opstress_unit_test.py
@@ -58,7 +58,29 @@ def mock_program_dao(monkeypatch):
     yield DAO
 
 
-@pytest.mark.usefixtures("mock_program_dao")
+@pytest.fixture(scope="function")
+def test_datamanager(mock_program_dao):
+    """Get a data manager instance for each test function."""
+    # Create the device under test (dut) and connect to the database.
+    dut = dmOpStress()
+    dut.do_connect(mock_program_dao)
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_opstress_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_opstress_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_opstress")
+    pub.unsubscribe(dut.do_update, "request_update_opstress")
+    pub.unsubscribe(dut.do_select_all, "selected_load")
+    pub.unsubscribe(dut.do_get_tree, "request_get_opstress_tree")
+    pub.unsubscribe(dut._do_delete, "request_delete_opstress")
+    pub.unsubscribe(dut._do_insert_opstress, "request_insert_opstress")
+
+    # Delete the device under test.
+    del dut
+
+
 class TestCreateControllers:
     """Class for controller initialization test suite."""
 
@@ -89,410 +111,139 @@ class TestCreateControllers:
         assert pub.isSubscribed(DUT._do_delete, "request_delete_opstress")
         assert pub.isSubscribed(DUT._do_insert_opstress, "request_insert_opstress")
 
+        # Unsubscribe from pypubsub topics.
+        pub.unsubscribe(DUT.do_get_attributes, "request_get_opstress_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "request_set_opstress_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "wvw_editing_opstress")
+        pub.unsubscribe(DUT.do_update, "request_update_opstress")
+        pub.unsubscribe(DUT.do_select_all, "selected_load")
+        pub.unsubscribe(DUT.do_get_tree, "request_get_opstress_tree")
+        pub.unsubscribe(DUT._do_delete, "request_delete_opstress")
+        pub.unsubscribe(DUT._do_insert_opstress, "request_insert_opstress")
 
-@pytest.mark.usefixtures("mock_program_dao")
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestSelectMethods:
     """Class for testing data manager select_all() and select() methods."""
 
-    def on_succeed_select_all(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["opstress"], MockRAMSTKOpStress)
-        print("\033[36m\nsucceed_retrieve_opstress topic was broadcast.")
-
     @pytest.mark.pof
     @pytest.mark.unit
-    def test_do_select_all(self, mock_program_dao):
+    def test_do_select_all(self, test_datamanager):
         """do_select_all() should return a Tree() object populated with
         RAMSTKOpStress instances on success."""
-        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_opstress")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
+        test_datamanager.do_select_all(
             {
                 "revision_id": 1,
                 "hardware_id": 1,
-                "mode_id": 1,
+                "mode_id": 6,
                 "mechanism_id": 1,
                 "load_id": 1,
             }
         )
-
-        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_opstress")
+        assert isinstance(test_datamanager.tree, Tree)
+        assert isinstance(
+            test_datamanager.tree.get_node(1).data["opstress"], MockRAMSTKOpStress
+        )
 
     @pytest.mark.pof
     @pytest.mark.unit
-    def test_do_select_all_populated_tree(self, mock_program_dao):
-        """do_select_all() should return a Tree() object populated with
-        RAMSTKOpStress instances on success."""
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-
-        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_opstress")
-
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-
-        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_opstress")
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_do_select(self, mock_program_dao):
+    def test_do_select(self, test_datamanager):
         """do_select() should return an instance of the RAMSTKOpStress on
         success."""
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
+        test_datamanager.do_select_all(
             {
                 "revision_id": 1,
                 "hardware_id": 1,
-                "mode_id": 1,
+                "mode_id": 6,
                 "mechanism_id": 1,
                 "load_id": 1,
             }
         )
-
-        _opstress = DUT.do_select(2, table="opstress")
+        _opstress = test_datamanager.do_select(2, table="opstress")
 
         assert isinstance(_opstress, MockRAMSTKOpStress)
         assert _opstress.description == "Test Operating Stress #2"
-        assert _opstress.measurable_parameter == ""
 
     @pytest.mark.pof
     @pytest.mark.unit
-    def test_do_select_unknown_table(self, mock_program_dao):
+    def test_do_select_unknown_table(self, test_datamanager):
         """do_select() should raise a KeyError when an unknown table name is
         requested."""
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
+        test_datamanager.do_select_all(
             {
                 "revision_id": 1,
                 "hardware_id": 1,
-                "mode_id": 1,
+                "mode_id": 6,
                 "mechanism_id": 1,
                 "load_id": 1,
             }
         )
 
         with pytest.raises(KeyError):
-            DUT.do_select(2, table="scibbidy-bibbidy-doo")
+            test_datamanager.do_select(2, table="scibbidy-bibbidy-doo")
 
     @pytest.mark.pof
     @pytest.mark.unit
-    def test_do_select_non_existent_id(self, mock_program_dao):
+    def test_do_select_non_existent_id(self, test_datamanager):
         """do_select() should return None when a non-existent opstress ID is
         requested."""
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
+        test_datamanager.do_select_all(
             {
                 "revision_id": 1,
                 "hardware_id": 1,
-                "mode_id": 1,
+                "mode_id": 6,
                 "mechanism_id": 1,
                 "load_id": 1,
             }
         )
 
-        assert DUT.do_select(100, table="opstress") is None
+        assert test_datamanager.do_select(100, table="opstress") is None
 
 
-@pytest.mark.usefixtures("mock_program_dao")
-class TestDeleteMethods:
-    """Class for testing the data manager delete() method."""
-
-    def on_succeed_delete(self, tree):
-        assert isinstance(tree, Tree)
-        print(
-            "\033[36m\nsucceed_delete_opstress topic was broadcast when deleting "
-            "a failure mode."
-        )
-
-    def on_fail_delete_non_existent_id(self, error_message):
-        assert error_message == (
-            "_do_delete: Attempted to delete non-existent OpStress ID 300."
-        )
-        print("\033[35m\nfail_delete_opstress topic was broadcast.")
-
-    def on_fail_delete_not_in_tree(self, error_message):
-        assert error_message == (
-            "_do_delete: Attempted to delete non-existent OpStress ID 2."
-        )
-        print("\033[35m\nfail_delete_opstress topic was broadcast.")
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_do_delete(self, mock_program_dao):
-        """_do_delete() should send the success message with the treelib Tree
-        when successfully deleting a test method."""
-        pub.subscribe(self.on_succeed_delete, "succeed_delete_opstress")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT._do_delete(2)
-
-        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_opstress")
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_do_delete_non_existent_id(self, mock_program_dao):
-        """_do_delete() should send the fail message when attempting to delete
-        a node ID that doesn't exist in the tree."""
-        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_opstress")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT._do_delete(300)
-
-        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_opstress")
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_do_delete_not_in_tree(self, mock_program_dao):
-        """_do_delete() should send the fail message when attempting to remove
-        a node that doesn't exist from the tree even if it exists in the
-        database."""
-        pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_opstress")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT.tree.remove_node(2)
-        DUT._do_delete(2)
-
-        pub.unsubscribe(self.on_fail_delete_not_in_tree, "fail_delete_opstress")
-
-
-@pytest.mark.usefixtures("mock_program_dao")
-class TestGetterSetter:
-    """Class for testing methods that get or set."""
-
-    def on_succeed_get_attributes(self, attributes):
-        assert isinstance(attributes, dict)
-        assert attributes["load_id"] == 1
-        assert attributes["description"] == "System Test Failure Mode #2"
-        print("\033[36m\nsucceed_get_mode_attributes topic was broadcast.")
-
-    def on_succeed_get_data_manager_tree(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(2).data["opstress"], MockRAMSTKOpStress)
-        print("\033[36m\nsucceed_get_opstress_tree topic was broadcast")
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_do_get_attributes(self, mock_program_dao):
-        """do_get_attributes() should return a dict of mode attributes on
-        success."""
-        pub.subscribe(self.on_succeed_get_attributes, "succeed_get_mode_attributes")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT.do_get_attributes(1, "opstress")
-
-        pub.unsubscribe(self.on_succeed_get_attributes, "succeed_get_mode_attributes")
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_do_set_attributes(self, mock_program_dao):
-        """do_set_attributes() should return None when successfully setting
-        operating load attributes."""
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-
-        DUT.do_set_attributes(
-            node_id=[1, -1],
-            package={"measurable_parameter": "Big " "test measurable parameter."},
-        )
-        DUT.do_set_attributes(
-            node_id=[1, -1], package={"description": "Big test operating load."}
-        )
-
-        pub.unsubscribe(DUT.do_set_attributes, "request_set_opstress_attributes")
-
-        assert (
-            DUT.do_select(1, table="opstress").description == "Big test operating load."
-        )
-        assert (
-            DUT.do_select(1, table="opstress").measurable_parameter
-            == "Big test measurable parameter."
-        )
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_on_get_tree_data_manager(self, mock_program_dao):
-        """on_get_tree() should return the PoF treelib Tree."""
-        pub.subscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_opstress_tree"
-        )
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT.do_get_tree()
-
-        pub.unsubscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_opstress_tree"
-        )
-
-
-@pytest.mark.usefixtures("mock_program_dao")
+@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
 
-    def on_succeed_insert_sibling(self, node_id, tree):
-        assert node_id == 3
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(3).data["opstress"], RAMSTKOpStress)
-        print("\033[36m\nsucceed_insert_opstress topic was broadcast.")
-
     @pytest.mark.pof
     @pytest.mark.unit
-    def test_do_insert_sibling(self, mock_program_dao):
+    def test_do_insert_sibling(self, test_datamanager):
         """_do_insert_opstress() should send the success message after
         successfully inserting an operating load."""
-        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_opstress")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
+        test_datamanager.do_select_all(
             {
                 "revision_id": 1,
                 "hardware_id": 1,
-                "mode_id": 1,
+                "mode_id": 6,
                 "mechanism_id": 1,
                 "load_id": 1,
             }
         )
+        test_datamanager._do_insert_opstress(2)
 
-        DUT._do_insert_opstress(2)
-
-        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_opstress")
-
-
-@pytest.mark.usefixtures("mock_program_dao")
-class TestUpdateMethods:
-    """Class for testing update() and update_all() methods."""
-
-    def on_fail_update_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_update: Attempted to save non-existent opstress with opstress ID 100."
+        assert isinstance(test_datamanager.tree, Tree)
+        assert isinstance(
+            test_datamanager.tree.get_node(3).data["opstress"], RAMSTKOpStress
         )
-        print("\033[35m\nfail_update_opstress topic was broadcast")
 
-    def on_fail_update_no_data_package(self, error_message):
-        assert error_message == ("do_update: No data package found for opstress ID 2.")
-        print("\033[35m\nfail_update_opstress topic was broadcast")
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
 
     @pytest.mark.pof
     @pytest.mark.unit
-    def test_do_update_non_existent_id(self, mock_program_dao):
-        """do_update() should return a non-zero error code when passed a PoF ID
-        that doesn't exist."""
-        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_opstress")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should send the success message with the treelib Tree
+        when successfully deleting a test method."""
+        test_datamanager.do_select_all(
             {
                 "revision_id": 1,
                 "hardware_id": 1,
-                "mode_id": 1,
+                "mode_id": 6,
                 "mechanism_id": 1,
                 "load_id": 1,
             }
         )
-        DUT.do_update(100, table="opstress")
+        test_datamanager._do_delete(2)
 
-        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_opstress")
-
-    @pytest.mark.pof
-    @pytest.mark.unit
-    def test_do_update_no_data_package(self, mock_program_dao):
-        """do_update() should return a non-zero error code when passed a FMEA
-        ID that has no data package."""
-        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_opstress")
-
-        DUT = dmOpStress()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(
-            {
-                "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 1,
-                "mechanism_id": 1,
-                "load_id": 1,
-            }
-        )
-        DUT.tree.get_node(2).data.pop("opstress")
-        DUT.do_update(2, table="opstress")
-
-        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_opstress")
+        assert test_datamanager.tree.get_node(2) is None

--- a/tests/controllers/opstress/opstress_unit_test.py
+++ b/tests/controllers/opstress/opstress_unit_test.py
@@ -13,7 +13,7 @@
 import pytest
 
 # noinspection PyUnresolvedReferences
-from mocks import MockDAO
+from mocks import MockDAO, MockRAMSTKOpStress
 from pubsub import pub
 from treelib import Tree
 
@@ -25,7 +25,7 @@ from ramstk.models.programdb import RAMSTKOpStress
 
 @pytest.fixture
 def mock_program_dao(monkeypatch):
-    _opstress_1 = RAMSTKOpStress()
+    _opstress_1 = MockRAMSTKOpStress()
     _opstress_1.revision_id = 1
     _opstress_1.hardware_id = 1
     _opstress_1.mode_id = 1
@@ -37,7 +37,7 @@ def mock_program_dao(monkeypatch):
     _opstress_1.measurable_parameter = ""
     _opstress_1.remarks = ""
 
-    _opstress_2 = RAMSTKOpStress()
+    _opstress_2 = MockRAMSTKOpStress()
     _opstress_2.revision_id = 1
     _opstress_2.hardware_id = 1
     _opstress_2.mode_id = 1
@@ -96,7 +96,7 @@ class TestSelectMethods:
 
     def on_succeed_select_all(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["opstress"], RAMSTKOpStress)
+        assert isinstance(tree.get_node(1).data["opstress"], MockRAMSTKOpStress)
         print("\033[36m\nsucceed_retrieve_opstress topic was broadcast.")
 
     @pytest.mark.pof
@@ -170,7 +170,7 @@ class TestSelectMethods:
 
         _opstress = DUT.do_select(2, table="opstress")
 
-        assert isinstance(_opstress, RAMSTKOpStress)
+        assert isinstance(_opstress, MockRAMSTKOpStress)
         assert _opstress.description == "Test Operating Stress #2"
         assert _opstress.measurable_parameter == ""
 
@@ -318,7 +318,7 @@ class TestGetterSetter:
 
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(2).data["opstress"], RAMSTKOpStress)
+        assert isinstance(tree.get_node(2).data["opstress"], MockRAMSTKOpStress)
         print("\033[36m\nsucceed_get_opstress_tree topic was broadcast")
 
     @pytest.mark.pof

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -23,5 +23,6 @@ from .mock_ramstkmission import MockRAMSTKMission
 from .mock_ramstkmissionphase import MockRAMSTKMissionPhase
 from .mock_ramstkmode import MockRAMSTKMode
 from .mock_ramstkopload import MockRAMSTKOpLoad
+from .mock_ramstkopstress import MockRAMSTKOpStress
 from .mock_ramstkrevision import MockRAMSTKRevision
 from .MockDAO import MockDAO

--- a/tests/mocks/mock_ramstkopstress.py
+++ b/tests/mocks/mock_ramstkopstress.py
@@ -1,0 +1,41 @@
+# RAMSTK Local Imports
+from . import MockRAMSTKBaseTable
+
+
+class MockRAMSTKOpStress(MockRAMSTKBaseTable):
+    __defaults__ = {
+        "description": "",
+        "load_history": "",
+        "measurable_parameter": "",
+        "remarks": "",
+    }
+
+    def __init__(self):
+        self.revision_id = 0
+        self.hardware_id = 0
+        self.mode_id = 0
+        self.mechanism_id = 0
+        self.load_id = 0
+        self.stress_id = 0
+        self.description = self.__defaults__["description"]
+        self.load_history = self.__defaults__["load_history"]
+        self.measurable_parameter = self.__defaults__["measurable_parameter"]
+        self.remarks = self.__defaults__["remarks"]
+
+        self.is_mode = False
+        self.is_mechanism = False
+        self.is_opload = False
+        self.is_opstress = True
+        self.is_testmethod = False
+
+    def get_attributes(self):
+        _attributes = {
+            "load_id": self.load_id,
+            "stress_id": self.stress_id,
+            "description": self.description,
+            "load_history": self.load_history,
+            "measurable_parameter": self.measurable_parameter,
+            "remarks": self.remarks,
+        }
+
+        return _attributes


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.
  - [ ] Followed in new code.
  - [ ] Corrected in existing code whenever possible.
  - [ ] Spelling and English grammar errors have been eliminated.
  - [ ] Attribute and variable names make sense.
  - [ ] Stub files created or updated.
  - [ ] New code is readable.
  - [ ] Execute 'make maintain' before committing changes and fix any issues.
  - [ ] Code is not overly complicated; refactor if it is.
  - [ ] Debugging, including print(), statements have been removed.

- Tests
  - [ ] At least one test for all newly created functions/methods?
  - [ ] Tests capture key use cases.
  - [ ] Enough edge cases covered for comfort.
  - [ ] Code coverage has not decreased.

- Documentation
  - [ ] Update api documentation to reflect the changes made.
  - [ ] Update the user documentation to reflect the changes made.

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [ ] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [ ] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [ ] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [ ] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
