### PR TITLE
refactor: remove do_get_tree() from Function datamanager

### DIFF
--- a/src/ramstk/controllers/function/datamanager.py
+++ b/src/ramstk/controllers/function/datamanager.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-#       ramstk.controllers.function.datamanager.py is part of The RAMSTK
-#       Project
+#       ramstk.controllers.function.datamanager.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2020 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Function Package Data Model."""
 
 # Standard Library Imports
@@ -29,7 +28,7 @@ class DataManager(RAMSTKDataManager):
     """
 
     # Define private scalar class attributes.
-    _tag = "functions"
+    _tag = "function"
 
     def __init__(self, **kwargs: Dict[Any, Any]) -> None:
         """Initialize a Function data manager instance."""
@@ -55,21 +54,9 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_update, "request_update_function")
 
         pub.subscribe(self.do_select_all, "selected_revision")
-        pub.subscribe(self.do_get_tree, "request_get_functions_tree")
 
         pub.subscribe(self._do_delete, "request_delete_function")
         pub.subscribe(self._do_insert_function, "request_insert_function")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the function treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage(
-            "succeed_get_functions_tree",
-            tree=self.tree,
-        )
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all the Function data from the RAMSTK Program database.
@@ -91,10 +78,10 @@ class DataManager(RAMSTKDataManager):
         ):
 
             self.tree.create_node(
-                tag="function",
+                tag=self._tag,
                 identifier=_function.function_id,
                 parent=_function.parent_id,
-                data={"function": _function},
+                data={self._tag: _function},
             )
 
         self.last_id = max(self.tree.nodes.keys())
@@ -161,10 +148,10 @@ class DataManager(RAMSTKDataManager):
             self.last_id = _function.function_id
 
             self.tree.create_node(
-                tag="function",
+                tag=self._tag,
                 identifier=_function.function_id,
                 parent=_function.parent_id,
-                data={"function": _function},
+                data={self._tag: _function},
             )
 
             pub.sendMessage(

--- a/src/ramstk/exim/export.py
+++ b/src/ramstk/exim/export.py
@@ -40,7 +40,7 @@ class Export:
         # Initialize public scalar attributes.
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(self._do_load_data, "succeed_get_functions_tree")
+        pub.subscribe(self._do_load_data, "succeed_get_function_tree")
         pub.subscribe(self._do_load_data, "succeed_get_requirements_tree")
         pub.subscribe(self._do_load_data, "succeed_get_hardwares_tree")
         pub.subscribe(self._do_load_data, "succeed_get_validations_tree")

--- a/tests/controllers/function/function_integration_test.py
+++ b/tests/controllers/function/function_integration_test.py
@@ -35,7 +35,7 @@ def test_datamanager(test_program_dao):
     pub.unsubscribe(dut.do_set_attributes, "wvw_editing_function")
     pub.unsubscribe(dut.do_update, "request_update_function")
     pub.unsubscribe(dut.do_select_all, "selected_revision")
-    pub.unsubscribe(dut.do_get_tree, "request_get_functions_tree")
+    pub.unsubscribe(dut.do_get_tree, "request_get_function_tree")
     pub.unsubscribe(dut._do_delete, "request_delete_function")
     pub.unsubscribe(dut._do_insert_function, "request_insert_function")
 

--- a/tests/controllers/function/function_unit_test.py
+++ b/tests/controllers/function/function_unit_test.py
@@ -6,7 +6,7 @@
 #       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing function module algorithms and models."""
 
 # Third Party Imports
@@ -96,7 +96,7 @@ def test_datamanager(mock_program_dao):
     pub.unsubscribe(dut.do_set_attributes, "wvw_editing_function")
     pub.unsubscribe(dut.do_update, "request_update_function")
     pub.unsubscribe(dut.do_select_all, "selected_revision")
-    pub.unsubscribe(dut.do_get_tree, "request_get_functions_tree")
+    pub.unsubscribe(dut.do_get_tree, "request_get_function_tree")
     pub.unsubscribe(dut._do_delete, "request_delete_function")
     pub.unsubscribe(dut._do_insert_function, "request_insert_function")
 
@@ -114,19 +114,19 @@ class TestCreateControllers:
         assert isinstance(test_datamanager, dmFunction)
         assert isinstance(test_datamanager.tree, Tree)
         assert isinstance(test_datamanager.dao, MockDAO)
-        assert test_datamanager._tag == "functions"
+        assert test_datamanager._tag == "function"
         assert test_datamanager._root == 0
         assert test_datamanager._revision_id == 0
         assert pub.isSubscribed(test_datamanager.do_select_all, "selected_revision")
         assert pub.isSubscribed(test_datamanager.do_update, "request_update_function")
         assert pub.isSubscribed(
-            test_datamanager.do_update_all, "request_update_all_functions"
+            test_datamanager.do_update_all, "request_update_all_function"
         )
         assert pub.isSubscribed(
             test_datamanager.do_get_attributes, "request_get_function_attributes"
         )
         assert pub.isSubscribed(
-            test_datamanager.do_get_tree, "request_get_functions_tree"
+            test_datamanager.do_get_tree, "request_get_function_tree"
         )
         assert pub.isSubscribed(
             test_datamanager.do_set_attributes, "request_set_function_attributes"

--- a/tests/exim/test_exports.py
+++ b/tests/exim/test_exports.py
@@ -32,10 +32,10 @@ class TestExport:
 
         DUT = Export()
 
-        pub.sendMessage("request_get_functions_tree")
+        pub.sendMessage("request_get_function_tree")
 
         assert isinstance(DUT._dic_output_data, dict)
-        assert isinstance(DUT._dic_output_data["functions"], dict)
+        assert isinstance(DUT._dic_output_data["function"], dict)
 
     @pytest.mark.unit
     def test_do_load_output_requirement(self, test_program_dao):


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have Function datamanager use metaclass methods.

## Describe how this was implemented.
Remove do_get_tree() method from Function datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #593 


## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [ ] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
