### PR TITLE
refactor: remove do_get_tree() OpLoad datamanager

### DIFF
--- a/src/ramstk/controllers/opload/datamanager.py
+++ b/src/ramstk/controllers/opload/datamanager.py
@@ -3,7 +3,7 @@
 #       ramstk.controllers.opload.datamanager.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Operating Load Package Data Controller."""
 
 # Standard Library Imports
@@ -63,27 +63,14 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_update, "request_update_opload")
 
         pub.subscribe(self.do_select_all, "selected_mechanism")
-        pub.subscribe(self.do_get_tree, "request_get_opload_tree")
 
         pub.subscribe(self._do_delete, "request_delete_opload")
         pub.subscribe(self._do_insert_opload, "request_insert_opload")
 
-    def do_get_tree(self) -> None:
-        """Retrieve the OpLoad treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage(
-            "succeed_get_opload_tree",
-            tree=self.tree,
-        )
-
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all the OpLoad data from the RAMSTK Program database.
 
-        :param attributes: the attributes dict for the selected
-            failure mode.
+        :param attributes: the attributes dict for the selected failure mode.
         :return: None
         :rtype: None
         """

--- a/tests/controllers/opload/opload_integration_test.py
+++ b/tests/controllers/opload/opload_integration_test.py
@@ -6,7 +6,7 @@
 #       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Class for testing operating load integrations."""
 
 # Third Party Imports

--- a/tests/controllers/opload/opload_unit_test.py
+++ b/tests/controllers/opload/opload_unit_test.py
@@ -6,7 +6,7 @@
 #       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Class for testing Operating Load algorithms and models."""
 
 # Third Party Imports

--- a/tests/controllers/pof/pof_integration_test.py
+++ b/tests/controllers/pof/pof_integration_test.py
@@ -306,6 +306,16 @@ class TestSelectMethods:
 
         pub.unsubscribe(self.on_succeed_on_select_all, "succeed_retrieve_pof")
 
+    @pytest.mark.integration
+    def test_on_select_all_empty_base_tree(
+        self, test_datamanager, test_mechanism, test_opload, test_opstress, test_method
+    ):
+        """should return an empty records tree if the base tree is empty."""
+        test_datamanager._mechanism_tree = Tree()
+
+        assert test_datamanager.on_select_all() is None
+        assert test_datamanager.tree.depth() == 0
+
 
 @pytest.mark.usefixtures(
     "test_datamanager", "test_mechanism", "test_opload", "test_opstress", "test_method"


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have the OpLoad datamanager use metaclass methods.

## Describe how this was implemented.
Removed do_get_tree() from OpLoad datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #599 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
