### PR TITLE
style: rename _module attribute in RAMSTKViews

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -2,8 +2,8 @@
 name: Bug Report
 about: Create a bug report to help us improve RAMSTK.
 labels:
-  - globalbacklog
-  - bug
+  - status: backlog
+  - type: bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/CHORE.md
+++ b/.github/ISSUE_TEMPLATE/CHORE.md
@@ -2,10 +2,10 @@
 name: Chore
 about: Build tools, CI workflow, refactoring, and code styling issues.
 labels:
-  - globalbacklog
+  - status: backlog
 
 ---
 
 **Describe the chore that needs to be addressed.**
 
-- [ ] This issue is an epic issue which subsumes the following:
+- [ ] This issue subsumes the following issues:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -2,8 +2,8 @@
 name: Feature Request
 about: If you'd like to make a suggestion please fill out the form below.
 labels:
-  - globalbacklog
-  - feature
+  - status: backlog
+  - type: feature
 
 ---
 
@@ -23,4 +23,4 @@ labels:
 
 > Add any other context about the feature request here.
 
-- [ ] This issue is an epic issue which subsumes the following:
+- [ ] This issue subsumes the following issues:

--- a/.github/ISSUE_TEMPLATE/TEST.md
+++ b/.github/ISSUE_TEMPLATE/TEST.md
@@ -2,11 +2,11 @@
 name: Test
 about: Fix or add new test.
 labels:
-  - globalbacklog
-  - test
+  - status: backlog
+  - type: test
 
 ---
 
 **Describe the test that is missing or needs to be fixed.**
 
-- [ ] This issue is an epic issue which subsumes the following:
+- [ ] This issue subsumes the following issues:

--- a/.github/workflows/on-issue-assign.yml
+++ b/.github/workflows/on-issue-assign.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Branch for Issue
     runs-on: ubuntu-latest
     steps:
-      - name: Is Issue Epic
+      - name: Is Issue dobranch
         id: getlabel
         uses: renanmav/match-label-action@v3
         with:
@@ -22,3 +22,11 @@ jobs:
         uses: robvanderleek/create-issue-branch@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  label_issue_in_progress:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add In Progress Label
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "status: inprogress"
+          remove-labels: "status: backlog"

--- a/src/ramstk/views/gtk3/allocation/view.pyi
+++ b/src/ramstk/views/gtk3/allocation/view.pyi
@@ -14,7 +14,7 @@ from . import AllocationGoalMethodPanel as AllocationGoalMethodPanel
 from . import AllocationTreePanel as AllocationTreePanel
 
 class AllocationWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_tooltips: List[str]

--- a/src/ramstk/views/gtk3/failure_definition/view.py
+++ b/src/ramstk/views/gtk3/failure_definition/view.py
@@ -27,7 +27,7 @@ class FailureDefinitionListView(RAMSTKListView):
 
     The attributes of the failure definition list view are:
 
-    :cvar _module: the name of the module.  Spaces are replaced with single
+    :cvar _tag: the name of the module.  Spaces are replaced with single
         underscores if the name is more than one word.
     :cvar _tablabel: the text to display on the view's tab.
     :cvar _tabtooltip: the text to display in the tooltip for the view's tab.
@@ -44,7 +44,7 @@ class FailureDefinitionListView(RAMSTKListView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "failure_definitions"
+    _tag: str = "failure_definitions"
     _tablabel = "<span weight='bold'>" + _("Failure\nDefinitions") + "</span>"
     _tabtooltip = _("Displays failure definitions for the selected revision.")
 

--- a/src/ramstk/views/gtk3/failure_definition/view.pyi
+++ b/src/ramstk/views/gtk3/failure_definition/view.pyi
@@ -13,7 +13,7 @@ from ramstk.views.gtk3.widgets import RAMSTKPanel as RAMSTKPanel
 from . import FailureDefinitionTreePanel as FailureDefinitionTreePanel
 
 class FailureDefinitionListView(RAMSTKListView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: List[str]

--- a/src/ramstk/views/gtk3/fmea/view.py
+++ b/src/ramstk/views/gtk3/fmea/view.py
@@ -69,7 +69,7 @@ class FMEAWorkView(RAMSTKWorkView):
     :cvar bool _pixbuf: indicates whether or icons are displayed in the
         RAMSTKTreeView.  If true, a GDKPixbuf column will be appended when
         creating the RAMSTKTreeView.  Default is True.
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
 
     :ivar list _lst_callbacks: the list of callback methods for the view's
         toolbar buttons and pop-up menu.  The methods are listed in the order
@@ -95,7 +95,7 @@ class FMEAWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "fmea"
+    _tag: str = "fmea"
     _pixbuf: bool = True
     _tablabel: str = _("FMEA")
     _tabtooltip: str = _(
@@ -202,7 +202,7 @@ class FMEAWorkView(RAMSTKWorkView):
             "You are about to delete {1} item {0} and all "
             "data associated with it.  Is this really what "
             "you want to do?"
-        ).format(_node_id, self._module.title())
+        ).format(_node_id, self._tag.title())
         _dialog = RAMSTKMessageDialog(parent=_parent)
         _dialog.do_set_message(_prompt)
         _dialog.do_set_message_type("question")

--- a/src/ramstk/views/gtk3/fmea/view.pyi
+++ b/src/ramstk/views/gtk3/fmea/view.pyi
@@ -23,7 +23,7 @@ from . import FMEATreePanel as FMEATreePanel
 def do_request_insert(level: str, parent_id: str) -> None: ...
 
 class FMEAWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _pixbuf: bool
     _tablabel: str
     _tabtooltip: str

--- a/src/ramstk/views/gtk3/function/view.py
+++ b/src/ramstk/views/gtk3/function/view.py
@@ -29,7 +29,7 @@ class FunctionModuleView(RAMSTKModuleView):
     connected RAMSTK Program in a flat list.  The attributes of a Function
     Module View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_mnu_labels: the list of labels for the view's pop-up
         menu.  The labels are listed in the order they appear in the menu.
@@ -43,7 +43,7 @@ class FunctionModuleView(RAMSTKModuleView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "function"
+    _tag: str = "function"
     _tablabel: str = "Function"
     _tabtooltip: str = _("Displays the functional hierarchy for the selected Revision.")
 
@@ -99,7 +99,7 @@ class FunctionModuleView(RAMSTKModuleView):
         self.__make_ui()
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(self._do_set_record_id, "selected_{0}".format(self._module))
+        pub.subscribe(self._do_set_record_id, f"selected_{self._tag}")
 
     def _do_set_record_id(self, attributes: Dict[str, Any]) -> None:
         """Set the stakeholder input's record ID.
@@ -134,7 +134,7 @@ class FunctionWorkView(RAMSTKWorkView):
     The Function Work View displays all the general data attributes for the
     selected Function. The attributes of a Function General Data Work View are:
 
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
     :cvar str _tablabel: the text to display on the tab's label.
     :cvar str _tabtooltip: the text to display as the tab's tooltip.
 
@@ -156,7 +156,7 @@ class FunctionWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "function"
+    _tag: str = "function"
     _tablabel = _("General\nData")
     _tabtooltip = _("Displays general information for the selected Function.")
 

--- a/src/ramstk/views/gtk3/function/view.pyi
+++ b/src/ramstk/views/gtk3/function/view.pyi
@@ -14,7 +14,7 @@ from . import FunctionGeneralDataPanel as FunctionGeneralDataPanel
 from . import FunctionTreePanel as FunctionTreePanel
 
 class FunctionModuleView(RAMSTKModuleView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: Any
@@ -29,7 +29,7 @@ class FunctionModuleView(RAMSTKModuleView):
     def __make_ui(self) -> None: ...
 
 class FunctionWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: Any
     _tabtooltip: Any
     _lst_mnu_labels: Any

--- a/src/ramstk/views/gtk3/hardware/view.py
+++ b/src/ramstk/views/gtk3/hardware/view.py
@@ -74,7 +74,7 @@ class HardwareModuleView(RAMSTKModuleView):
     connected RAMSTK Program in a flat list.  The attributes of a Hardware
     Module View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_mnu_labels: the list of labels for the view's pop-up
         menu.  The labels are listed in the order they appear in the menu.
@@ -88,7 +88,7 @@ class HardwareModuleView(RAMSTKModuleView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "hardware"
+    _tag: str = "hardware"
     _tablabel: str = "Hardware"
     _tabtooltip: str = _(
         "Displays the hardware hierarchy (BoM) for the selected Revision."
@@ -168,7 +168,7 @@ class HardwareModuleView(RAMSTKModuleView):
         self.__make_ui()
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(self._do_set_record_id, "selected_{0}".format(self._module))
+        pub.subscribe(self._do_set_record_id, f"selected_{self._tag}")
 
     def _do_request_calculate_hardware(self, __button: Gtk.ToolButton) -> None:
         """Send request to calculate the selected hardware item.

--- a/src/ramstk/views/gtk3/hardware/view.pyi
+++ b/src/ramstk/views/gtk3/hardware/view.pyi
@@ -102,7 +102,7 @@ from . import HardwareMiscellaneousPanel as HardwareMiscellaneousPanel
 from . import HardwareTreePanel as HardwareTreePanel
 
 class HardwareModuleView(RAMSTKModuleView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: Any
@@ -122,7 +122,7 @@ class HardwareModuleView(RAMSTKModuleView):
     def __make_ui(self) -> None: ...
 
 class HardwareGeneralDataView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _pnlGeneralData: Any
@@ -143,7 +143,7 @@ class HardwareGeneralDataView(RAMSTKWorkView):
 
 class HardwareAssessmentInputView(RAMSTKWorkView):
     _lst_title: List[str]
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _dic_component_panels: Any
@@ -170,7 +170,7 @@ class HardwareAssessmentInputView(RAMSTKWorkView):
 
 class HardwareAssessmentResultsView(RAMSTKWorkView):
     _lst_title: Any
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _dic_component_results: Any

--- a/src/ramstk/views/gtk3/hazard_analysis/view.py
+++ b/src/ramstk/views/gtk3/hazard_analysis/view.py
@@ -28,7 +28,7 @@ class HazardsWorkView(RAMSTKWorkView):
     The WorkView displays all the attributes for the Hazards Analysis (HazOps).
     The attributes of a HazOps Work View are:
 
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
 
     :ivar list _lst_callbacks: the list of callback methods for the view's
         toolbar buttons and pop-up menu.  The methods are listed in the order
@@ -49,7 +49,7 @@ class HazardsWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "hazard"
+    _tag: str = "hazard"
     _tablabel: str = _("HazOps")
     _tabtooltip: str = _("Displays the HazOps analysis for the selected Function.")
 

--- a/src/ramstk/views/gtk3/hazard_analysis/view.pyi
+++ b/src/ramstk/views/gtk3/hazard_analysis/view.pyi
@@ -13,7 +13,7 @@ from ramstk.views.gtk3.widgets import RAMSTKWorkView as RAMSTKWorkView
 from . import HazardsTreePanel as HazardsTreePanel
 
 class HazardsWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: List[str]

--- a/src/ramstk/views/gtk3/pof/view.py
+++ b/src/ramstk/views/gtk3/pof/view.py
@@ -40,7 +40,7 @@ class PoFWorkView(RAMSTKWorkView):
     :cvar list _lst_labels: the list of labels for the widgets on the work
         view.  The PoF work stream module has no labels, but an empty list
         is required to prevent an AttributeError when creating the UI.
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
     :cvar bool _pixbuf: indicates whether or icons are displayed in the
         RAMSTKTreeView.  If true, a GDKPixbuf column will be appended when
         creating the RAMSTKTreeView.  Default is True.
@@ -63,7 +63,7 @@ class PoFWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "pof"
+    _tag: str = "pof"
     _pixbuf: bool = True
     _tablabel = _("PoF")
     _tabtooltip = _(
@@ -139,7 +139,7 @@ class PoFWorkView(RAMSTKWorkView):
             "You are about to delete {1} item {0} and all "
             "data associated with it.  Is this really what "
             "you want to do?"
-        ).format(_node_id, self._module.title())
+        ).format(_node_id, self._tag.title())
         _dialog = RAMSTKMessageDialog(parent=_parent)
         _dialog.do_set_message(_prompt)
         _dialog.do_set_message_type("question")

--- a/src/ramstk/views/gtk3/pof/view.pyi
+++ b/src/ramstk/views/gtk3/pof/view.pyi
@@ -15,7 +15,7 @@ from ramstk.views.gtk3.widgets import RAMSTKWorkView as RAMSTKWorkView
 from . import PoFTreePanel as PoFTreePanel
 
 class PoFWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _pixbuf: bool
     _tablabel: str
     _tabtooltip: str

--- a/src/ramstk/views/gtk3/preferences/view.py
+++ b/src/ramstk/views/gtk3/preferences/view.py
@@ -46,7 +46,7 @@ class PreferencesDialog(RAMSTKBaseView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module = "preferences"
+    _tag = "preferences"
     _pixbuf: bool = True
     _tablabel: str = _("")
     _tabtooltip: str = _("")

--- a/src/ramstk/views/gtk3/preferences/view.pyi
+++ b/src/ramstk/views/gtk3/preferences/view.pyi
@@ -16,7 +16,7 @@ from . import LookFeelPreferencesPanel as LookFeelPreferencesPanel
 from . import TreeLayoutPreferencesPanel as TreeLayoutPreferencesPanel
 
 class PreferencesDialog(RAMSTKBaseView):
-    _module: str
+    _tag: str
     _pixbuf: bool
     _tablabel: str
     _tabtooltip: str

--- a/src/ramstk/views/gtk3/program_status/view.py
+++ b/src/ramstk/views/gtk3/program_status/view.py
@@ -32,7 +32,7 @@ class ProgramStatusWorkView(RAMSTKWorkView):
     solid line) for all tasks in the V&V plan as well as the actual progress
     (points).  The attributes of a Verification burn down curve view are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_callbacks: the list of callback methods for the view's
         toolbar buttons and pop-up menu.  The methods are listed in the order
@@ -52,7 +52,7 @@ class ProgramStatusWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module = "validation"
+    _tag = "validation"
     _tablabel = (
         "<span weight='bold'>" + _("Program\nVerification\nProgress") + "</span>"
     )

--- a/src/ramstk/views/gtk3/program_status/view.pyi
+++ b/src/ramstk/views/gtk3/program_status/view.pyi
@@ -14,7 +14,7 @@ from ramstk.views.gtk3.widgets import RAMSTKWorkView as RAMSTKWorkView
 from . import ProgramStatusPlotPanel as ProgramStatusPlotPanel
 
 class ProgramStatusWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_callbacks: List[Callable]

--- a/src/ramstk/views/gtk3/requirement/view.py
+++ b/src/ramstk/views/gtk3/requirement/view.py
@@ -42,7 +42,7 @@ class RequirementModuleView(RAMSTKModuleView):
     the connected RAMSTK Program in a flat list.  The attributes of a
     Requirement Module View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_mnu_labels: the list of labels for the view's pop-up
         menu.  The labels are listed in the order they appear in the menu.
@@ -56,7 +56,7 @@ class RequirementModuleView(RAMSTKModuleView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "requirement"
+    _tag: str = "requirement"
     _tablabel: str = "Requirement"
     _tabtooltip: str = _(
         "Displays the requirements hierarchy for the selected Revision."
@@ -114,7 +114,7 @@ class RequirementModuleView(RAMSTKModuleView):
         self.__make_ui()
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(self._do_set_record_id, "selected_{0}".format(self._module))
+        pub.subscribe(self._do_set_record_id, f"selected_{self._tag}")
 
     def do_request_delete(self, __button: Gtk.ToolButton) -> None:
         """Request to delete selected record from the RAMSTKRequirement table.
@@ -173,7 +173,7 @@ class RequirementGeneralDataView(RAMSTKWorkView):
     The Requirement Work View displays all the general data attributes for the
     selected Requirement.  The attributes of a requirement Work View are:
 
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
     :cvar str _tablabel: the text to display on the tab's label.
     :cvar str _tabtooltip: the text to display as the tab's tooltip.
 
@@ -195,7 +195,7 @@ class RequirementGeneralDataView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "requirement"
+    _tag: str = "requirement"
     _tablabel: str = _("General\nData")
     _tabtooltip: str = _("Displays general information for the selected Requirement.")
 
@@ -315,7 +315,7 @@ class RequirementAnalysisView(RAMSTKWorkView):
     answers for the selected Requirement. The attributes of a Requirement
     Analysis Work View are:
 
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
     :cvar str _tablabel: the text to display on the tab's label.
     :cvar str _tabtooltip: the text to display as the tab's tooltip.
 
@@ -337,7 +337,7 @@ class RequirementAnalysisView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "requirement"
+    _tag: str = "requirement"
     _tablabel: str = "<span weight='bold'>" + _("Analysis") + "</span>"
     _tabtooltip: str = _("Analyzes the selected requirement.")
 

--- a/src/ramstk/views/gtk3/requirement/view.pyi
+++ b/src/ramstk/views/gtk3/requirement/view.pyi
@@ -21,7 +21,7 @@ from . import RequirementTreePanel as RequirementTreePanel
 from . import RequirementVerifiabilityPanel as RequirementVerifiabilityPanel
 
 class RequirementModuleView(RAMSTKModuleView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: Any
@@ -37,7 +37,7 @@ class RequirementModuleView(RAMSTKModuleView):
     def __make_ui(self) -> None: ...
 
 class RequirementGeneralDataView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: Any
@@ -53,7 +53,7 @@ class RequirementGeneralDataView(RAMSTKWorkView):
     def __make_ui(self) -> None: ...
 
 class RequirementAnalysisView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _pnlClarity: Any

--- a/src/ramstk/views/gtk3/revision/view.py
+++ b/src/ramstk/views/gtk3/revision/view.py
@@ -35,7 +35,7 @@ class RevisionModuleView(RAMSTKModuleView):
     connected RAMSTK Program in a flat list.  The attributes of a Revision
     Module View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_mnu_labels: the list of labels for the view's pop-up
         menu.  The labels are listed in the order they appear in the menu.
@@ -49,7 +49,7 @@ class RevisionModuleView(RAMSTKModuleView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "revision"
+    _tag: str = "revision"
     _tablabel: str = "Revision"
     _tabtooltip: str = _("Displays the list of Revisions for the open RAMSTK Project.")
 
@@ -167,7 +167,7 @@ class RevisionWorkView(RAMSTKWorkView):
     The Revision Work View displays all the general data attributes for the
     selected Revision. The attributes of a Revision General Data Work View are:
 
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
     :cvar str _tablabel: the text to display on the tab's label.
     :cvar str _tabtooltip: the text to display as the tab's tooltip.
 
@@ -189,7 +189,7 @@ class RevisionWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "revision"
+    _tag: str = "revision"
     _tablabel = _("General\nData")
     _tabtooltip = _("Displays general information for the selected Revision")
 

--- a/src/ramstk/views/gtk3/revision/view.pyi
+++ b/src/ramstk/views/gtk3/revision/view.pyi
@@ -19,7 +19,7 @@ from . import RevisionGeneralDataPanel as RevisionGeneralDataPanel
 from . import RevisionTreePanel as RevisionTreePanel
 
 class RevisionModuleView(RAMSTKModuleView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: Any
@@ -37,7 +37,7 @@ class RevisionModuleView(RAMSTKModuleView):
     def __make_ui(self) -> None: ...
 
 class RevisionWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: Any
     _tabtooltip: Any
     _lst_tooltips: Any

--- a/src/ramstk/views/gtk3/similar_item/view.py
+++ b/src/ramstk/views/gtk3/similar_item/view.py
@@ -33,7 +33,7 @@ class SimilarItemWorkView(RAMSTKWorkView):
         a Topic 633 analysis.
     :cvar dict _dic_environment: the environments and associated index to use
         in a Topic 633 analysis.
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
 
     :ivar dict _dic_hardware: dict to hold information from the Hardware
         module.
@@ -57,7 +57,7 @@ class SimilarItemWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "similar_item"
+    _tag: str = "similar_item"
     _tablabel: str = _("Similar Item")
     _tabtooltip: str = _(
         "Displays the Similar Item analysis for the selected hardware item."

--- a/src/ramstk/views/gtk3/similar_item/view.pyi
+++ b/src/ramstk/views/gtk3/similar_item/view.pyi
@@ -15,7 +15,7 @@ from . import SimilarItemMethodPanel as SimilarItemMethodPanel
 from . import SimilarItemTreePanel as SimilarItemTreePanel
 
 class SimilarItemWorkView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: List[str]

--- a/src/ramstk/views/gtk3/stakeholder/view.py
+++ b/src/ramstk/views/gtk3/stakeholder/view.py
@@ -29,7 +29,7 @@ class StakeholderListView(RAMSTKListView):
     with the selected Requirement.  The attributes of the Stakeholder List
     View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_callbacks: the list of callback methods for the view's
         toolbar buttons and pop-up menu.  The methods are listed in the order
@@ -49,7 +49,7 @@ class StakeholderListView(RAMSTKListView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module = "stakeholders"
+    _tag = "stakeholders"
     _tablabel = "<span weight='bold'>" + _("Stakeholder\nInputs") + "</span>"
     _tabtooltip = _("Displays stakeholder inputs for the selected revision.")
     _view_type = "list"

--- a/src/ramstk/views/gtk3/stakeholder/view.pyi
+++ b/src/ramstk/views/gtk3/stakeholder/view.pyi
@@ -13,7 +13,7 @@ from ramstk.views.gtk3.widgets import RAMSTKPanel as RAMSTKPanel
 from . import StakeholderTreePanel as StakeholderTreePanel
 
 class StakeholderListView(RAMSTKListView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _view_type: str

--- a/src/ramstk/views/gtk3/usage_profile/view.py
+++ b/src/ramstk/views/gtk3/usage_profile/view.py
@@ -24,7 +24,7 @@ class UsageProfileListView(RAMSTKListView):
 
     The attributes of a Usage Profile List View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_mnu_labels: the list of labels for the view's pop-up
         menu.  The labels are listed in the order they appear in the menu.
@@ -36,7 +36,7 @@ class UsageProfileListView(RAMSTKListView):
     # Define private dict class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "usage_profile"
+    _tag: str = "usage_profile"
     _tablabel: str = "<span weight='bold'>" + _("Usage\nProfiles") + "</span>"
     _tabtooltip: str = _("Displays usage profiles for the selected revision.")
 

--- a/src/ramstk/views/gtk3/usage_profile/view.pyi
+++ b/src/ramstk/views/gtk3/usage_profile/view.pyi
@@ -13,7 +13,7 @@ from ramstk.views.gtk3.widgets import RAMSTKPanel
 from . import UsageProfileTreePanel as UsageProfileTreePanel
 
 class UsageProfileListView(RAMSTKListView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_col_order: List[int]

--- a/src/ramstk/views/gtk3/validation/view.py
+++ b/src/ramstk/views/gtk3/validation/view.py
@@ -38,7 +38,7 @@ class ValidationModuleView(RAMSTKModuleView):
     connected RAMSTK Program in a flat list.  The attributes of a Validation
     Module View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_mnu_labels: the list of labels for the view's pop-up
         menu.  The labels are listed in the order they appear in the menu.
@@ -52,7 +52,7 @@ class ValidationModuleView(RAMSTKModuleView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "validation"
+    _tag: str = "validation"
     _tablabel: str = "Verification"
     _tabtooltip: str = _(
         "Displays the list of verification tasks for the selected Revision."
@@ -105,7 +105,7 @@ class ValidationModuleView(RAMSTKModuleView):
         self.__make_ui()
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(self._do_set_record_id, "selected_{0}".format(self._module))
+        pub.subscribe(self._do_set_record_id, f"selected_{self._tag}")
 
     def do_request_delete(self, __button: Gtk.ToolButton) -> None:
         """Request to delete selected record from the RAMSTKValidation table.
@@ -174,7 +174,7 @@ class ValidationGeneralDataView(RAMSTKWorkView):
 
     :cvar dict _dic_keys:
     :cvar list _lst_labels: the list of label text.
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
 
     :ivar list _lst_callbacks: the list of callback methods for the view's
         toolbar buttons and pop-up menu.  The methods are listed in the order
@@ -194,7 +194,7 @@ class ValidationGeneralDataView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "validation"
+    _tag: str = "validation"
     _tablabel: str = _("General\nData")
     _tabtooltip: str = _(
         "Displays general information for the selected Verification task."

--- a/src/ramstk/views/gtk3/validation/view.pyi
+++ b/src/ramstk/views/gtk3/validation/view.pyi
@@ -17,7 +17,7 @@ from . import ValidationTaskEffortPanel as ValidationTaskEffortPanel
 from . import ValidationTreePanel as ValidationTreePanel
 
 class ValidationModuleView(RAMSTKModuleView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_mnu_labels: Any
@@ -32,7 +32,7 @@ class ValidationModuleView(RAMSTKModuleView):
     def __make_ui(self) -> None: ...
 
 class ValidationGeneralDataView(RAMSTKWorkView):
-    _module: str
+    _tag: str
     _tablabel: str
     _tabtooltip: str
     _lst_callbacks: Any

--- a/src/ramstk/views/gtk3/widgets/baseview.py
+++ b/src/ramstk/views/gtk3/widgets/baseview.py
@@ -169,22 +169,12 @@ class RAMSTKBaseView(Gtk.HBox):
 
         # Subscribe to PyPubSub messages.
         pub.subscribe(self.do_set_cursor_active, "request_set_cursor_active")
-        pub.subscribe(
-            self.do_set_cursor_active, "succeed_update_{0}".format(self._module)
-        )
-        pub.subscribe(
-            self.do_set_cursor_active, "succeed_calculate_{0}".format(self._module)
-        )
+        pub.subscribe(self.do_set_cursor_active, f"succeed_update_{self._tag}")
+        pub.subscribe(self.do_set_cursor_active, f"succeed_calculate_{self._tag}")
         pub.subscribe(self.do_set_cursor_active, "succeed_update_all")
-        pub.subscribe(
-            self.do_set_cursor_active_on_fail, "fail_delete_{0}".format(self._module)
-        )
-        pub.subscribe(
-            self.do_set_cursor_active_on_fail, "fail_insert_{0}".format(self._module)
-        )
-        pub.subscribe(
-            self.do_set_cursor_active_on_fail, "fail_update_{0}".format(self._module)
-        )
+        pub.subscribe(self.do_set_cursor_active_on_fail, f"fail_delete_{self._tag}")
+        pub.subscribe(self.do_set_cursor_active_on_fail, f"fail_insert_{self._tag}")
+        pub.subscribe(self.do_set_cursor_active_on_fail, f"fail_update_{self._tag}")
 
         pub.subscribe(self.on_select_revision, "selected_revision")
 
@@ -196,16 +186,12 @@ class RAMSTKBaseView(Gtk.HBox):
         _fmt_file = (
             self.RAMSTK_USER_CONFIGURATION.RAMSTK_CONF_DIR
             + "/layouts/"
-            + self.RAMSTK_USER_CONFIGURATION.RAMSTK_FORMAT_FILE[self._module]
+            + self.RAMSTK_USER_CONFIGURATION.RAMSTK_FORMAT_FILE[self._tag]
         )
 
         try:
-            _bg_color = self.RAMSTK_USER_CONFIGURATION.RAMSTK_COLORS[
-                self._module + "bg"
-            ]
-            _fg_color = self.RAMSTK_USER_CONFIGURATION.RAMSTK_COLORS[
-                self._module + "fg"
-            ]
+            _bg_color = self.RAMSTK_USER_CONFIGURATION.RAMSTK_COLORS[self._tag + "bg"]
+            _fg_color = self.RAMSTK_USER_CONFIGURATION.RAMSTK_COLORS[self._tag + "fg"]
         except KeyError:
             _bg_color = "#FFFFFF"
             _fg_color = "#000000"
@@ -397,7 +383,7 @@ class RAMSTKBaseView(Gtk.HBox):
             "You are about to delete {1} {0} and all "
             "data associated with it.  Is this really what "
             "you want to do?"
-        ).format(self._record_id, self._module.title())
+        ).format(self._record_id, self._tag.title())
         _dialog = RAMSTKMessageDialog(parent=_parent)
         _dialog.do_set_message(_prompt)
         _dialog.do_set_message_type("question")
@@ -405,7 +391,7 @@ class RAMSTKBaseView(Gtk.HBox):
         if _dialog.do_run() == Gtk.ResponseType.YES:
             self.do_set_cursor_busy()
             pub.sendMessage(
-                "request_delete_{0}".format(self._module),
+                f"request_delete_{self._tag}",
                 node_id=self._record_id,
             )
 
@@ -422,12 +408,12 @@ class RAMSTKBaseView(Gtk.HBox):
 
         if _sibling:
             pub.sendMessage(
-                "request_insert_{0:s}".format(self._module.lower()),
+                f"request_insert_{self._tag.lower()}",
                 parent_id=self._parent_id,
             )
         else:
             pub.sendMessage(
-                "request_insert_{0:s}".format(self._module.lower()),
+                f"request_insert_{self._tag.lower()}",
                 parent_id=self._record_id,
             )  # noqa
 
@@ -454,9 +440,7 @@ class RAMSTKBaseView(Gtk.HBox):
         :return: None
         """
         self.do_set_cursor_busy()
-        pub.sendMessage(
-            "request_update_{0:s}".format(self._module), node_id=self._record_id
-        )
+        pub.sendMessage(f"request_update_{self._tag}", node_id=self._record_id)
 
     def do_request_update_all(self, __button: Gtk.ToolButton) -> None:
         """Send request to save all the records to RAMSTK program database.
@@ -465,7 +449,7 @@ class RAMSTKBaseView(Gtk.HBox):
         :return: None
         """
         self.do_set_cursor_busy()
-        pub.sendMessage("request_update_all_{0:s}s".format(self._module))
+        pub.sendMessage(f"request_update_all_{self._tag}s")
 
     def do_set_cursor(self, cursor: Gdk.CursorType) -> None:
         """Set the cursor for the Module, List, and Work Book Gdk.Window().
@@ -632,7 +616,7 @@ class RAMSTKBaseView(Gtk.HBox):
         :return: None
         :rtype: None
         """
-        _data = tree.get_node(node_id).data[self._module].get_attributes()
+        _data = tree.get_node(node_id).data[self._tag].get_attributes()
         self._pnlPanel.on_insert(_data)
 
     def on_select_revision(self, attributes: Dict[str, Any]) -> None:
@@ -767,7 +751,7 @@ class RAMSTKListView(RAMSTKBaseView):
     def do_request_update_all(self, __button: Gtk.ToolButton) -> None:
         """Send request to update the matrix."""
         super().do_set_cursor_busy()
-        pub.sendMessage("request_update_all_{0:s}s".format(self._module))
+        pub.sendMessage(f"request_update_all_{self._tag}s")
 
     def make_ui(self) -> None:
         """Build the list view user interface.
@@ -781,8 +765,8 @@ class RAMSTKListView(RAMSTKBaseView):
 class RAMSTKModuleView(RAMSTKBaseView):
     """Display data in the RAMSTK Module Book.
 
-    This is the meta class for all RAMSTK Module View classes.
-    Attributes of the RAMSTKModuleView are:
+    This is the meta class for all RAMSTK Module View classes. Attributes of the
+    RAMSTKModuleView are:
     """
 
     def __init__(

--- a/tests/views/gtk3/widgets/test_baseview.py
+++ b/tests/views/gtk3/widgets/test_baseview.py
@@ -27,7 +27,7 @@ class TestRAMSTKBaseView:
         """__init__() should create a RAMSTKBaseView."""
         _logger = RAMSTKLogManager(test_toml_user_configuration.RAMSTK_USER_LOG)
         DUT = RAMSTKBaseView(test_toml_user_configuration, _logger)
-        DUT._module = "revision"
+        DUT._tag = "revision"
 
         assert isinstance(DUT, RAMSTKBaseView)
         assert isinstance(DUT.RAMSTK_USER_CONFIGURATION, RAMSTKUserConfiguration)
@@ -47,11 +47,12 @@ class TestRAMSTKBaseView:
 
     @pytest.mark.skip
     def test_do_raise_dialog_missing_severity(self, test_toml_user_configuration):
-        """do_raise_dialog() should log a message to the debug log when the severity is missing from the kwargs."""
+        """do_raise_dialog() should log a message to the debug log when the severity is
+        missing from the kwargs."""
         _logger = RAMSTKLogManager(test_toml_user_configuration.RAMSTK_USER_LOG)
         test_toml_user_configuration.RAMSTK_LOGLEVEL = "DEBUG"
         DUT = RAMSTKBaseView(test_toml_user_configuration, _logger)
-        DUT._module = "revision"
+        DUT._tag = "revision"
 
         assert isinstance(
             DUT.do_raise_dialog(
@@ -64,11 +65,12 @@ class TestRAMSTKBaseView:
 
     @pytest.mark.skip
     def test_do_raise_dialog_missing_message(self, test_toml_user_configuration):
-        """do_raise_dialog() should log a message to the debug log when the message is missing from the kwargs."""
+        """do_raise_dialog() should log a message to the debug log when the message is
+        missing from the kwargs."""
         _logger = RAMSTKLogManager(test_toml_user_configuration.RAMSTK_USER_LOG)
         test_toml_user_configuration.RAMSTK_LOGLEVEL = "DEBUG"
         DUT = RAMSTKBaseView(test_toml_user_configuration, _logger)
-        DUT._module = "revision"
+        DUT._tag = "revision"
 
         assert isinstance(
             DUT.do_raise_dialog(


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To rename _module class attribute in RAMSTKView classes to _tag for consistency with other classes.

## Describe how this was implemented.
Renamed _module in all RAMSTKView classes and test files.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #800 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
