### PR TITLE
refactor: remove do_get_tree() from Preferences

### DIFF
--- a/src/ramstk/controllers/preferences/datamanager.py
+++ b/src/ramstk/controllers/preferences/datamanager.py
@@ -1,11 +1,10 @@
 # pylint: disable=cyclic-import
 # -*- coding: utf-8 -*-
 #
-#       ramstk.controllers.preferences.datamanager.py is part of The RAMSTK
-#       Project
+#       ramstk.controllers.preferences.datamanager.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Preferences Package Data Model."""
 
 # Standard Library Imports
@@ -32,8 +31,7 @@ class DataManager(RAMSTKDataManager):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _tag = "preferences"
-    _root = 0
+    _tag = "preference"
 
     # Define public dict class attributes.
 
@@ -65,17 +63,7 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_set_attributes, "request_set_preference_attributes")
         pub.subscribe(super().do_update, "request_update_preference")
 
-        pub.subscribe(self.do_get_tree, "request_get_preferences_tree")
-
         pub.subscribe(self._do_select_all, "succeed_connect_program_database")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the Preferences treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage("succeed_get_preferences_tree", tree=self.tree)
 
     def _do_select_all(self, dao: BaseDatabase) -> None:
         """Retrieve all the Options data from the RAMSTK Program database.

--- a/tests/controllers/preferences/preferences_integration_test.py
+++ b/tests/controllers/preferences/preferences_integration_test.py
@@ -2,11 +2,11 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.controllers.preferences.preferences_integration_test.py is part
-#       of The RAMSTK Project
+#       tests.controllers.preferences.preferences_integration_test.py is part of The
+#       RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Preferences integrations."""
 
 # Standard Library Imports
@@ -35,7 +35,7 @@ def test_datamanager(test_program_dao):
     pub.unsubscribe(dut.do_get_attributes, "request_get_preference_attributes")
     pub.unsubscribe(dut.do_set_attributes, "request_set_preference_attributes")
     pub.unsubscribe(dut.do_update, "request_update_preference")
-    pub.unsubscribe(dut.do_get_tree, "request_get_preferences_tree")
+    pub.unsubscribe(dut.do_get_tree, "request_get_preference_tree")
     pub.unsubscribe(dut._do_select_all, "succeed_connect_program_database")
 
     # Delete the device under test.
@@ -243,7 +243,7 @@ class TestGetterSetter:
             self.on_succeed_get_data_manager_tree, "succeed_get_preferences_tree"
         )
 
-        pub.sendMessage("request_get_preferences_tree")
+        pub.sendMessage("request_get_preference_tree")
 
         pub.unsubscribe(
             self.on_succeed_get_data_manager_tree, "succeed_get_preferences_tree"

--- a/tests/controllers/preferences/preferences_unit_test.py
+++ b/tests/controllers/preferences/preferences_unit_test.py
@@ -2,11 +2,11 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.controllers.preferences.preferences_unit_test.py is part of The
-#       RAMSTK Project
+#       tests.controllers.preferences.preferences_unit_test.py is part of The RAMSTK
+#       Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Preferences module algorithms and models."""
 
 # Standard Library Imports
@@ -71,7 +71,7 @@ def test_datamanager(mock_program_dao):
     pub.unsubscribe(dut.do_get_attributes, "request_get_preference_attributes")
     pub.unsubscribe(dut.do_set_attributes, "request_set_preference_attributes")
     pub.unsubscribe(dut.do_update, "request_update_preference")
-    pub.unsubscribe(dut.do_get_tree, "request_get_preferences_tree")
+    pub.unsubscribe(dut.do_get_tree, "request_get_preference_tree")
     pub.unsubscribe(dut._do_select_all, "succeed_connect_program_database")
 
     # Delete the device under test.
@@ -92,7 +92,7 @@ class TestCreateControllers:
         assert DUT._pkey == {
             "programinfo": ["revision_id"],
         }
-        assert DUT._tag == "preferences"
+        assert DUT._tag == "preference"
         assert DUT._root == 0
 
         assert pub.isSubscribed(DUT._do_select_all, "succeed_connect_program_database")
@@ -100,7 +100,7 @@ class TestCreateControllers:
         assert pub.isSubscribed(
             DUT.do_get_attributes, "request_get_preference_attributes"
         )
-        assert pub.isSubscribed(DUT.do_get_tree, "request_get_preferences_tree")
+        assert pub.isSubscribed(DUT.do_get_tree, "request_get_preference_tree")
         assert pub.isSubscribed(
             DUT.do_set_attributes, "request_set_preference_attributes"
         )
@@ -109,7 +109,7 @@ class TestCreateControllers:
         pub.unsubscribe(DUT.do_get_attributes, "request_get_preference_attributes")
         pub.unsubscribe(DUT.do_set_attributes, "request_set_preference_attributes")
         pub.unsubscribe(DUT.do_update, "request_update_preference")
-        pub.unsubscribe(DUT.do_get_tree, "request_get_preferences_tree")
+        pub.unsubscribe(DUT.do_get_tree, "request_get_preference_tree")
         pub.unsubscribe(DUT._do_select_all, "succeed_connect_program_database")
 
 


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have Preferences datamanager use metaclass methods.

## Describe how this was implemented.
Remove do_get_tree() from Preferences datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #602 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
