### PR TITLE
refactor: remove do_get_tree() from Mode datamanager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,11 +192,11 @@ uninstall:
 	${RM} "$(PREFIX)/share/applications/RAMSTK.desktop"
 
 # Targets for testing.
-test.unit: clean-test
+test.unit:
 	@echo -e "\n\t\033[1;33mRunning RAMSTK unit tests without coverage ...\033[0m\n"
 	py.test $(TESTOPTS) -m unit --no-cov $(TESTFILE)
 
-test.integration: clean-test
+test.integration:
 	@echo -e "\n\t\033[1;33mRunning RAMSTK integration tests without coverage ...\033[0m\n"
 	py.test $(TESTOPTS) -m integration --no-cov $(TESTFILE)
 

--- a/src/ramstk/controllers/mode/datamanager.py
+++ b/src/ramstk/controllers/mode/datamanager.py
@@ -3,7 +3,7 @@
 #       ramstk.controllers.mode.datamanager.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Mode Package Data Controller."""
 
 # Standard Library Imports
@@ -52,21 +52,9 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_update, "request_update_mode")
 
         pub.subscribe(self.do_select_all, "selected_revision")
-        pub.subscribe(self.do_get_tree, "request_get_mode_tree")
 
         pub.subscribe(self._do_delete, "request_delete_mode")
         pub.subscribe(self._do_insert_mode, "request_insert_mode")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the Mode treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage(
-            "succeed_get_mode_tree",
-            tree=self.tree,
-        )
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all the Mode data from the RAMSTK Program database.


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have the Mode datamanager use metaclass methods.

## Describe how this was implemented.
Remove do_get_tree() from Mode datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #598 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
