### PR TITLE
refactor: remove do_get_tree() from Program Status

### DIFF
--- a/src/ramstk/controllers/program_status/datamanager.py
+++ b/src/ramstk/controllers/program_status/datamanager.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-#       ramstk.controllers.program_status.datamanager.py is part of The RAMSTK
-#       Project
+#       ramstk.controllers.program_status.datamanager.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2020 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Program Status Package Data Model."""
 
 # Standard Library Imports
@@ -58,22 +57,10 @@ class DataManager(RAMSTKDataManager):
         pub.subscribe(super().do_update, "request_update_program_status")
 
         pub.subscribe(self.do_select_all, "selected_revision")
-        pub.subscribe(self.do_get_tree, "request_get_program_status_tree")
 
         pub.subscribe(self._do_delete, "request_delete_program_status")
         pub.subscribe(self._do_insert_program_status, "request_insert_program_status")
         pub.subscribe(self._do_set_attributes, "succeed_calculate_all_validation_tasks")
-
-    def do_get_tree(self) -> None:
-        """Retrieve the program status treelib Tree.
-
-        :return: None
-        :rtype: None
-        """
-        pub.sendMessage(
-            "succeed_get_program_status_tree",
-            tree=self.tree,
-        )
 
     def do_select_all(self, attributes: Dict[str, Any]) -> None:
         """Retrieve all Program Status data from the RAMSTK Program database.

--- a/tests/controllers/program_status/program_status_integration_test.py
+++ b/tests/controllers/program_status/program_status_integration_test.py
@@ -2,11 +2,11 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.controllers.program_status.program_status_integration_test.py is
-#       part of The RAMSTK Project
+#       tests.controllers.program_status.program_status_integration_test.py is part of
+#       The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Program Status module integrations."""
 
 # Standard Library Imports

--- a/tests/controllers/program_status/program_status_unit_test.py
+++ b/tests/controllers/program_status/program_status_unit_test.py
@@ -2,11 +2,11 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.controllers.program_status.program_status_unit_test.py is part
-#       of The RAMSTK Project
+#       tests.controllers.program_status.program_status_unit_test.py is part of The
+#       RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2021 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Program Status module algorithms and models."""
 
 # Standard Library Imports


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To have the Program Status datamanager use metaclass methods.

## Describe how this was implemented.
Remove the do_get_tree() method from the Program Status datamanager.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #603 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
