### PR TITLE
test: cleanup Requirements test suite

### DIFF
--- a/tests/controllers/requirement/requirement_integration_test.py
+++ b/tests/controllers/requirement/requirement_integration_test.py
@@ -9,6 +9,9 @@
 # Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Requirement module integrations."""
 
+# Standard Library Imports
+from datetime import date
+
 # Third Party Imports
 import pytest
 from pubsub import pub
@@ -16,35 +19,192 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.controllers import dmRequirement
+from ramstk.models.programdb import RAMSTKRequirement
 
 
-@pytest.mark.usefixtures("test_program_dao")
-class TestUpdateMethods:
+@pytest.fixture(scope="class")
+def test_datamanager(test_program_dao):
+    """Get a data manager instance for each test class."""
+    # Create the device under test (dut) and connect to the database.
+    dut = dmRequirement()
+    dut.do_connect(test_program_dao)
+    dut.do_select_all(attributes={"revision_id": 1})
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_requirement_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_requirement_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "mvw_editing_requirement")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_requirement")
+    pub.unsubscribe(dut.do_update, "request_update_requirement")
+    pub.unsubscribe(dut.do_create_all_codes, "request_create_all_requirement_codes")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_get_tree, "request_get_requirements_tree")
+    pub.unsubscribe(dut.do_create_code, "request_create_requirement_code")
+    pub.unsubscribe(dut._do_delete, "request_delete_requirement")
+    pub.unsubscribe(dut._do_insert_requirement, "request_insert_requirement")
+
+    # Delete the device under test.
+    del dut
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestSelectMethods:
+    """Class for testing data manager select_all() and select() methods."""
+
+    def on_succeed_select_all(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data, dict)
+        assert isinstance(tree.get_node(1).data["requirement"], RAMSTKRequirement)
+
+        print("\033[36m\nsucceed_retrieve_requirements topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_select_all_populated_tree(self, test_datamanager):
+        """do_select_all() should clear the existing Tree when a new group of
+        requirements is selected."""
+        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_requirements")
+
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+
+        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_requirements")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestInsertMethods:
     """Class for testing the data manager insert() method."""
 
-    def on_fail_insert_no_revision(self, error_message):
+    def on_succeed_insert_sibling(self, node_id, tree):
+        assert node_id == 4
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(4).data["requirement"], RAMSTKRequirement)
+        assert tree.get_node(4).data["requirement"].parent_id == 0
+        assert tree.get_node(4).data["requirement"].requirement_id == 4
+        assert tree.get_node(4).data["requirement"].description == "New Requirement"
+
+        print("\033[36m\nsucceed_insert_requirement topic was broadcast")
+
+    def on_succeed_insert_child(self, node_id, tree):
+        assert node_id == 5
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(5).data["requirement"], RAMSTKRequirement)
+        assert tree.get_node(5).data["requirement"].parent_id == 1
+        assert tree.get_node(5).data["requirement"].requirement_id == 5
+        assert tree.get_node(5).data["requirement"].description == "New Requirement"
+        print("\033[36m\nsucceed_insert_requirement topic was broadcast")
+
+    def on_fail_insert_no_parent(self, error_message):
         assert error_message == (
             "_do_insert_requirement: Attempted to insert child requirement "
             "under non-existent requirement ID 32."
         )
         print("\033[35m\nfail_insert_requirement topic was broadcast")
 
+    def on_fail_insert_no_revision(self, error_message):
+        assert error_message == (
+            "do_insert: Database error when attempting to add a record.  Database "
+            "returned:\n\tKey (fld_revision_id)=(10) is not present in table "
+            '"ramstk_revision".'
+        )
+        print("\033[35m\nfail_insert_requirement topic was broadcast.")
+
     @pytest.mark.integration
-    def test_do_insert_no_revision(self, test_program_dao):
+    def test_do_insert_sibling(self, test_datamanager):
         """do_insert() should send the success message after successfully
         inserting a new top-level requirement."""
+        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_requirement")
+
+        pub.sendMessage("request_insert_requirement", parent_id=0)
+
+        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_requirement")
+
+    @pytest.mark.integration
+    def test_do_insert_child(self, test_datamanager):
+        """do_insert() should send the success message after successfully
+        inserting a new child requirement."""
+        pub.subscribe(self.on_succeed_insert_child, "succeed_insert_requirement")
+
+        pub.sendMessage("request_insert_requirement", parent_id=1)
+
+        pub.unsubscribe(self.on_succeed_insert_child, "succeed_insert_requirement")
+
+    @pytest.mark.integration
+    def test_do_insert_no_parent(self, test_datamanager):
+        """do_insert() should send the fail message attempting to add a child
+        to a non-existent requirement."""
+        pub.subscribe(self.on_fail_insert_no_parent, "fail_insert_requirement")
+
+        pub.sendMessage("request_insert_requirement", parent_id=32)
+
+        pub.unsubscribe(self.on_fail_insert_no_parent, "fail_insert_requirement")
+
+    @pytest.mark.integration
+    def test_do_insert_no_revision(self, test_datamanager):
+        """_do_insert_requirement() should send the success message after
+        successfully inserting a n operating stress."""
         pub.subscribe(self.on_fail_insert_no_revision, "fail_insert_requirement")
 
-        DUT = dmRequirement()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._revision_id = 40
-        DUT._do_insert_requirement(parent_id=1)
+        test_datamanager._revision_id = 10
+        pub.sendMessage("request_insert_requirement", parent_id=1)
 
         pub.unsubscribe(self.on_fail_insert_no_revision, "fail_insert_requirement")
 
 
-@pytest.mark.usefixtures("test_program_dao")
+@pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
+
+    def on_succeed_delete(self, tree):
+        assert isinstance(tree, Tree)
+        print("\033[36m\nsucceed_delete_requirement topic was broadcast.")
+
+    def on_fail_delete_non_existent_id(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent requirement ID 300."
+        )
+        print("\033[35m\nfail_delete_requirement topic was broadcast.")
+
+    def on_fail_delete_not_in_tree(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent requirement ID 2."
+        )
+        print("\033[35m\nfail_delete_requirement topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should send the success message with the treelib
+        Tree."""
+        pub.subscribe(self.on_succeed_delete, "succeed_delete_requirement")
+
+        pub.sendMessage("request_delete_requirement", node_id=test_datamanager.last_id)
+
+        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_requirement")
+
+    @pytest.mark.integration
+    def test_do_delete_non_existent_id(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to delete
+        a non-existent requirement."""
+        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_requirement")
+
+        pub.sendMessage("request_delete_requirement", node_id=300)
+
+        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_requirement")
+
+    @pytest.mark.integration
+    def test_do_delete_not_in_tree(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to remove
+        a node that doesn't exist from the tree even if it exists in the
+        database."""
+        pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_requirement")
+
+        test_datamanager.tree.remove_node(2)
+        pub.sendMessage("request_delete_requirement", node_id=2)
+
+        pub.unsubscribe(self.on_fail_delete_not_in_tree, "fail_delete_requirement")
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
@@ -53,6 +213,9 @@ class TestUpdateMethods:
         assert tree.get_node(1).data["requirement"].description == "Test Requirement"
         print("\033[36m\nsucceed_update_requirement topic was broadcast")
 
+    def on_succeed_update_all(self):
+        print("\033[36m\nsucceed_update_all topic was broadcast")
+
     def on_fail_update_wrong_data_type(self, error_message):
         assert error_message == (
             "do_update: The value for one or more attributes for requirement "
@@ -60,68 +223,236 @@ class TestUpdateMethods:
         )
         print("\033[35m\nfail_update_requirement topic was broadcast")
 
+    def on_fail_update_root_node_wrong_data_type(self, error_message):
+        assert error_message == ("do_update: Attempting to update the root node 0.")
+        print("\033[35m\nfail_update_requirement topic was broadcast")
+
+    def on_fail_update_non_existent_id(self, error_message):
+        assert error_message == (
+            "do_update: Attempted to save non-existent requirement with "
+            "requirement ID 100."
+        )
+        print("\033[35m\nfail_update_requirement topic was broadcast")
+
+    def on_fail_update_no_data_package(self, error_message):
+        assert error_message == (
+            "do_update: No data package found for requirement ID 1."
+        )
+        print("\033[35m\nfail_update_requirement topic was broadcast")
+
     @pytest.mark.integration
-    def test_do_update(self, test_program_dao):
+    def test_do_update(self, test_datamanager):
         """do_update() should return a zero error code on success."""
         pub.subscribe(self.on_succeed_update, "succeed_update_requirement")
 
-        DUT = dmRequirement()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        _requirement = DUT.do_select(1, table="requirement")
+        _requirement = test_datamanager.do_select(1, table="requirement")
         _requirement.description = "Test Requirement"
-        DUT.do_update(1, table="requirement")
+
+        pub.sendMessage("request_update_requirement", node_id=1, table="requirement")
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_requirement")
 
     @pytest.mark.integration
-    def test_do_update_all(self, test_program_dao):
+    def test_do_update_all(self, test_datamanager):
         """do_update_all() should update all the functions in the database."""
-        DUT = dmRequirement()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
+        pub.subscribe(self.on_succeed_update_all, "succeed_update_all")
 
-        _requirement = DUT.do_select(1, table="requirement")
+        _requirement = test_datamanager.do_select(1, table="requirement")
         _requirement.description = "Big test requirement #1"
-        _requirement = DUT.do_select(2, table="requirement")
+        _requirement = test_datamanager.do_select(2, table="requirement")
         _requirement.description = "Big test requirement #2"
 
         pub.sendMessage("request_update_all_requirements")
 
         assert (
-            DUT.do_select(1, table="requirement").description
+            test_datamanager.do_select(1, table="requirement").description
             == "Big test requirement #1"
         )
         assert (
-            DUT.do_select(2, table="requirement").description
+            test_datamanager.do_select(2, table="requirement").description
             == "Big test requirement #2"
         )
 
+        pub.unsubscribe(self.on_succeed_update_all, "succeed_update_all")
+
     @pytest.mark.integration
-    def test_do_update_wrong_data_type(self, test_program_dao):
+    def test_do_update_wrong_data_type(self, test_datamanager):
         """do_update() should return a non-zero error code when passed a
         Requirement ID that doesn't exist."""
         pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_requirement")
 
-        DUT = dmRequirement()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        _requirement = DUT.do_select(1, table="requirement")
+        _requirement = test_datamanager.do_select(1, table="requirement")
         _requirement.priority = {1: 2}
 
-        DUT.do_update(1, table="requirement")
+        pub.sendMessage("request_update_requirement", node_id=1, table="requirement")
 
         pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_requirement")
 
     @pytest.mark.integration
-    def test_do_update_root_node(self, test_program_dao):
+    def test_do_update_root_node_wrong_data_type(self, test_datamanager):
         """do_update() should return a non-zero error code when passed a
         Requirement ID that doesn't exist."""
-        DUT = dmRequirement()
-        DUT.do_connect(test_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        _requirement = DUT.do_select(1, table="requirement")
+        pub.subscribe(
+            self.on_fail_update_root_node_wrong_data_type, "fail_update_requirement"
+        )
+
+        _requirement = test_datamanager.do_select(1, table="requirement")
         _requirement.priority = {1: 2}
 
-        DUT.do_update(0, table="requirement")
+        pub.sendMessage("request_update_requirement", node_id=0, table="requirement")
+
+        pub.unsubscribe(
+            self.on_fail_update_root_node_wrong_data_type, "fail_update_requirement"
+        )
+
+    @pytest.mark.integration
+    def test_do_update_non_existent_id(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a
+        Requirement ID that doesn't exist."""
+        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_requirement")
+
+        pub.sendMessage("request_update_requirement", node_id=100, table="requirement")
+
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_requirement")
+
+    @pytest.mark.integration
+    def test_do_update_no_data_package(self, test_datamanager):
+        """do_update() should send the fail_update_requirement message when
+        there is no data package attached to the node."""
+        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_requirement")
+
+        test_datamanager.tree.get_node(1).data.pop("requirement")
+        pub.sendMessage("request_update_requirement", node_id=1, table="requirement")
+
+        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_requirement")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestGetterSetter:
+    """Class for testing methods that get or set."""
+
+    def on_succeed_get_attributes(self, attributes):
+        assert isinstance(attributes, dict)
+        assert attributes["requirement_id"] == 1
+        assert attributes["description"] == ""
+        assert attributes["priority"] == 0
+        print("\033[36m\nsucceed_get_requirement_attributes topic was broadcast")
+
+    def on_succeed_get_data_manager_tree(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data, dict)
+        assert isinstance(tree.get_node(1).data["requirement"], RAMSTKRequirement)
+        print("\033[36m\nsucceed_get_requirement_tree topic was broadcast")
+
+    def on_succeed_set_attributes(self, tree):
+        assert isinstance(tree, Tree)
+        assert tree.get_node(1).data["requirement"].requirement_code == "REQ-0001"
+        print("\033[36m\nsucceed_get_requirement_tree topic was broadcast")
+
+    def on_succeed_set_attributes_default(self, tree):
+        assert isinstance(tree, Tree)
+        assert tree.get_node(1).data["requirement"].validated_date == date.today()
+        print("\033[36m\nsucceed_get_requirement_tree topic was broadcast")
+
+    def on_succeed_create_code(self, requirement_code):
+        assert requirement_code == "DOYLE-0001"
+        print("\033[36m\nsucceed_create_requirement_code topic was " "broadcast")
+
+    def on_fail_create_code_non_existent_id(self, error_message):
+        assert error_message == (
+            "do_create_code: No data package found for " "requirement ID 10."
+        )
+        print("\033[36m\nfail_create_requirement_code topic was broadcast")
+
+    @pytest.mark.unit
+    def test_do_get_attributes(self, test_datamanager):
+        """_do_get_attributes() should return a dict of requirement attributes
+        on success."""
+        pub.subscribe(
+            self.on_succeed_get_attributes, "succeed_get_requirement_attributes"
+        )
+
+        pub.sendMessage(
+            "request_get_requirement_attributes", node_id=1, table="requirement"
+        )
+
+        pub.unsubscribe(
+            self.on_succeed_get_attributes, "succeed_get_requirement_attributes"
+        )
+
+    @pytest.mark.unit
+    def test_on_get_data_manager_tree(self, test_datamanager):
+        """on_get_tree() should return the requirement treelib Tree."""
+        pub.subscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_requirements_tree"
+        )
+
+        pub.sendMessage("request_get_requirements_tree")
+
+        pub.unsubscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_requirements_tree"
+        )
+
+    @pytest.mark.integration
+    def test_do_set_attributes(self, test_datamanager):
+        """do_set_attributes() should send the success message."""
+        pub.subscribe(self.on_succeed_set_attributes, "succeed_get_requirements_tree")
+
+        pub.sendMessage(
+            "request_set_requirement_attributes",
+            node_id=[1, -1],
+            package={"requirement_code": "REQ-0001"},
+        )
+
+        pub.unsubscribe(self.on_succeed_set_attributes, "succeed_get_requirements_tree")
+
+    @pytest.mark.integration
+    def test_do_set_attributes_default(self, test_datamanager):
+        """do_set_attributes() should set validation date to today() if no
+        value is passed."""
+        pub.subscribe(
+            self.on_succeed_set_attributes_default, "succeed_get_requirements_tree"
+        )
+
+        pub.sendMessage(
+            "request_set_requirement_attributes",
+            node_id=[1, -1],
+            package={"validated_date": None},
+        )
+
+        pub.unsubscribe(
+            self.on_succeed_set_attributes_default, "succeed_get_requirements_tree"
+        )
+
+    @pytest.mark.integration
+    def test_do_create_code(self, test_datamanager):
+        """do_create_requirement_code() should return."""
+        pub.subscribe(self.on_succeed_create_code, "succeed_create_requirement_code")
+
+        pub.sendMessage("request_create_requirement_code", node_id=1, prefix="DOYLE")
+
+        pub.unsubscribe(self.on_succeed_create_code, "succeed_create_requirement_code")
+
+    @pytest.mark.integration
+    def test_do_create_code_non_existent_id(self, test_datamanager):
+        """do_create_requirement_code() should send the fail message when there
+        is no node in the tree for the passed Requirement ID."""
+        pub.subscribe(
+            self.on_fail_create_code_non_existent_id, "fail_create_requirement_code"
+        )
+
+        pub.sendMessage("request_create_requirement_code", node_id=10, prefix="DOYLE")
+
+        pub.unsubscribe(
+            self.on_fail_create_code_non_existent_id, "fail_create_requirement_code"
+        )
+
+    @pytest.mark.integration
+    def test_do_create_all_codes(self, test_datamanager):
+        """do_create_requirement_code() should return."""
+        pub.sendMessage("request_create_all_requirement_codes", prefix="DOYLE")
+
+        assert (
+            test_datamanager.tree.get_node(2).data["requirement"].requirement_code
+            == "DOYLE-0002"
+        )

--- a/tests/controllers/requirement/requirement_unit_test.py
+++ b/tests/controllers/requirement/requirement_unit_test.py
@@ -16,7 +16,7 @@ from datetime import date
 import pytest
 
 # noinspection PyUnresolvedReferences
-from mocks import MockDAO
+from mocks import MockDAO, MockRAMSTKRequirement
 from pubsub import pub
 from treelib import Tree
 
@@ -28,7 +28,7 @@ from ramstk.models.programdb import RAMSTKRequirement
 
 @pytest.fixture
 def mock_program_dao(monkeypatch):
-    _requirement_1 = RAMSTKRequirement()
+    _requirement_1 = MockRAMSTKRequirement()
     _requirement_1.revision_id = 1
     _requirement_1.requirement_id = 1
     _requirement_1.derived = 0
@@ -78,7 +78,7 @@ def mock_program_dao(monkeypatch):
     _requirement_1.q_verifiable_4 = 0
     _requirement_1.q_verifiable_5 = 0
 
-    _requirement_2 = RAMSTKRequirement()
+    _requirement_2 = MockRAMSTKRequirement()
     _requirement_2.revision_id = 1
     _requirement_2.requirement_id = 2
     _requirement_2.derived = 1
@@ -175,7 +175,7 @@ class TestSelectMethods:
     def on_succeed_select_all(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(tree.get_node(1).data, dict)
-        assert isinstance(tree.get_node(1).data["requirement"], RAMSTKRequirement)
+        assert isinstance(tree.get_node(1).data["requirement"], MockRAMSTKRequirement)
 
         print("\033[36m\nsucceed_retrieve_requirements topic was broadcast.")
 
@@ -214,7 +214,7 @@ class TestSelectMethods:
 
         _requirement = DUT.do_select(1, table="requirement")
 
-        assert isinstance(_requirement, RAMSTKRequirement)
+        assert isinstance(_requirement, MockRAMSTKRequirement)
         assert _requirement.description == ""
         assert _requirement.priority == 0
 
@@ -316,7 +316,7 @@ class TestGetterSetter:
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(tree.get_node(1).data, dict)
-        assert isinstance(tree.get_node(1).data["requirement"], RAMSTKRequirement)
+        assert isinstance(tree.get_node(1).data["requirement"], MockRAMSTKRequirement)
         print("\033[36m\nsucceed_get_requirement_tree topic was broadcast")
 
     def on_succeed_create_code(self, requirement_code):

--- a/tests/controllers/requirement/requirement_unit_test.py
+++ b/tests/controllers/requirement/requirement_unit_test.py
@@ -137,6 +137,32 @@ def mock_program_dao(monkeypatch):
     yield DAO
 
 
+@pytest.fixture(scope="function")
+def test_datamanager(mock_program_dao):
+    """Get a data manager instance for each test function."""
+    # Create the device under test (dut) and connect to the database.
+    dut = dmRequirement()
+    dut.do_connect(mock_program_dao)
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_requirement_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_requirement_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "mvw_editing_requirement")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_requirement")
+    pub.unsubscribe(dut.do_update, "request_update_requirement")
+    pub.unsubscribe(dut.do_create_all_codes, "request_create_all_requirement_codes")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_get_tree, "request_get_requirements_tree")
+    pub.unsubscribe(dut.do_create_code, "request_create_requirement_code")
+    pub.unsubscribe(dut._do_delete, "request_delete_requirement")
+    pub.unsubscribe(dut._do_insert_requirement, "request_insert_requirement")
+
+    # Delete the device under test.
+    del dut
+
+
 class TestCreateControllers:
     """Class for controller initialization test suite."""
 
@@ -168,7 +194,21 @@ class TestCreateControllers:
             DUT._do_insert_requirement, "request_insert_requirement"
         )
 
+        # Unsubscribe from pypubsub topics.
+        pub.unsubscribe(DUT.do_get_attributes, "request_get_requirement_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "request_set_requirement_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "mvw_editing_requirement")
+        pub.unsubscribe(DUT.do_set_attributes, "wvw_editing_requirement")
+        pub.unsubscribe(DUT.do_update, "request_update_requirement")
+        pub.unsubscribe(DUT.do_create_all_codes, "request_create_all_requirement_codes")
+        pub.unsubscribe(DUT.do_select_all, "selected_revision")
+        pub.unsubscribe(DUT.do_get_tree, "request_get_requirements_tree")
+        pub.unsubscribe(DUT.do_create_code, "request_create_requirement_code")
+        pub.unsubscribe(DUT._do_delete, "request_delete_requirement")
+        pub.unsubscribe(DUT._do_insert_requirement, "request_insert_requirement")
 
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestSelectMethods:
     """Class for testing data manager select_all() and select() methods."""
 
@@ -180,363 +220,107 @@ class TestSelectMethods:
         print("\033[36m\nsucceed_retrieve_requirements topic was broadcast.")
 
     @pytest.mark.unit
-    def test_do_select_all(self, mock_program_dao):
+    def test_do_select_all(self, test_datamanager):
         """do_select_all() should return a Tree object populated with
         RAMSTKRequirement instances on success."""
-        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_requirements")
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_requirements")
+        assert isinstance(test_datamanager.tree, Tree)
+        assert isinstance(test_datamanager.tree.get_node(1).data, dict)
+        assert isinstance(
+            test_datamanager.tree.get_node(1).data["requirement"], MockRAMSTKRequirement
+        )
 
     @pytest.mark.unit
-    def test_do_select_all_populated_tree(self, mock_program_dao):
+    def test_do_select_all_populated_tree(self, test_datamanager):
         """do_select_all() should clear the existing Tree when a new group of
         requirements is selected."""
         pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_requirements")
 
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
         pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_requirements")
 
     @pytest.mark.unit
-    def test_do_select(self, mock_program_dao):
+    def test_do_select(self, test_datamanager):
         """do_select() should return an instance of the RAMSTKRequirement on
         success."""
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
-        _requirement = DUT.do_select(1, table="requirement")
+        _requirement = test_datamanager.do_select(1, table="requirement")
 
         assert isinstance(_requirement, MockRAMSTKRequirement)
         assert _requirement.description == ""
         assert _requirement.priority == 0
 
     @pytest.mark.unit
-    def test_do_select_unknown_table(self, mock_program_dao):
+    def test_do_select_unknown_table(self, test_datamanager):
         """do_select() should raise a KeyError when an unknown table name is
         requested."""
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
         with pytest.raises(KeyError):
-            DUT.do_select(1, table="scibbidy-bibbidy-doo")
+            test_datamanager.do_select(1, table="scibbidy-bibbidy-doo")
 
     @pytest.mark.unit
-    def test_do_select_non_existent_id(self, mock_program_dao):
+    def test_do_select_non_existent_id(self, test_datamanager):
         """do_select() should return None when a non-existent Requirement ID is
         requested."""
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
 
-        assert DUT.do_select(100, table="requirement") is None
+        assert test_datamanager.do_select(100, table="requirement") is None
 
 
-class TestDeleteMethods:
-    """Class for testing the data manager delete() method."""
-
-    def on_succeed_delete(self, tree):
-        assert isinstance(tree, Tree)
-        print("\033[36m\nsucceed_delete_requirement topic was broadcast.")
-
-    def on_fail_delete_non_existent_id(self, error_message):
-        assert error_message == (
-            "_do_delete: Attempted to delete non-existent requirement ID 300."
-        )
-        print("\033[35m\nfail_delete_requirement topic was broadcast.")
-
-    def on_fail_delete_not_in_tree(self, error_message):
-        assert error_message == (
-            "_do_delete: Attempted to delete non-existent requirement ID 2."
-        )
-        print("\033[35m\nfail_delete_requirement topic was broadcast.")
-
-    @pytest.mark.unit
-    def test_do_delete(self, mock_program_dao):
-        """_do_delete() should send the success message with the treelib
-        Tree."""
-        pub.subscribe(self.on_succeed_delete, "succeed_delete_requirement")
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_delete(DUT.last_id)
-
-        assert DUT.last_id == 1
-
-        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_requirement")
-
-    @pytest.mark.unit
-    def test_do_delete_non_existent_id(self, mock_program_dao):
-        """_do_delete() should send the fail message when attempting to delete
-        a non-existent requirement."""
-        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_requirement")
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_delete(300)
-
-        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_requirement")
-
-    @pytest.mark.unit
-    def test_do_delete_not_in_tree(self, mock_program_dao):
-        """_do_delete() should send the fail message when attempting to remove
-        a node that doesn't exist from the tree even if it exists in the
-        database."""
-        pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_requirement")
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.tree.remove_node(2)
-        DUT._do_delete(2)
-
-        pub.unsubscribe(self.on_fail_delete_not_in_tree, "fail_delete_requirement")
-
-
-class TestGetterSetter:
-    """Class for testing methods that get or set."""
-
-    def on_succeed_get_attributes(self, attributes):
-        assert isinstance(attributes, dict)
-        assert attributes["requirement_id"] == 1
-        assert attributes["description"] == ""
-        assert attributes["priority"] == 0
-        print("\033[36m\nsucceed_get_requirement_attributes topic was broadcast")
-
-    def on_succeed_get_data_manager_tree(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data, dict)
-        assert isinstance(tree.get_node(1).data["requirement"], MockRAMSTKRequirement)
-        print("\033[36m\nsucceed_get_requirement_tree topic was broadcast")
-
-    def on_succeed_create_code(self, requirement_code):
-        assert requirement_code == "DOYLE-0001"
-        print("\033[36m\nsucceed_create_requirement_code topic was " "broadcast")
-
-    def on_fail_create_code_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_create_code: No data package found for " "requirement ID 10."
-        )
-        print("\033[36m\nfail_create_requirement_code topic was broadcast")
-
-    @pytest.mark.unit
-    def test_do_get_attributes(self, mock_program_dao):
-        """_do_get_attributes() should return a dict of requirement attributes
-        on success."""
-        pub.subscribe(
-            self.on_succeed_get_attributes, "succeed_get_requirement_attributes"
-        )
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_get_attributes(1, "requirement")
-
-        pub.unsubscribe(
-            self.on_succeed_get_attributes, "succeed_get_requirement_attributes"
-        )
-
-    @pytest.mark.unit
-    def test_do_set_attributes(self, mock_program_dao):
-        """do_set_attributes() should send the success message."""
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        DUT.do_set_attributes(node_id=[1, -1], package={"requirement_code": "REQ-0001"})
-        assert DUT.do_select(1, table="requirement").requirement_code == "REQ-0001"
-
-    @pytest.mark.unit
-    def test_do_set_attributes_default(self, mock_program_dao):
-        """do_set_attributes() should set validation date to today() if no
-        value is passed."""
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        pub.sendMessage(
-            "request_set_requirement_attributes",
-            node_id=[1, -1],
-            package={"validated_date": None},
-        )
-        assert DUT.do_select(1, table="requirement").validated_date == date.today()
-
-    @pytest.mark.unit
-    def test_on_get_data_manager_tree(self, mock_program_dao):
-        """on_get_tree() should return the requirement treelib Tree."""
-        pub.subscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_requirements_tree"
-        )
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_get_tree()
-
-        pub.unsubscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_requirements_tree"
-        )
-
-    @pytest.mark.unit
-    def test_do_create_code(self, mock_program_dao):
-        """do_create_requirement_code() should return."""
-        pub.subscribe(self.on_succeed_create_code, "succeed_create_requirement_code")
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        pub.sendMessage("request_create_requirement_code", node_id=1, prefix="DOYLE")
-
-        pub.unsubscribe(self.on_succeed_create_code, "succeed_create_requirement_code")
-
-    @pytest.mark.unit
-    def test_do_create_code_non_existent_id(self, mock_program_dao):
-        """do_create_requirement_code() should send the fail message when there
-        is no node in the tree for the passed Requirement ID."""
-        pub.subscribe(
-            self.on_fail_create_code_non_existent_id, "fail_create_requirement_code"
-        )
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        pub.sendMessage("request_create_requirement_code", node_id=10, prefix="DOYLE")
-
-        pub.unsubscribe(
-            self.on_fail_create_code_non_existent_id, "fail_create_requirement_code"
-        )
-
-    @pytest.mark.unit
-    def test_do_create_all_codes(self, mock_program_dao):
-        """do_create_requirement_code() should return."""
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-
-        pub.sendMessage("request_create_all_requirement_codes", prefix="DOYLE")
-
-        assert DUT.tree.get_node(2).data["requirement"].requirement_code == "DOYLE-0002"
-
-
+@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
 
-    def on_succeed_insert_sibling(self, node_id, tree):
-        assert node_id == 3
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(3).data["requirement"], RAMSTKRequirement)
-        assert tree.get_node(3).data["requirement"].requirement_id == 3
-        assert tree.get_node(3).data["requirement"].description == "New Requirement"
-
-        print("\033[36m\nsucceed_insert_requirement topic was broadcast")
-
-    def on_succeed_insert_child(self, node_id, tree):
-        assert node_id == 3
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(3).data["requirement"], RAMSTKRequirement)
-        assert tree.get_node(3).data["requirement"].parent_id == 1
-        assert tree.get_node(3).data["requirement"].requirement_id == 3
-        assert tree.get_node(3).data["requirement"].description == "New Requirement"
-        print("\033[36m\nsucceed_insert_requirement topic was broadcast")
-
-    def on_fail_insert_no_parent(self, error_message):
-        assert error_message == (
-            "_do_insert_requirement: Attempted to insert child requirement "
-            "under non-existent requirement ID 32."
-        )
-        print("\033[35m\nfail_insert_requirement topic was broadcast")
-
     @pytest.mark.unit
-    def test_do_insert_sibling(self, mock_program_dao):
+    def test_do_insert_sibling(self, test_datamanager):
         """do_insert() should send the success message after successfully
         inserting a new top-level requirement."""
-        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_requirement")
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+        test_datamanager._do_insert_requirement(parent_id=0)
 
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_insert_requirement(parent_id=0)
-
-        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_requirement")
+        assert isinstance(test_datamanager.tree, Tree)
+        assert isinstance(
+            test_datamanager.tree.get_node(3).data["requirement"], RAMSTKRequirement
+        )
+        assert test_datamanager.tree.get_node(3).data["requirement"].requirement_id == 3
+        assert (
+            test_datamanager.tree.get_node(3).data["requirement"].description
+            == "New Requirement"
+        )
 
     @pytest.mark.unit
-    def test_do_insert_child(self, mock_program_dao):
+    def test_do_insert_child(self, test_datamanager):
         """do_insert() should send the success message after successfully
         inserting a new child requirement."""
-        pub.subscribe(self.on_succeed_insert_child, "succeed_insert_requirement")
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+        test_datamanager._do_insert_requirement(parent_id=1)
 
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_insert_requirement(parent_id=1)
-
-        pub.unsubscribe(self.on_succeed_insert_child, "succeed_insert_requirement")
-
-    @pytest.mark.unit
-    def test_do_insert_no_parent(self, mock_program_dao):
-        """do_insert() should send the fail message attempting to add a child
-        to a non-existent requirement."""
-        pub.subscribe(self.on_fail_insert_no_parent, "fail_insert_requirement")
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT._do_insert_requirement(parent_id=32)
-
-        pub.unsubscribe(self.on_fail_insert_no_parent, "fail_insert_requirement")
-
-
-class TestUpdateMethods:
-    """Class for testing update() and update_all() methods."""
-
-    def on_fail_update_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_update: Attempted to save non-existent requirement with "
-            "requirement ID 100."
+        assert isinstance(test_datamanager.tree, Tree)
+        assert isinstance(
+            test_datamanager.tree.get_node(3).data["requirement"], RAMSTKRequirement
         )
-        print("\033[35m\nfail_update_requirement topic was broadcast")
-
-    def on_fail_update_no_data_package(self, error_message):
-        assert error_message == (
-            "do_update: No data package found for requirement ID 1."
+        assert test_datamanager.tree.get_node(3).data["requirement"].parent_id == 1
+        assert test_datamanager.tree.get_node(3).data["requirement"].requirement_id == 3
+        assert (
+            test_datamanager.tree.get_node(3).data["requirement"].description
+            == "New Requirement"
         )
-        print("\033[35m\nfail_update_requirement topic was broadcast")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
 
     @pytest.mark.unit
-    def test_do_update_non_existent_id(self, mock_program_dao):
-        """do_update() should return a non-zero error code when passed a
-        Requirement ID that doesn't exist."""
-        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_requirement")
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should send the success message with the treelib
+        Tree."""
+        test_datamanager.do_select_all(attributes={"revision_id": 1})
+        test_datamanager._do_delete(test_datamanager.last_id)
 
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.do_update(100, table="requirement")
-
-        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_requirement")
-
-    @pytest.mark.unit
-    def test_do_update_no_data_package(self, mock_program_dao):
-        """do_update() should send the fail_update_requirement message when
-        there is no data package attached to the node."""
-        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_requirement")
-
-        DUT = dmRequirement()
-        DUT.do_connect(mock_program_dao)
-        DUT.do_select_all(attributes={"revision_id": 1})
-        DUT.tree.get_node(1).data.pop("requirement")
-        DUT.do_update(1, table="requirement")
-
-        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_requirement")
+        assert test_datamanager.last_id == 1

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -26,6 +26,7 @@ from .mock_ramstkopload import MockRAMSTKOpLoad
 from .mock_ramstkopstress import MockRAMSTKOpStress
 from .mock_ramstkprograminfo import MockRAMSTKProgramInfo
 from .mock_ramstkprogramstatus import MockRAMSTKProgramStatus
+from .mock_ramstkrequirement import MockRAMSTKRequirement
 from .mock_ramstkrevision import MockRAMSTKRevision
 from .mock_ramstksiteinfo import MockRAMSTKSiteInfo
 from .MockDAO import MockDAO

--- a/tests/mocks/mock_ramstkrequirement.py
+++ b/tests/mocks/mock_ramstkrequirement.py
@@ -1,0 +1,170 @@
+# Standard Library Imports
+from datetime import date
+
+# RAMSTK Package Imports
+from ramstk.utilities import none_to_default
+
+# RAMSTK Local Imports
+from . import MockRAMSTKBaseTable
+
+
+class MockRAMSTKRequirement(MockRAMSTKBaseTable):
+    __defaults__ = {
+        "derived": 0,
+        "description": "",
+        "figure_number": "",
+        "owner": 0,
+        "page_number": "",
+        "parent_id": 0,
+        "priority": 0,
+        "requirement_code": "",
+        "specification": "",
+        "requirement_type": 0,
+        "validated": 0,
+        "validated_date": date.today(),
+        "q_clarity_0": 0,
+        "q_clarity_1": 0,
+        "q_clarity_2": 0,
+        "q_clarity_3": 0,
+        "q_clarity_4": 0,
+        "q_clarity_5": 0,
+        "q_clarity_6": 0,
+        "q_clarity_7": 0,
+        "q_clarity_8": 0,
+        "q_complete_0": 0,
+        "q_complete_1": 0,
+        "q_complete_2": 0,
+        "q_complete_3": 0,
+        "q_complete_4": 0,
+        "q_complete_5": 0,
+        "q_complete_6": 0,
+        "q_complete_7": 0,
+        "q_complete_8": 0,
+        "q_complete_9": 0,
+        "q_consistent_0": 0,
+        "q_consistent_1": 0,
+        "q_consistent_2": 0,
+        "q_consistent_3": 0,
+        "q_consistent_4": 0,
+        "q_consistent_5": 0,
+        "q_consistent_6": 0,
+        "q_consistent_7": 0,
+        "q_consistent_8": 0,
+        "q_verifiable_0": 0,
+        "q_verifiable_1": 0,
+        "q_verifiable_2": 0,
+        "q_verifiable_3": 0,
+        "q_verifiable_4": 0,
+        "q_verifiable_5": 0,
+    }
+
+    def __init__(self):
+        self.revision_id = 0
+        self.requirement_id = 0
+        self.derived = self.__defaults__["derived"]
+        self.description = self.__defaults__["description"]
+        self.figure_number = self.__defaults__["figure_number"]
+        self.owner = self.__defaults__["owner"]
+        self.page_number = self.__defaults__["page_number"]
+        self.parent_id = self.__defaults__["parent_id"]
+        self.priority = self.__defaults__["priority"]
+        self.requirement_code = self.__defaults__["requirement_code"]
+        self.specification = self.__defaults__["specification"]
+        self.requirement_type = self.__defaults__["requirement_type"]
+        self.validated = self.__defaults__["validated"]
+        self.validated_date = self.__defaults__["validated_date"]
+        self.q_clarity_0 = self.__defaults__["q_clarity_0"]
+        self.q_clarity_1 = self.__defaults__["q_clarity_1"]
+        self.q_clarity_2 = self.__defaults__["q_clarity_2"]
+        self.q_clarity_3 = self.__defaults__["q_clarity_3"]
+        self.q_clarity_4 = self.__defaults__["q_clarity_4"]
+        self.q_clarity_5 = self.__defaults__["q_clarity_5"]
+        self.q_clarity_6 = self.__defaults__["q_clarity_6"]
+        self.q_clarity_7 = self.__defaults__["q_clarity_7"]
+        self.q_clarity_8 = self.__defaults__["q_clarity_8"]
+        self.q_complete_0 = self.__defaults__["q_complete_0"]
+        self.q_complete_1 = self.__defaults__["q_complete_1"]
+        self.q_complete_2 = self.__defaults__["q_complete_2"]
+        self.q_complete_3 = self.__defaults__["q_complete_3"]
+        self.q_complete_4 = self.__defaults__["q_complete_4"]
+        self.q_complete_5 = self.__defaults__["q_complete_5"]
+        self.q_complete_6 = self.__defaults__["q_complete_6"]
+        self.q_complete_7 = self.__defaults__["q_complete_7"]
+        self.q_complete_8 = self.__defaults__["q_complete_8"]
+        self.q_complete_9 = self.__defaults__["q_complete_9"]
+        self.q_consistent_0 = self.__defaults__["q_consistent_0"]
+        self.q_consistent_1 = self.__defaults__["q_consistent_1"]
+        self.q_consistent_2 = self.__defaults__["q_consistent_2"]
+        self.q_consistent_3 = self.__defaults__["q_consistent_3"]
+        self.q_consistent_4 = self.__defaults__["q_consistent_4"]
+        self.q_consistent_5 = self.__defaults__["q_consistent_5"]
+        self.q_consistent_6 = self.__defaults__["q_consistent_6"]
+        self.q_consistent_7 = self.__defaults__["q_consistent_7"]
+        self.q_consistent_8 = self.__defaults__["q_consistent_8"]
+        self.q_verifiable_0 = self.__defaults__["q_verifiable_0"]
+        self.q_verifiable_1 = self.__defaults__["q_verifiable_1"]
+        self.q_verifiable_2 = self.__defaults__["q_verifiable_2"]
+        self.q_verifiable_3 = self.__defaults__["q_verifiable_3"]
+        self.q_verifiable_4 = self.__defaults__["q_verifiable_4"]
+        self.q_verifiable_5 = self.__defaults__["q_verifiable_5"]
+
+    def get_attributes(self):
+        _attributes = {
+            "revision_id": self.revision_id,
+            "requirement_id": self.requirement_id,
+            "derived": self.derived,
+            "description": self.description,
+            "figure_number": self.figure_number,
+            "owner": self.owner,
+            "page_number": self.page_number,
+            "parent_id": self.parent_id,
+            "priority": self.priority,
+            "requirement_code": self.requirement_code,
+            "specification": self.specification,
+            "requirement_type": self.requirement_type,
+            "validated": self.validated,
+            "validated_date": self.validated_date,
+            "q_clarity_0": self.q_clarity_0,
+            "q_clarity_1": self.q_clarity_1,
+            "q_clarity_2": self.q_clarity_2,
+            "q_clarity_3": self.q_clarity_3,
+            "q_clarity_4": self.q_clarity_4,
+            "q_clarity_5": self.q_clarity_5,
+            "q_clarity_6": self.q_clarity_6,
+            "q_clarity_7": self.q_clarity_7,
+            "q_clarity_8": self.q_clarity_8,
+            "q_complete_0": self.q_complete_0,
+            "q_complete_1": self.q_complete_1,
+            "q_complete_2": self.q_complete_2,
+            "q_complete_3": self.q_complete_3,
+            "q_complete_4": self.q_complete_4,
+            "q_complete_5": self.q_complete_5,
+            "q_complete_6": self.q_complete_6,
+            "q_complete_7": self.q_complete_7,
+            "q_complete_8": self.q_complete_8,
+            "q_complete_9": self.q_complete_9,
+            "q_consistent_0": self.q_consistent_0,
+            "q_consistent_1": self.q_consistent_1,
+            "q_consistent_2": self.q_consistent_2,
+            "q_consistent_3": self.q_consistent_3,
+            "q_consistent_4": self.q_consistent_4,
+            "q_consistent_5": self.q_consistent_5,
+            "q_consistent_6": self.q_consistent_6,
+            "q_consistent_7": self.q_consistent_7,
+            "q_consistent_8": self.q_consistent_8,
+            "q_verifiable_0": self.q_verifiable_0,
+            "q_verifiable_1": self.q_verifiable_1,
+            "q_verifiable_2": self.q_verifiable_2,
+            "q_verifiable_3": self.q_verifiable_3,
+            "q_verifiable_4": self.q_verifiable_4,
+            "q_verifiable_5": self.q_verifiable_5,
+        }
+
+        return _attributes
+
+    def create_code(self, prefix: str) -> None:
+        _zeds = 4 - len(str(self.requirement_id))
+        _pad = "0" * _zeds
+        _code = "{0:s}-{1:s}{2:d}".format(prefix, _pad, self.requirement_id)
+
+        self.requirement_code = str(none_to_default(_code, ""))


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.
  - [ ] Followed in new code.
  - [ ] Corrected in existing code whenever possible.
  - [ ] Spelling and English grammar errors have been eliminated.
  - [ ] Attribute and variable names make sense.
  - [ ] Stub files created or updated.
  - [ ] New code is readable.
  - [ ] Execute 'make maintain' before committing changes and fix any issues.
  - [ ] Code is not overly complicated; refactor if it is.
  - [ ] Debugging, including print(), statements have been removed.

- Tests
  - [ ] At least one test for all newly created functions/methods?
  - [ ] Tests capture key use cases.
  - [ ] Enough edge cases covered for comfort.
  - [ ] Code coverage has not decreased.

- Documentation
  - [ ] Update api documentation to reflect the changes made.
  - [ ] Update the user documentation to reflect the changes made.

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [ ] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [ ] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [ ] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [ ] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
