### PR TITLE
refactor: remove do_get_tree from Allocation datamanager

### DIFF
--- a/src/ramstk/controllers/allocation/datamanager.py
+++ b/src/ramstk/controllers/allocation/datamanager.py
@@ -5,7 +5,7 @@
 #       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Allocation Package Data Model."""
 
 # Standard Library Imports
@@ -25,7 +25,7 @@ from ramstk.models.programdb import RAMSTKAllocation
 class DataManager(RAMSTKDataManager):
     """Contain the attributes and methods of the Allocation data manager."""
 
-    _tag: str = "allocations"
+    _tag: str = "allocation"
     _root: int = 0
 
     def __init__(self, **kwargs: Dict[str, Any]) -> None:
@@ -54,23 +54,11 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_set_tree, "succeed_calculate_allocation")
         pub.subscribe(super().do_update, "request_update_allocation")
 
-        pub.subscribe(self.do_get_tree, "request_get_allocation_tree")
         pub.subscribe(self.do_select_all, "selected_revision")
         pub.subscribe(self.do_set_all_attributes, "succeed_calculate_allocation_goals")
 
         pub.subscribe(self._do_delete, "request_delete_hardware")
         pub.subscribe(self._do_insert_allocation, "request_insert_allocation")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the allocation treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage(
-            "succeed_get_allocation_tree",
-            tree=self.tree,
-        )
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve the Allocation BoM data from the RAMSTK Program database.

--- a/tests/controllers/allocation/allocation_unit_test.py
+++ b/tests/controllers/allocation/allocation_unit_test.py
@@ -168,7 +168,7 @@ class TestCreateControllers:
         assert isinstance(test_datamanager, dmAllocation)
         assert isinstance(test_datamanager.tree, Tree)
         assert isinstance(test_datamanager.dao, MockDAO)
-        assert test_datamanager._tag == "allocations"
+        assert test_datamanager._tag == "allocation"
         assert test_datamanager._root == 0
         assert pub.isSubscribed(
             test_datamanager.do_get_attributes, "request_get_allocation_attributes"
@@ -180,7 +180,7 @@ class TestCreateControllers:
             test_datamanager.do_set_attributes, "wvw_editing_allocation"
         )
         assert pub.isSubscribed(
-            test_datamanager.do_update_all, "request_update_all_allocations"
+            test_datamanager.do_update_all, "request_update_all_allocation"
         )
         assert pub.isSubscribed(
             test_datamanager.do_get_tree, "request_get_allocation_tree"


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
Remove do_get_tree() method in favor of metclass version.

## Describe how this was implemented.
Deleted do_get_tree() and updated self._tag to be singular.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #587 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
