### PR TITLE
refactor: remove do_get_tree from Options

### DIFF
--- a/src/ramstk/controllers/options/datamanager.py
+++ b/src/ramstk/controllers/options/datamanager.py
@@ -18,18 +18,14 @@ from ramstk.models.commondb import RAMSTKSiteInfo
 
 
 class DataManager(RAMSTKDataManager):
-    """Contain the attributes and methods of the Options data manager.
-
-    This class manages the admin-configurable options and data from the
-    Site database.
-    """
+    """Contain the attributes and methods of the Option data manager."""
 
     # Define private dict class attributes.
 
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _tag = "options"
+    _tag = "option"
     _root = 0
 
     # Define public dict class attributes.
@@ -62,16 +58,6 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_get_attributes, "request_get_option_attributes")
         pub.subscribe(super().do_set_attributes, "request_set_option_attributes")
         pub.subscribe(super().do_update, "request_update_option")
-
-        pub.subscribe(self.do_get_tree, "request_get_options_tree")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the Options treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage("succeed_get_options_tree", tree=self.tree)
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all the Options data from the RAMSTK Program database.

--- a/tests/controllers/options/options_integration_test.py
+++ b/tests/controllers/options/options_integration_test.py
@@ -2,11 +2,11 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.controllers.options.options_integration_test.py is part of The
-#       RAMSTK Project
+#       tests.controllers.options.options_integration_test.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Options module integrations."""
 
 # Third Party Imports
@@ -33,7 +33,7 @@ def test_datamanager(test_common_dao):
     pub.unsubscribe(dut.do_get_attributes, "request_get_option_attributes")
     pub.unsubscribe(dut.do_set_attributes, "request_set_option_attributes")
     pub.unsubscribe(dut.do_update, "request_update_option")
-    pub.unsubscribe(dut.do_get_tree, "request_get_options_tree")
+    pub.unsubscribe(dut.do_get_tree, "request_get_option_tree")
 
     # Delete the device under test.
     del dut

--- a/tests/controllers/options/options_unit_test.py
+++ b/tests/controllers/options/options_unit_test.py
@@ -2,11 +2,10 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.controllers.options.options_unit_test.py is part of The RAMSTK
-#       Project
+#       tests.controllers.options.options_unit_test.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Options module algorithms and models."""
 
 # Standard Library Imports
@@ -69,7 +68,7 @@ def test_datamanager(mock_common_dao):
     pub.unsubscribe(dut.do_get_attributes, "request_get_option_attributes")
     pub.unsubscribe(dut.do_set_attributes, "request_set_option_attributes")
     pub.unsubscribe(dut.do_update, "request_update_option")
-    pub.unsubscribe(dut.do_get_tree, "request_get_options_tree")
+    pub.unsubscribe(dut.do_get_tree, "request_get_option_tree")
 
     # Delete the device under test.
     del dut
@@ -89,20 +88,20 @@ class TestCreateControllers:
         assert DUT._pkey == {
             "siteinfo": ["site_id"],
         }
-        assert DUT._tag == "options"
+        assert DUT._tag == "option"
         assert DUT._root == 0
         assert DUT._site_id == 0
 
         assert pub.isSubscribed(DUT.do_update, "request_update_option")
         assert pub.isSubscribed(DUT.do_get_attributes, "request_get_option_attributes")
-        assert pub.isSubscribed(DUT.do_get_tree, "request_get_options_tree")
+        assert pub.isSubscribed(DUT.do_get_tree, "request_get_option_tree")
         assert pub.isSubscribed(DUT.do_set_attributes, "request_set_option_attributes")
 
         # Unsubscribe from pypubsub topics.
         pub.unsubscribe(DUT.do_get_attributes, "request_get_option_attributes")
         pub.unsubscribe(DUT.do_set_attributes, "request_set_option_attributes")
         pub.unsubscribe(DUT.do_update, "request_update_option")
-        pub.unsubscribe(DUT.do_get_tree, "request_get_options_tree")
+        pub.unsubscribe(DUT.do_get_tree, "request_get_option_tree")
 
 
 @pytest.mark.usefixtures("test_datamanager")


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have Options datamanager use metaclass methods.

## Describe how this was implemented.
Remove do_get_tree() method from Options datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #601 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
