### PR TITLE
test: clean up Revision test suite

### DIFF
--- a/tests/controllers/revision/revision_integration_test.py
+++ b/tests/controllers/revision/revision_integration_test.py
@@ -16,6 +16,7 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.controllers import dmRevision
+from ramstk.models.programdb import RAMSTKRevision
 
 
 @pytest.fixture(scope="class")
@@ -41,6 +42,121 @@ def test_datamanager(test_program_dao):
 
 
 @pytest.mark.usefixtures("test_datamanager")
+class TestSelectMethods:
+    """Class for testing data manager select_all() and select() methods."""
+
+    def on_succeed_select_all(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data, dict)
+        assert isinstance(tree.get_node(1).data["revision"], RAMSTKRevision)
+        print("\033[36m\nsucceed_retrieve_revision topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_select_all_populated_tree(self, test_datamanager):
+        """do_select() should clear any existing tree when selecting
+        revisions."""
+        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_revisions")
+
+        test_datamanager.do_select_all()
+
+        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_revisions")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestInsertMethods:
+    """Class for testing the data manager insert() method."""
+
+    def on_succeed_insert_sibling(self, node_id, tree):
+        assert node_id == 3
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(3).data["revision"], RAMSTKRevision)
+        assert tree.get_node(3).data["revision"].revision_id == 3
+        assert tree.get_node(3).data["revision"].name == "New Revision"
+
+        print("\033[36m\nsucceed_insert_revision topic was broadcast")
+
+    def on_fail_insert_no_database(self, error_message):
+        assert error_message == (
+            "_do_insert_revision: Failed to insert " "revision into program database."
+        )
+        print("\033[35m\nfail_insert_revision topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_insert_sibling(self, test_datamanager):
+        """_do_insert_revision() should send the success message after
+        successfully inserting a new revision."""
+        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_revision")
+
+        pub.sendMessage("request_insert_revision", parent_id=0)
+
+        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_revision")
+
+    @pytest.mark.integration
+    def test_do_insert_no_database(self):
+        """_do_insert_revision() should send the success message after
+        successfully inserting a new revision."""
+        pub.subscribe(self.on_fail_insert_no_database, "fail_insert_revision")
+
+        DUT = dmRevision()
+        DUT._do_insert_revision()
+
+        pub.unsubscribe(self.on_fail_insert_no_database, "fail_insert_revision")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
+
+    def on_succeed_delete(self, tree):
+        assert isinstance(tree, Tree)
+        print("\033[36m\nsucceed_delete_revision topic was broadcast.")
+
+    def on_fail_delete_non_existent_id(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent revision ID 300."
+        )
+        print("\033[35m\nfail_delete_revision topic was broadcast.")
+
+    def on_fail_delete_not_in_tree(self, error_message):
+        assert error_message == (
+            "_do_delete: Attempted to delete non-existent revision ID 1."
+        )
+        print("\033[35m\nfail_delete_revision topic was broadcast.")
+
+    @pytest.mark.integration
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should send the success message with the treelib
+        Tree."""
+        pub.subscribe(self.on_succeed_delete, "succeed_delete_revision")
+
+        pub.sendMessage("request_delete_revision", node_id=2)
+
+        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_revision")
+
+    @pytest.mark.integration
+    def test_do_delete_non_existent_id(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to delete
+        a non-existent revision."""
+        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_revision")
+
+        pub.sendMessage("request_delete_revision", node_id=300)
+
+        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_revision")
+
+    @pytest.mark.integration
+    def test_do_delete_not_in_tree(self, test_datamanager):
+        """_do_delete() should send the fail message when attempting to remove
+        a node that doesn't exist from the tree even if it exists in the
+        database."""
+        pub.subscribe(self.on_fail_delete_not_in_tree, "fail_delete_revision")
+
+        test_datamanager.tree.remove_node(1)
+        pub.sendMessage("request_delete_revision", node_id=1)
+
+        pub.unsubscribe(self.on_fail_delete_not_in_tree, "fail_delete_revision")
+
+
+@pytest.mark.usefixtures("test_datamanager")
 class TestUpdateMethods:
     """Class to test data controller update methods using actual database."""
 
@@ -49,11 +165,29 @@ class TestUpdateMethods:
         assert tree.get_node(1).data["revision"].name == "Test Revision"
         print("\033[36m\nsucceed_update_revision topic was broadcast")
 
+    def on_succeed_update_all(self):
+        print("\033[36m\nsucceed_update_all topic was broadcast")
+
     def on_fail_update_wrong_data_type(self, error_message):
         assert error_message == (
             "do_update: The value for one or more attributes for revision ID "
             "1 was the wrong type."
         )
+        print("\033[35m\nfail_update_revision topic was broadcast")
+
+    def on_fail_update_root_node_wrong_data_type(self, error_message):
+        assert error_message == ("do_update: Attempting to update the root node 0.")
+        print("\033[35m\nfail_update_revision topic was broadcast")
+
+    def on_fail_update_non_existent_id(self, error_message):
+        assert error_message == (
+            "do_update: Attempted to save non-existent revision with revision "
+            "ID 100."
+        )
+        print("\033[35m\nfail_update_revision topic was broadcast")
+
+    def on_fail_update_no_data_package(self, error_message):
+        assert error_message == ("do_update: No data package found for revision ID 1.")
         print("\033[35m\nfail_update_revision topic was broadcast")
 
     @pytest.mark.integration
@@ -64,7 +198,8 @@ class TestUpdateMethods:
 
         _revision = test_datamanager.do_select(1, table="revision")
         _revision.name = "Test Revision"
-        test_datamanager.do_update(1, table="revision")
+
+        pub.sendMessage("request_update_revision", node_id=1, table="revision")
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_revision")
 
@@ -72,24 +207,18 @@ class TestUpdateMethods:
     def test_do_update_all(self, test_datamanager):
         """do_update() should send the succeed_update_revision message on
         success."""
+        pub.subscribe(self.on_succeed_update_all, "succeed_update_all")
+
         _revision = test_datamanager.do_select(1, table="revision")
-        _revision.name = "Test Revision"
-
-        test_datamanager.do_update(1, table="revision")
-
-        pub.unsubscribe(self.on_succeed_update, "succeed_update_revision")
-
-    @pytest.mark.integration
-    def test_do_update_all(self, test_datamanager):
-        """do_update() should send the succeed_update_revision message on
-        success."""
-        _revision = test_datamanager.do_select(1, table="revision")
-        _revision.name = "Test Revision"
+        _revision.name = "Big test revision"
 
         pub.sendMessage("request_update_all_revisions")
 
-        _revision = test_datamanager.do_select(1, table="revision")
-        assert _revision.name == "Test Revision"
+        assert (
+            test_datamanager.do_select(1, table="revision").name == "Big test revision"
+        )
+
+        pub.unsubscribe(self.on_succeed_update_all, "succeed_update_all")
 
     @pytest.mark.integration
     def test_do_update_wrong_data_type(self, test_datamanager):
@@ -99,12 +228,103 @@ class TestUpdateMethods:
         pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_revision")
 
         test_datamanager.tree.get_node(1).data["revision"].cost = None
-        test_datamanager.do_update(1, table="revision")
+        pub.sendMessage("request_update_revision", node_id=1, table="revision")
 
         pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_revision")
 
     @pytest.mark.integration
-    def test_do_update_root_node(self, test_datamanager):
+    def test_do_update_root_node_wrong_data_type(self, test_datamanager):
         """do_update() should end the fail_update_revision message when passed
         a revision ID that has no data package."""
-        test_datamanager.do_update(0, table="revision")
+        pub.subscribe(
+            self.on_fail_update_root_node_wrong_data_type, "fail_update_revision"
+        )
+
+        pub.sendMessage("request_update_revision", node_id=0, table="revision")
+
+        pub.unsubscribe(
+            self.on_fail_update_root_node_wrong_data_type, "fail_update_revision"
+        )
+
+    @pytest.mark.integration
+    def test_do_update_non_existent_id(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a
+        revision ID that doesn't exist."""
+        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_revision")
+
+        pub.sendMessage("request_update_revision", node_id=100, table="revision")
+
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_revision")
+
+    @pytest.mark.integration
+    def test_do_update_no_data_package(self, test_datamanager):
+        """do_update() should return a non-zero error code when passed a
+        Function ID that has no data package."""
+        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_revision")
+
+        test_datamanager.tree.get_node(1).data.pop("revision")
+        pub.sendMessage("request_update_revision", node_id=1, table="revision")
+
+        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_revision")
+
+
+@pytest.mark.usefixtures("test_datamanager")
+class TestGetterSetter:
+    """Class for testing methods that get or set."""
+
+    def on_succeed_get_attributes(self, attributes):
+        assert isinstance(attributes, dict)
+        assert attributes["revision_id"] == 1
+        assert attributes["name"] == "Test Revision"
+        assert attributes["program_time"] == 0.0
+        print("\033[36m\nsucceed_get_revision_attributes topic was broadcast")
+
+    def on_succeed_get_data_manager_tree(self, tree):
+        assert isinstance(tree, Tree)
+        assert isinstance(tree.get_node(1).data["revision"], RAMSTKRevision)
+        print("\033[36m\nsucceed_get_revision_tree topic was broadcast")
+
+    def on_succeed_set_attributes(self, tree):
+        assert isinstance(tree, Tree)
+        assert tree.get_node(1).data["revision"].revision_code == "ABC"
+        print("\033[36m\nsucceed_get_revision_tree topic was broadcast")
+
+    @pytest.mark.integration
+    def test_do_get_attributes(self, test_datamanager):
+        """_do_get_attributes() should return a dict of revision attributes on
+        success."""
+        pub.subscribe(self.on_succeed_get_attributes, "succeed_get_revision_attributes")
+
+        pub.sendMessage("request_get_revision_attributes", node_id=1, table="revision")
+
+        pub.unsubscribe(
+            self.on_succeed_get_attributes, "succeed_get_revision_attributes"
+        )
+
+    @pytest.mark.integration
+    def test_on_get_data_manager_tree(self, test_datamanager):
+        """on_get_tree() should return the revision treelib Tree."""
+        pub.subscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_revision_tree"
+        )
+
+        pub.sendMessage("request_get_revision_tree")
+
+        pub.unsubscribe(
+            self.on_succeed_get_data_manager_tree, "succeed_get_revision_tree"
+        )
+
+    @pytest.mark.integration
+    def test_do_set_attributes(self, test_datamanager):
+        """do_set_attributes() should send the success message."""
+        pub.subscribe(self.on_succeed_set_attributes, "succeed_get_revision_tree")
+
+        pub.sendMessage(
+            "request_set_revision_attributes",
+            node_id=[1],
+            package={"revision_code": "ABC"},
+        )
+
+        assert test_datamanager.tree.get_node(1).data["revision"].revision_code == "ABC"
+
+        pub.unsubscribe(self.on_succeed_set_attributes, "succeed_get_revision_tree")

--- a/tests/controllers/revision/revision_unit_test.py
+++ b/tests/controllers/revision/revision_unit_test.py
@@ -99,6 +99,14 @@ def test_datamanager(mock_program_dao):
     yield dut
 
     # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_revision_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_revision_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_revision")
+    pub.unsubscribe(dut.do_update, "request_update_revision")
+    pub.unsubscribe(dut.do_get_tree, "request_get_revision_tree")
+    pub.unsubscribe(dut.do_select_all, "request_retrieve_revisions")
+    pub.unsubscribe(dut._do_delete, "request_delete_revision")
+    pub.unsubscribe(dut._do_insert_revision, "request_insert_revision")
 
     # Delete the device under test.
     del dut
@@ -130,6 +138,16 @@ class TestCreateControllers:
         )
         assert pub.isSubscribed(DUT._do_delete, "request_delete_revision")
         assert pub.isSubscribed(DUT._do_insert_revision, "request_insert_revision")
+
+        # Unsubscribe from pypubsub topics.
+        pub.unsubscribe(DUT.do_get_attributes, "request_get_revision_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "request_set_revision_attributes")
+        pub.unsubscribe(DUT.do_set_attributes, "wvw_editing_revision")
+        pub.unsubscribe(DUT.do_update, "request_update_revision")
+        pub.unsubscribe(DUT.do_get_tree, "request_get_revision_tree")
+        pub.unsubscribe(DUT.do_select_all, "request_retrieve_revisions")
+        pub.unsubscribe(DUT._do_delete, "request_delete_revision")
+        pub.unsubscribe(DUT._do_insert_revision, "request_insert_revision")
 
 
 @pytest.mark.usefixtures("test_datamanager")
@@ -185,122 +203,13 @@ class TestSelectMethods:
 
 
 @pytest.mark.usefixtures("test_datamanager")
-class TestDeleteMethods:
-    """Class for testing the data manager delete() method."""
-
-    def on_succeed_delete(self, tree):
-        assert isinstance(tree, Tree)
-        print("\033[36m\nsucceed_delete_revision topic was broadcast.")
-
-    def on_fail_delete_non_existent_id(self, error_message):
-        assert error_message == (
-            "_do_delete: Attempted to delete non-existent revision ID 300."
-        )
-        print("\033[35m\nfail_delete_revision topic was broadcast.")
-
-    @pytest.mark.unit
-    def test_do_delete(self, test_datamanager):
-        """_do_delete() should send the success message with the treelib
-        Tree."""
-        pub.subscribe(self.on_succeed_delete, "succeed_delete_revision")
-
-        test_datamanager.do_select_all()
-        test_datamanager._do_delete(test_datamanager.last_id)
-
-        assert test_datamanager.last_id == 1
-
-        pub.unsubscribe(self.on_succeed_delete, "succeed_delete_revision")
-
-    @pytest.mark.unit
-    def test_do_delete_non_existent_id(self, test_datamanager):
-        """_do_delete() should send the fail message when attempting to delete
-        a non-existent revision."""
-        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_revision")
-
-        test_datamanager.do_select_all()
-        test_datamanager._do_delete(300)
-
-        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_revision")
-
-
-@pytest.mark.usefixtures("test_datamanager")
-class TestGetterSetter:
-    """Class for testing methods that get or set."""
-
-    def on_succeed_get_attributes(self, attributes):
-        assert isinstance(attributes, dict)
-        assert attributes["revision_id"] == 1
-        assert attributes["name"] == "Original Revision"
-        assert attributes["program_time"] == 2562
-        print("\033[36m\nsucceed_get_revision_attributes topic was broadcast")
-
-    def on_succeed_get_data_manager_tree(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(1).data["revision"], MockRAMSTKRevision)
-        print("\033[36m\nsucceed_get_revision_tree topic was broadcast")
-
-    @pytest.mark.unit
-    def test_do_get_attributes(self, test_datamanager):
-        """_do_get_attributes() should return a dict of revision attributes on
-        success."""
-        pub.subscribe(self.on_succeed_get_attributes, "succeed_get_revision_attributes")
-
-        test_datamanager.do_select_all()
-        test_datamanager.do_get_attributes(1, "revision")
-
-        pub.unsubscribe(
-            self.on_succeed_get_attributes, "succeed_get_revision_attributes"
-        )
-
-    @pytest.mark.unit
-    def test_do_set_attributes(self, test_datamanager):
-        """do_set_attributes() should send the success message."""
-        test_datamanager.do_select_all()
-        test_datamanager.do_set_attributes(
-            node_id=[
-                1,
-            ],
-            package={"revision_code": "-"},
-        )
-
-        assert test_datamanager.do_select(1, table="revision").revision_code == "-"
-
-    @pytest.mark.unit
-    def test_on_get_data_manager_tree(self, test_datamanager):
-        """on_get_tree() should return the revision treelib Tree."""
-        pub.subscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_revision_tree"
-        )
-
-        test_datamanager.do_select_all()
-        test_datamanager.do_get_tree()
-
-        pub.unsubscribe(
-            self.on_succeed_get_data_manager_tree, "succeed_get_revision_tree"
-        )
-
-
-@pytest.mark.usefixtures("test_datamanager")
 class TestInsertMethods:
     """Class for testing the data manager insert() method."""
-
-    def on_succeed_insert_sibling(self, node_id, tree):
-        assert node_id == 3
-        assert isinstance(tree, Tree)
-        print("\033[36m\nsucceed_insert_revision topic was broadcast")
-
-    def on_fail_insert_no_database(self, error_message):
-        assert error_message == (
-            "_do_insert_revision: Failed to insert " "revision into program database."
-        )
-        print("\033[35m\nfail_insert_revision topic was broadcast.")
 
     @pytest.mark.unit
     def test_do_insert_sibling(self, test_datamanager):
         """_do_insert_revision() should send the success message after
         successfully inserting a new revision."""
-        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_revision")
-
         test_datamanager.do_select_all()
         test_datamanager._do_insert_revision()
 
@@ -310,54 +219,17 @@ class TestInsertMethods:
         assert test_datamanager.tree.get_node(3).data["revision"].revision_id == 3
         assert test_datamanager.tree.get_node(3).data["revision"].name == "New Revision"
 
-        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_revision")
-
-    @pytest.mark.unit
-    def test_do_insert_no_database(self):
-        """_do_insert_revision() should send the success message after
-        successfully inserting a new revision."""
-        pub.subscribe(self.on_fail_insert_no_database, "fail_insert_revision")
-
-        DUT = dmRevision()
-        DUT._do_insert_revision()
-
-        pub.unsubscribe(self.on_fail_insert_no_database, "fail_insert_revision")
-
 
 @pytest.mark.usefixtures("test_datamanager")
-class TestUpdateMethods:
-    """Class for testing update() and update_all() methods."""
-
-    def on_fail_update_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_update: Attempted to save non-existent revision with revision "
-            "ID 100."
-        )
-        print("\033[35m\nfail_update_revision topic was broadcast")
-
-    def on_fail_update_no_data_package(self, error_message):
-        assert error_message == ("do_update: No data package found for revision ID 1.")
-        print("\033[35m\nfail_update_revision topic was broadcast")
+class TestDeleteMethods:
+    """Class for testing the data manager delete() method."""
 
     @pytest.mark.unit
-    def test_do_update_non_existent_id(self, test_datamanager):
-        """do_update() should return a non-zero error code when passed a
-        revision ID that doesn't exist."""
-        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_revision")
-
+    def test_do_delete(self, test_datamanager):
+        """_do_delete() should send the success message with the treelib
+        Tree."""
         test_datamanager.do_select_all()
-        test_datamanager.do_update(100, table="revision")
+        test_datamanager._do_delete(2)
 
-        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_revision")
-
-    @pytest.mark.unit
-    def test_do_update_no_data_package(self, test_datamanager):
-        """do_update() should return a non-zero error code when passed a
-        Function ID that has no data package."""
-        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_revision")
-
-        test_datamanager.do_select_all()
-        test_datamanager.tree.get_node(1).data.pop("revision")
-        test_datamanager.do_update(1, table="revision")
-
-        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_revision")
+        assert test_datamanager.last_id == 1
+        assert test_datamanager.tree.get_node(2) is None


### PR DESCRIPTION
## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.
  - [ ] Followed in new code.
  - [ ] Corrected in existing code whenever possible.
  - [ ] Spelling and English grammar errors have been eliminated.
  - [ ] Attribute and variable names make sense.
  - [ ] Stub files created or updated.
  - [ ] New code is readable.
  - [ ] Execute 'make maintain' before committing changes and fix any issues.
  - [ ] Code is not overly complicated; refactor if it is.
  - [ ] Debugging, including print(), statements have been removed.

- Tests
  - [ ] At least one test for all newly created functions/methods?
  - [ ] Tests capture key use cases.
  - [ ] Enough edge cases covered for comfort.
  - [ ] Code coverage has not decreased.

- Documentation
  - [ ] Update api documentation to reflect the changes made.
  - [ ] Update the user documentation to reflect the changes made.

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
 decorating the code block.  These # ISSUE: comments are automatically
  converted to issues on successful merge.  Alternatively, you can manually
   raise an issue for each problem area you identify.
  - [ ] TODO and FIXME statements have been have been converted to # ISSUE
 : comments or removed in their entirety.
  - [ ] \# ISSUE: comments have been removed for those issues this PR
   addresses.
  - [ ] Update the features section of README.md for newly added work stream modules.

- All PR checks pass.
  - [ ] Execute 'make format', 'make stylecheck', 'make typecheck', and 'make
   lint' before committing changes and fix any issues.
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Other information
<!-- Provide any other information that is import to this PR such as
screenshots if this impacts the GUI. -->
