### PR TITLE
refactor: remove calls to RAMSTKPanel methods in RAMSTKView classes

### DIFF
--- a/src/ramstk/views/gtk3/allocation/panel.py
+++ b/src/ramstk/views/gtk3/allocation/panel.py
@@ -752,8 +752,8 @@ class AllocationTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/allocation/view.py
+++ b/src/ramstk/views/gtk3/allocation/view.py
@@ -29,7 +29,7 @@ class AllocationWorkView(RAMSTKWorkView):
     the selected hardware item. The attributes of an Allocation General Data
     Work View are:
 
-    :cvar _module: the name of the module.
+    :cvar _tag: the name of the module.
 
     :ivar _lst_callbacks: the list of callback methods for the view's
         toolbar buttons and pop-up menu.  The methods are listed in the order
@@ -49,7 +49,7 @@ class AllocationWorkView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "allocation"
+    _tag: str = "allocation"
     _tablabel: str = _("Allocation")
     _tabtooltip: str = _(
         "Displays the Allocation analysis for the selected hardware item."
@@ -131,7 +131,6 @@ class AllocationWorkView(RAMSTKWorkView):
         self._pnlGoalMethods.do_load_comboboxes()
 
         super().do_embed_treeview_panel()
-        self._pnlPanel.do_set_callbacks()
 
         self.remove(self.get_children()[-1])
         _hpaned.pack1(self._pnlGoalMethods, True, True)

--- a/src/ramstk/views/gtk3/failure_definition/panel.py
+++ b/src/ramstk/views/gtk3/failure_definition/panel.py
@@ -106,8 +106,8 @@ class FailureDefinitionTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/failure_definition/view.py
+++ b/src/ramstk/views/gtk3/failure_definition/view.py
@@ -140,8 +140,6 @@ class FailureDefinitionListView(RAMSTKListView):
         """
         super().make_ui()
 
-        self._pnlPanel.do_set_properties()
-        self._pnlPanel.do_set_callbacks()
         self._pnlPanel.tvwTreeView.dic_handler_id[
             "button-press"
         ] = self._pnlPanel.tvwTreeView.connect(

--- a/src/ramstk/views/gtk3/fmea/panel.py
+++ b/src/ramstk/views/gtk3/fmea/panel.py
@@ -121,8 +121,8 @@ class FMEAMethodPanel(RAMSTKFixedPanel):
 
         # Initialize public scalar attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         # Move the item criticality RAMSTKTextView() below it's label.
@@ -1239,6 +1239,7 @@ class FMEATreePanel(RAMSTKTreePanel):
 
         super().do_set_properties()
         super().do_make_panel()
+        super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(
             _(

--- a/src/ramstk/views/gtk3/fmea/view.py
+++ b/src/ramstk/views/gtk3/fmea/view.py
@@ -356,7 +356,6 @@ class FMEAWorkView(RAMSTKWorkView):
         self.__do_load_rpn_lists()
         self.__do_load_severity_lists()
         self._pnlPanel.do_load_comboboxes()
-        self._pnlPanel.do_set_callbacks()
 
         self.remove(self.get_children()[-1])
         _hpaned.pack1(self._pnlMethods, True, True)

--- a/src/ramstk/views/gtk3/function/panel.py
+++ b/src/ramstk/views/gtk3/function/panel.py
@@ -412,8 +412,8 @@ class FunctionTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/function/view.py
+++ b/src/ramstk/views/gtk3/function/view.py
@@ -119,8 +119,6 @@ class FunctionModuleView(RAMSTKModuleView):
         """
         super().make_ui()
 
-        self._pnlPanel.do_set_properties()
-        self._pnlPanel.do_set_callbacks()
         self._pnlPanel.tvwTreeView.dic_handler_id[
             "button-press"
         ] = self._pnlPanel.tvwTreeView.connect(

--- a/src/ramstk/views/gtk3/hardware/panel.py
+++ b/src/ramstk/views/gtk3/hardware/panel.py
@@ -613,8 +613,8 @@ class HardwareTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(
@@ -1221,7 +1221,6 @@ class HardwareLogisticsPanel(RAMSTKFixedPanel):
 
         # Initialize public scalar instance attributes.
 
-        # Make a fixed type panel.
         super().do_set_properties()
         super().do_make_panel()
         super().do_set_callbacks()
@@ -1369,7 +1368,6 @@ class HardwareMiscellaneousPanel(RAMSTKFixedPanel):
 
         # Initialize public scalar instance attributes.
 
-        # Make a fixed type panel.
         super().do_set_properties()
         super().do_make_panel()
         super().do_set_callbacks()

--- a/src/ramstk/views/gtk3/hardware/view.py
+++ b/src/ramstk/views/gtk3/hardware/view.py
@@ -243,8 +243,6 @@ class HardwareModuleView(RAMSTKModuleView):
         """
         super().make_ui()
 
-        self._pnlPanel.do_set_properties()
-        self._pnlPanel.do_set_callbacks()
         self._pnlPanel.do_set_cell_callbacks(
             "mvw_editing_hardware",
             [
@@ -316,7 +314,7 @@ class HardwareGeneralDataView(RAMSTKWorkView):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _module: str = "hardware"
+    _tag: str = "hardware"
     _tablabel: str = _("General\nData")
     _tabtooltip: str = _("Displays general information for the selected Hardware")
 
@@ -446,7 +444,7 @@ class HardwareAssessmentInputView(RAMSTKWorkView):
 
     :cvar list _lst_labels: the text to use for the assessment input widget
         labels.
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
 
     :ivar dict _dic_assessment_input: dictionary of component-specific
         AssessmentInputs classes.
@@ -473,7 +471,7 @@ class HardwareAssessmentInputView(RAMSTKWorkView):
     _lst_title: List[str] = [_("Operating Stresses")]
 
     # Define private scalar class attributes.
-    _module: str = "hardware"
+    _tag: str = "hardware"
     _tablabel: str = _("Assessment\nInputs")
     _tabtooltip: str = _(
         "Displays reliability assessment inputs for the selected hardware item."
@@ -682,7 +680,7 @@ class HardwareAssessmentResultsView(RAMSTKWorkView):
 
     :cvar list _lst_labels: the text to use for the reliability assessment
         results widget labels.
-    :cvar str _module: the name of the module.
+    :cvar str _tag: the name of the module.
 
     :ivar dict _dic_assessment_results: dictionary of component-specific
         AssessmentResults classes.
@@ -703,7 +701,7 @@ class HardwareAssessmentResultsView(RAMSTKWorkView):
     _lst_title = [_("Assessment Model Results"), _("Stress Results")]
 
     # Define private scalar class attributes.
-    _module: str = "hardware"
+    _tag: str = "hardware"
     _tablabel: str = _("Assessment\nResults")
     _tabtooltip: str = _(
         "Displays reliability, maintainability, and availability assessment results "

--- a/src/ramstk/views/gtk3/hazard_analysis/panel.py
+++ b/src/ramstk/views/gtk3/hazard_analysis/panel.py
@@ -714,8 +714,8 @@ class HazardsTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar instance attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/pof/panel.py
+++ b/src/ramstk/views/gtk3/pof/panel.py
@@ -380,6 +380,7 @@ class PoFTreePanel(RAMSTKTreePanel):
 
         super().do_set_properties()
         super().do_make_panel()
+        super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(
             _(

--- a/src/ramstk/views/gtk3/pof/view.py
+++ b/src/ramstk/views/gtk3/pof/view.py
@@ -242,7 +242,6 @@ class PoFWorkView(RAMSTKWorkView):
         super().do_embed_treeview_panel()
         self.__do_load_test_method_lists()
         self._pnlPanel.do_load_comboboxes()
-        self._pnlPanel.do_set_callbacks()
 
         self.show_all()
 

--- a/src/ramstk/views/gtk3/requirement/panel.py
+++ b/src/ramstk/views/gtk3/requirement/panel.py
@@ -835,8 +835,8 @@ class RequirementTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/requirement/view.py
+++ b/src/ramstk/views/gtk3/requirement/view.py
@@ -155,8 +155,6 @@ class RequirementModuleView(RAMSTKModuleView):
         """
         super().make_ui()
 
-        self._pnlPanel.do_set_properties()
-        self._pnlPanel.do_set_callbacks()
         self._pnlPanel.do_set_cell_callbacks(
             "mvw_editing_requirement", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         )

--- a/src/ramstk/views/gtk3/revision/panel.py
+++ b/src/ramstk/views/gtk3/revision/panel.py
@@ -491,8 +491,8 @@ class RevisionTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(_("Displays the list of revisions."))
@@ -624,7 +624,6 @@ class RevisionGeneralDataPanel(RAMSTKFixedPanel):
 
         # Initialize public scalar instance attributes.
 
-        # Make a fixed type panel.
         super().do_set_properties()
         super().do_make_panel()
         super().do_set_callbacks()

--- a/src/ramstk/views/gtk3/revision/view.py
+++ b/src/ramstk/views/gtk3/revision/view.py
@@ -152,8 +152,6 @@ class RevisionModuleView(RAMSTKModuleView):
         """
         super().make_ui()
 
-        self._pnlPanel.do_set_properties()
-        self._pnlPanel.do_set_callbacks()
         self._pnlPanel.tvwTreeView.dic_handler_id[
             "button-press"
         ] = self._pnlPanel.tvwTreeView.connect(

--- a/src/ramstk/views/gtk3/similar_item/panel.py
+++ b/src/ramstk/views/gtk3/similar_item/panel.py
@@ -1219,8 +1219,8 @@ class SimilarItemTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar instance attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/similar_item/view.py
+++ b/src/ramstk/views/gtk3/similar_item/view.py
@@ -211,8 +211,6 @@ class SimilarItemWorkView(RAMSTKWorkView):
         """
         _hpaned: Gtk.HPaned = super().do_make_layout_lr()
 
-        self._pnlMethod.do_load_comboboxes()
-
         super().do_embed_treeview_panel()
         self._pnlPanel.do_load_comboboxes()
 

--- a/src/ramstk/views/gtk3/stakeholder/panel.py
+++ b/src/ramstk/views/gtk3/stakeholder/panel.py
@@ -323,8 +323,8 @@ class StakeholderTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(_("Displays the list of stakeholders."))

--- a/src/ramstk/views/gtk3/stakeholder/view.py
+++ b/src/ramstk/views/gtk3/stakeholder/view.py
@@ -183,14 +183,13 @@ class StakeholderListView(RAMSTKListView):
         """
         super().make_ui()
 
-        self._pnlPanel.do_set_properties()
         self._pnlPanel.do_load_affinity_groups(
             self.RAMSTK_USER_CONFIGURATION.RAMSTK_AFFINITY_GROUPS
         )
         self._pnlPanel.do_load_stakeholders(
             self.RAMSTK_USER_CONFIGURATION.RAMSTK_STAKEHOLDERS
         )
-        self._pnlPanel.do_set_callbacks()
+
         self._pnlPanel.tvwTreeView.dic_handler_id[
             "button-press"
         ] = self._pnlPanel.tvwTreeView.connect(

--- a/src/ramstk/views/gtk3/usage_profile/panel.py
+++ b/src/ramstk/views/gtk3/usage_profile/panel.py
@@ -341,8 +341,8 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/usage_profile/view.py
+++ b/src/ramstk/views/gtk3/usage_profile/view.py
@@ -220,10 +220,8 @@ class UsageProfileListView(RAMSTKListView):
         self._pnlPanel.dic_units = (
             self.RAMSTK_USER_CONFIGURATION.RAMSTK_MEASUREMENT_UNITS
         )
-
-        self._pnlPanel.do_set_properties()
         self._pnlPanel.do_load_comboboxes()
-        self._pnlPanel.do_set_callbacks()
+
         self._pnlPanel.tvwTreeView.dic_handler_id[
             "button-press"
         ] = self._pnlPanel.tvwTreeView.connect(

--- a/src/ramstk/views/gtk3/validation/panel.py
+++ b/src/ramstk/views/gtk3/validation/panel.py
@@ -533,8 +533,8 @@ class ValidationTreePanel(RAMSTKTreePanel):
 
         # Initialize public scalar class attributes.
 
-        super().do_make_panel()
         super().do_set_properties()
+        super().do_make_panel()
         super().do_set_callbacks()
 
         self.tvwTreeView.set_tooltip_text(

--- a/src/ramstk/views/gtk3/validation/view.py
+++ b/src/ramstk/views/gtk3/validation/view.py
@@ -146,14 +146,13 @@ class ValidationModuleView(RAMSTKModuleView):
         """
         super().make_ui()
 
-        self._pnlPanel.do_set_properties()
         self._pnlPanel.do_load_measurement_units(
             self.RAMSTK_USER_CONFIGURATION.RAMSTK_MEASUREMENT_UNITS
         )
         self._pnlPanel.do_load_verification_types(
             self.RAMSTK_USER_CONFIGURATION.RAMSTK_VALIDATION_TYPE
         )
-        self._pnlPanel.do_set_callbacks()
+
         self._pnlPanel.do_set_cell_callbacks(
             "mvw_editing_validation",
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
Set RAMSTKPanel properties and callbacks in the panel's __init__() method, not the consuming RAMSTKView.

## Describe how this was implemented.
Remove calls to RAMSTKPanel methods from all RAMSTKView classes.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #815 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
