### PR TITLE
refactor: remove do_get_tree() from Hazard datamanager

### DIFF
--- a/src/ramstk/controllers/hazards/analysismanager.py
+++ b/src/ramstk/controllers/hazards/analysismanager.py
@@ -77,7 +77,7 @@ class AnalysisManager(RAMSTKAnalysisManager):
             "request_get_hazard_tree",
         )
         pub.sendMessage(
-            "succeed_calculate_hazard",
+            "succeed_calculate_fha",
             node_id=node_id,
         )
 

--- a/src/ramstk/controllers/hazards/datamanager.py
+++ b/src/ramstk/controllers/hazards/datamanager.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-#       ramstk.controllers.hazards.datamanager.py is part of The RAMSTK
-#       Project
+#       ramstk.controllers.hazards.datamanager.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2020 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Hazards Package Data Model."""
 
 # Standard Library Imports
@@ -22,13 +21,9 @@ from ramstk.models.programdb import RAMSTKHazardAnalysis
 
 
 class DataManager(RAMSTKDataManager):
-    """Contain the attributes and methods of the Hazard data manager.
+    """Contain the attributes and methods of the Hazard data manager."""
 
-    This class manages the hazard data from the RAMSTKHazardAnalysis and
-    RAMSTKHazardAnalysis data models.
-    """
-
-    _tag = "hazards"
+    _tag = "hazard"
 
     def __init__(self, **kwargs: Dict[Any, Any]) -> None:
         """Initialize a Hazard data manager instance."""
@@ -53,20 +48,11 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_set_attributes, "wvw_editing_hazard")
         pub.subscribe(super().do_update, "request_update_hazard")
 
-        pub.subscribe(self.do_get_tree, "request_get_hazard_tree")
         pub.subscribe(self.do_select_all, "selected_function")
         pub.subscribe(self.do_set_all_attributes, "request_set_all_hazard_attributes")
 
         pub.subscribe(self._do_delete, "request_delete_hazard")
         pub.subscribe(self._do_insert_hazard, "request_insert_hazard")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the hazard treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage("succeed_get_hazard_tree", tree=self.tree)
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all the Hazard data from the RAMSTK Program database.

--- a/src/ramstk/controllers/hazards/datamanager.py
+++ b/src/ramstk/controllers/hazards/datamanager.py
@@ -124,7 +124,7 @@ class DataManager(RAMSTKDataManager):
         except (AttributeError, DataAccessError, NodeIDAbsentError):
             _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
             _error_msg = (
-                "{1}: Attempted to delete non-existent hazard " "ID {0}."
+                "{1}: Attempted to delete non-existent hazard ID {0}."
             ).format(str(node_id), _method_name)
             pub.sendMessage(
                 "do_log_debug",

--- a/tests/controllers/hazards/hazards_unit_test.py
+++ b/tests/controllers/hazards/hazards_unit_test.py
@@ -127,13 +127,13 @@ class TestCreateControllers:
         assert isinstance(test_datamanager, dmHazards)
         assert isinstance(test_datamanager.tree, Tree)
         assert isinstance(test_datamanager.dao, MockDAO)
-        assert test_datamanager._tag == "hazards"
+        assert test_datamanager._tag == "hazard"
         assert test_datamanager._root == 0
         assert test_datamanager._revision_id == 0
         assert pub.isSubscribed(test_datamanager.do_select_all, "selected_function")
         assert pub.isSubscribed(test_datamanager.do_update, "request_update_hazard")
         assert pub.isSubscribed(
-            test_datamanager.do_update_all, "request_update_all_hazards"
+            test_datamanager.do_update_all, "request_update_all_hazard"
         )
         assert pub.isSubscribed(
             test_datamanager.do_get_attributes, "request_get_hazard_attributes"


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have Hazard datamanager use metaclass methods.

## Describe how this was implemented.
Remove do_get_tree() from Hazards datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #594 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
