### PR TITLE
test: cleanup preferences test suite

### DIFF
--- a/src/ramstk/controllers/preferences/datamanager.py
+++ b/src/ramstk/controllers/preferences/datamanager.py
@@ -70,12 +70,12 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(self._do_select_all, "succeed_connect_program_database")
 
     def do_get_tree(self) -> None:
-        """Retrieve the Options treelib Tree.
+        """Retrieve the Preferences treelib Tree.
 
         :return: None
         :rtype: None
         """
-        pub.sendMessage("succeed_get_options_tree", tree=self.tree)
+        pub.sendMessage("succeed_get_preferences_tree", tree=self.tree)
 
     def _do_select_all(self, dao: BaseDatabase) -> None:
         """Retrieve all the Options data from the RAMSTK Program database.

--- a/tests/controllers/preferences/preferences_integration_test.py
+++ b/tests/controllers/preferences/preferences_integration_test.py
@@ -9,21 +9,71 @@
 # Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Preferences integrations."""
 
+# Standard Library Imports
+from datetime import date
+
 # Third Party Imports
 import pytest
 from pubsub import pub
+from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.controllers import dmPreferences
+from ramstk.models.programdb import RAMSTKProgramInfo
 
 
-@pytest.mark.usefixtures("test_program_dao")
+@pytest.fixture(scope="class")
+def test_datamanager(test_program_dao):
+    """Get a data manager instance for each test class."""
+    # Create the device under test (dut) and connect to the database.
+    dut = dmPreferences()
+    dut._do_select_all(test_program_dao)
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_preference_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_preference_attributes")
+    pub.unsubscribe(dut.do_update, "request_update_preference")
+    pub.unsubscribe(dut.do_get_tree, "request_get_preferences_tree")
+    pub.unsubscribe(dut._do_select_all, "succeed_connect_program_database")
+
+    # Delete the device under test.
+    del dut
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestSelectMethods:
+    """Class for testing data manager select_all() and select() methods."""
+
+    def on_succeed_select_all(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data["programinfo"], RAMSTKProgramInfo)
+        # There should be a root node with no data package and a node with
+        # the one RAMSTKProgramInfo record.
+        assert len(tree.all_nodes()) == 2
+        print("\033[36m\nsucceed_retrieve_preferences topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_select_all_populated_tree(self, test_datamanager, test_program_dao):
+        """do_select_all() should clear nodes from an existing Options tree."""
+        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_preferences")
+
+        pub.sendMessage("succeed_connect_program_database", dao=test_program_dao)
+
+        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_preferences")
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
     def on_succeed_update(self, node_id):
         assert node_id == 1
         print("\033[36m\nsucceed_update_preferences topic was broadcast")
+
+    def on_succeed_update_all(self):
+        print("\033[36m\nsucceed_update_all topic was broadcast")
 
     def on_fail_update_wrong_data_type(self, error_message):
         assert error_message == (
@@ -33,46 +83,189 @@ class TestUpdateMethods:
         )
         print("\033[35m\nfail_update_preferences topic was broadcast")
 
+    def on_fail_update_root_node_wrong_data_type(self, error_message):
+        assert error_message == ("do_update: Attempting to update the root node 0.")
+        print("\033[35m\nfail_update_preferences topic was broadcast")
+
+    def on_fail_update_non_existent_id(self, error_message):
+        assert error_message == (
+            "do_update: Attempted to save non-existent " "Program ID skullduggery."
+        )
+        print("\033[35m\nfail_update_preferences topic was broadcast")
+
+    def on_fail_update_no_data_package(self, error_message):
+        assert error_message == (
+            "do_update: No data package found for " "Preference 1."
+        )
+        print("\033[35m\nfail_update_preferences topic was broadcast")
+
     @pytest.mark.integration
-    def test_do_update(self, test_program_dao):
+    def test_do_update(self, test_datamanager):
         """do_update() should return a zero error code on success."""
         pub.subscribe(self.on_succeed_update, "succeed_update_preferences")
 
-        DUT = dmPreferences()
-        DUT._do_select_all(test_program_dao)
+        test_datamanager.tree.get_node(1).data["programinfo"].hardware_active = 0
+        test_datamanager.tree.get_node(1).data["programinfo"].vandv_active = 0
 
-        DUT.tree.get_node(1).data["programinfo"].hardware_active = 0
-        DUT.tree.get_node(1).data["programinfo"].vandv_active = 0
-        DUT.do_update(1, table="programinfo")
+        pub.sendMessage("request_update_preference", node_id=1, table="programinfo")
 
-        assert DUT.tree.get_node(1).data["programinfo"].hardware_active == 0
-        assert DUT.tree.get_node(1).data["programinfo"].vandv_active == 0
-
-        DUT.tree.get_node(1).data["programinfo"].hardware_active = 1
-        DUT.tree.get_node(1).data["programinfo"].vandv_active = 1
-        DUT.do_update(1, table="programinfo")
-
-        assert DUT.tree.get_node(1).data["programinfo"].hardware_active == 1
-        assert DUT.tree.get_node(1).data["programinfo"].vandv_active == 1
+        assert (
+            test_datamanager.tree.get_node(1).data["programinfo"].hardware_active == 0
+        )
+        assert test_datamanager.tree.get_node(1).data["programinfo"].vandv_active == 0
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_preferences")
 
+        test_datamanager.tree.get_node(1).data["programinfo"].hardware_active = 1
+        test_datamanager.tree.get_node(1).data["programinfo"].vandv_active = 1
+
+        pub.sendMessage("request_update_preference", node_id=1, table="programinfo")
+
+        assert (
+            test_datamanager.tree.get_node(1).data["programinfo"].hardware_active == 1
+        )
+        assert test_datamanager.tree.get_node(1).data["programinfo"].vandv_active == 1
+
     @pytest.mark.integration
-    def test_do_update_wrong_data_type(self, test_program_dao):
+    def test_do_update_all(self, test_datamanager):
+        """do_update_all() should broadcast the succeed message on success."""
+        pub.subscribe(self.on_succeed_update_all, "succeed_update_all")
+
+        pub.sendMessage("request_update_all_preferences")
+
+        pub.unsubscribe(self.on_succeed_update_all, "succeed_update_all")
+
+    @pytest.mark.integration
+    def test_do_update_wrong_data_type(self, test_datamanager):
         """do_update() should return a zero error code on success."""
         pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_preferences")
 
-        DUT = dmPreferences()
-        DUT._do_select_all(test_program_dao)
-        DUT.tree.get_node(1).data["programinfo"].hardware_active = {0: 1}
-        DUT.do_update(1, table="programinfo")
+        test_datamanager.tree.get_node(1).data["programinfo"].hardware_active = {0: 1}
+        pub.sendMessage("request_update_preference", node_id=1, table="programinfo")
 
         pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_preferences")
 
     @pytest.mark.integration
-    def test_do_update_root_node(self, test_program_dao):
+    def test_do_update_root_node_wrong_data_type(self, test_datamanager):
         """do_update() should return a zero error code on success."""
-        DUT = dmPreferences()
-        DUT._do_select_all(test_program_dao)
-        DUT.tree.get_node(1).data["programinfo"].hardware_active = {0: 1}
-        DUT.do_update(0, table="programinfo")
+        pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_preferences")
+
+        test_datamanager.tree.get_node(1).data["programinfo"].hardware_active = {0: 1}
+
+        pub.sendMessage("request_update_preference", node_id=1, table="programinfo")
+
+        pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_preferences")
+
+    @pytest.mark.integration
+    def test_do_update_non_existent_id(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a
+        Options ID that doesn't exist."""
+        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_preferences")
+
+        pub.sendMessage(
+            "request_update_preference", node_id="skullduggery", table="programinfo"
+        )
+
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_preferences")
+
+    @pytest.mark.integration
+    def test_do_update_no_data_package(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a
+        Options ID that doesn't exist."""
+        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_preferences")
+
+        test_datamanager.tree.get_node(1).data.pop("programinfo")
+
+        pub.sendMessage("request_update_preference", node_id=1, table="programinfo")
+
+        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_preferences")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestGetterSetter:
+    """Class for testing methods that get or set."""
+
+    def on_succeed_get_attributes(self, attributes):
+        assert isinstance(attributes, dict)
+        assert attributes["function_active"] == 1
+        assert attributes["requirement_active"] == 1
+        assert attributes["hardware_active"] == 1
+        assert attributes["software_active"] == 0
+        assert attributes["rcm_active"] == 0
+        assert attributes["testing_active"] == 0
+        assert attributes["incident_active"] == 0
+        assert attributes["survival_active"] == 0
+        assert attributes["vandv_active"] == 1
+        assert attributes["hazard_active"] == 1
+        assert attributes["stakeholder_active"] == 1
+        assert attributes["allocation_active"] == 1
+        assert attributes["similar_item_active"] == 1
+        assert attributes["fmea_active"] == 1
+        assert attributes["pof_active"] == 1
+        assert attributes["rbd_active"] == 0
+        assert attributes["fta_active"] == 0
+        assert attributes["created_on"] == date.today()
+        assert attributes["created_by"] == ""
+        assert attributes["last_saved"] == date.today()
+        assert attributes["last_saved_by"] == ""
+        print("\033[36m\nsucceed_get_programinfo_attributes topic was broadcast.")
+
+    def on_succeed_get_data_manager_tree(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data["programinfo"], RAMSTKProgramInfo)
+        print("\033[36m\nsucceed_get_preferences_tree topic was broadcast")
+
+    def on_succeed_set_attributes(self, tree):
+        assert isinstance(tree, Tree)
+        assert tree.get_node(1).data["programinfo"].function_active == 0
+        print("\033[36m\nsucceed_get_options_tree topic was broadcast")
+
+    @pytest.mark.integration
+    def test_do_get_attributes(self, test_datamanager):
+        """do_get_attributes() should return a dict of program information
+        attributes on success."""
+        pub.subscribe(
+            self.on_succeed_get_attributes, "succeed_get_programinfo_attributes"
+        )
+
+        pub.sendMessage(
+            "request_get_preference_attributes", node_id=1, table="programinfo"
+        )
+
+        pub.unsubscribe(
+            self.on_succeed_get_attributes, "succeed_get_programinfo_attributes"
+        )
+
+    @pytest.mark.integration
+    def test_on_get_data_manager_tree(self, test_datamanager):
+        """on_get_tree() should return the Preferences treelib Tree."""
+        pub.subscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_preferences_tree"
+        )
+
+        pub.sendMessage("request_get_preferences_tree")
+
+        pub.unsubscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_preferences_tree"
+        )
+
+    @pytest.mark.integration
+    def test_do_set_attributes(self, test_datamanager):
+        """do_set_attributes() should return None when successfully setting
+        program information attributes."""
+        pub.subscribe(self.on_succeed_set_attributes, "succeed_get_preferences_tree")
+
+        pub.sendMessage(
+            "request_set_preference_attributes",
+            node_id=[1],
+            package={"function_active": 0},
+        )
+
+        pub.unsubscribe(self.on_succeed_set_attributes, "succeed_get_preferences_tree")
+
+        pub.sendMessage(
+            "request_set_preference_attributes",
+            node_id=[1],
+            package={"function_active": 1},
+        )
+        assert test_datamanager.do_select(1, table="programinfo").function_active == 1

--- a/tests/controllers/preferences/preferences_unit_test.py
+++ b/tests/controllers/preferences/preferences_unit_test.py
@@ -16,7 +16,7 @@ from datetime import date
 import pytest
 
 # noinspection PyUnresolvedReferences
-from mocks import MockDAO
+from mocks import MockDAO, MockRAMSTKProgramInfo
 from pubsub import pub
 from treelib import Tree
 
@@ -28,7 +28,7 @@ from ramstk.models.programdb import RAMSTKProgramInfo
 
 @pytest.fixture(scope="function")
 def mock_program_dao(monkeypatch):
-    _program_1 = RAMSTKProgramInfo()
+    _program_1 = MockRAMSTKProgramInfo()
     _program_1.revision_id = 1
     _program_1.function_active = 1
     _program_1.requirement_active = 1
@@ -94,7 +94,7 @@ class TestSelectMethods:
 
     def on_succeed_select_all(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["programinfo"], RAMSTKProgramInfo)
+        assert isinstance(tree.get_node(1).data["programinfo"], MockRAMSTKProgramInfo)
         print("\033[36m\nsucceed_retrieve_preferences topic was broadcast.")
 
     @pytest.mark.unit
@@ -130,7 +130,7 @@ class TestSelectMethods:
 
         _preferences = DUT.do_select(1, table="programinfo")
 
-        assert isinstance(_preferences, RAMSTKProgramInfo)
+        assert isinstance(_preferences, MockRAMSTKProgramInfo)
         assert _preferences.function_active == 1
         assert _preferences.requirement_active == 1
         assert _preferences.hardware_active == 1
@@ -204,7 +204,7 @@ class TestGetterSetter:
 
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["programinfo"], RAMSTKProgramInfo)
+        assert isinstance(tree.get_node(1).data["programinfo"], MockRAMSTKProgramInfo)
         print("\033[36m\nsucceed_get_preferences_tree topic was broadcast")
 
     @pytest.mark.unit
@@ -219,7 +219,9 @@ class TestGetterSetter:
         DUT._do_select_all(mock_program_dao)
         DUT.do_get_attributes(1, "programinfo")
 
-        assert isinstance(DUT.tree.get_node(1).data["programinfo"], RAMSTKProgramInfo)
+        assert isinstance(
+            DUT.tree.get_node(1).data["programinfo"], MockRAMSTKProgramInfo
+        )
 
         pub.unsubscribe(
             self.on_succeed_get_attributes, "succeed_get_programinfo_attributes"

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -24,6 +24,7 @@ from .mock_ramstkmissionphase import MockRAMSTKMissionPhase
 from .mock_ramstkmode import MockRAMSTKMode
 from .mock_ramstkopload import MockRAMSTKOpLoad
 from .mock_ramstkopstress import MockRAMSTKOpStress
+from .mock_ramstkprograminfo import MockRAMSTKProgramInfo
 from .mock_ramstkrevision import MockRAMSTKRevision
 from .mock_ramstksiteinfo import MockRAMSTKSiteInfo
 from .MockDAO import MockDAO

--- a/tests/mocks/mock_ramstkprograminfo.py
+++ b/tests/mocks/mock_ramstkprograminfo.py
@@ -1,0 +1,83 @@
+# Standard Library Imports
+from datetime import date
+
+# RAMSTK Local Imports
+from . import MockRAMSTKBaseTable
+
+
+class MockRAMSTKProgramInfo(MockRAMSTKBaseTable):
+    __defaults__ = {
+        "function_active": 1,
+        "requirement_active": 1,
+        "hardware_active": 1,
+        "software_active": 0,
+        "rcm_active": 0,
+        "testing_active": 0,
+        "incident_active": 0,
+        "survival_active": 0,
+        "vandv_active": 1,
+        "hazard_active": 1,
+        "stakeholder_active": 1,
+        "allocation_active": 1,
+        "similar_item_active": 1,
+        "fmea_active": 1,
+        "pof_active": 1,
+        "rbd_active": 0,
+        "fta_active": 0,
+        "created_on": date.today(),
+        "created_by": "",
+        "last_saved": date.today(),
+        "last_saved_by": "",
+    }
+
+    def __init__(self):
+        self.revision_id = 0
+        self.function_active = self.__defaults__["function_active"]
+        self.requirement_active = self.__defaults__["requirement_active"]
+        self.hardware_active = self.__defaults__["hardware_active"]
+        self.software_active = self.__defaults__["software_active"]
+        self.rcm_active = self.__defaults__["rcm_active"]
+        self.testing_active = self.__defaults__["testing_active"]
+        self.incident_active = self.__defaults__["incident_active"]
+        self.survival_active = self.__defaults__["survival_active"]
+        self.vandv_active = self.__defaults__["vandv_active"]
+        self.hazard_active = self.__defaults__["hazard_active"]
+        self.stakeholder_active = self.__defaults__["stakeholder_active"]
+        self.allocation_active = self.__defaults__["allocation_active"]
+        self.similar_item_active = self.__defaults__["similar_item_active"]
+        self.fmea_active = self.__defaults__["fmea_active"]
+        self.pof_active = self.__defaults__["pof_active"]
+        self.rbd_active = self.__defaults__["rbd_active"]
+        self.fta_active = self.__defaults__["fta_active"]
+        self.created_on = self.__defaults__["created_on"]
+        self.created_by = self.__defaults__["created_by"]
+        self.last_saved = self.__defaults__["last_saved"]
+        self.last_saved_by = self.__defaults__["last_saved_by"]
+
+    def get_attributes(self):
+        _attributes = {
+            "revision_id": self.revision_id,
+            "function_active": self.function_active,
+            "requirement_active": self.requirement_active,
+            "hardware_active": self.hardware_active,
+            "software_active": self.software_active,
+            "rcm_active": self.rcm_active,
+            "testing_active": self.testing_active,
+            "incident_active": self.incident_active,
+            "survival_active": self.survival_active,
+            "vandv_active": self.vandv_active,
+            "fmea_active": self.fmea_active,
+            "pof_active": self.pof_active,
+            "hazard_active": self.hazard_active,
+            "stakeholder_active": self.stakeholder_active,
+            "allocation_active": self.allocation_active,
+            "similar_item_active": self.similar_item_active,
+            "rbd_active": self.rbd_active,
+            "fta_active": self.fta_active,
+            "created_on": self.created_on,
+            "created_by": self.created_by,
+            "last_saved": self.last_saved,
+            "last_saved_by": self.last_saved_by,
+        }
+
+        return _attributes


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.
  - [ ] Followed in new code.
  - [ ] Corrected in existing code whenever possible.
  - [ ] Spelling and English grammar errors have been eliminated.
  - [ ] Attribute and variable names make sense.
  - [ ] Stub files created or updated.
  - [ ] New code is readable.
  - [ ] Execute 'make maintain' before committing changes and fix any issues.
  - [ ] Code is not overly complicated; refactor if it is.
  - [ ] Debugging, including print(), statements have been removed.

- Tests
  - [ ] At least one test for all newly created functions/methods?
  - [ ] Tests capture key use cases.
  - [ ] Enough edge cases covered for comfort.
  - [ ] Code coverage has not decreased.

- Documentation
  - [ ] Update api documentation to reflect the changes made.
  - [ ] Update the user documentation to reflect the changes made.

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [ ] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [ ] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [ ] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [ ] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
