### PR TITLE
refactor: remove do_get_tree from OpStress

### DIFF
--- a/src/ramstk/controllers/opstress/datamanager.py
+++ b/src/ramstk/controllers/opstress/datamanager.py
@@ -3,7 +3,7 @@
 #       ramstk.controllers.opstress.datamanager.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Operating Load Package Data Controller."""
 
 # Standard Library Imports
@@ -66,21 +66,9 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_update, "request_update_opstress")
 
         pub.subscribe(self.do_select_all, "selected_load")
-        pub.subscribe(self.do_get_tree, "request_get_opstress_tree")
 
         pub.subscribe(self._do_delete, "request_delete_opstress")
         pub.subscribe(self._do_insert_opstress, "request_insert_opstress")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the OpStress treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage(
-            "succeed_get_opstress_tree",
-            tree=self.tree,
-        )
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all the OpStress data from the RAMSTK Program database.

--- a/tests/controllers/opstress/opstress_integration_test.py
+++ b/tests/controllers/opstress/opstress_integration_test.py
@@ -6,7 +6,7 @@
 #       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Class for testing operating stress integrations."""
 
 # Third Party Imports

--- a/tests/controllers/opstress/opstress_unit_test.py
+++ b/tests/controllers/opstress/opstress_unit_test.py
@@ -6,7 +6,7 @@
 #       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Class for testing Operating Stress algorithms and models."""
 
 # Third Party Imports


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have the OpStress datamanager use metaclass methods.

## Describe how this was implemented.
Remove do_get_tree() from the OpStress datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #600


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
