### PR TITLE
fix: not able to delete FMEA or PoF row

### DIFF
--- a/src/ramstk/views/gtk3/fmea/view.py
+++ b/src/ramstk/views/gtk3/fmea/view.py
@@ -22,7 +22,7 @@ from ramstk.configuration import (
 from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk, _
 from ramstk.views.gtk3.assistants import AddControlAction
-from ramstk.views.gtk3.widgets import RAMSTKMessageDialog, RAMSTKPanel, RAMSTKWorkView
+from ramstk.views.gtk3.widgets import RAMSTKPanel, RAMSTKWorkView
 
 # RAMSTK Local Imports
 from . import FMEAMethodPanel, FMEATreePanel
@@ -104,7 +104,7 @@ class FMEAWorkView(RAMSTKWorkView):
         # Initialize private list attributes.
         self._lst_callbacks.insert(0, self._do_request_insert_sibling)
         self._lst_callbacks.insert(1, self._do_request_insert_child)
-        self._lst_callbacks.insert(2, self._do_request_delete)
+        self._lst_callbacks.insert(2, super().do_request_delete)
         self._lst_callbacks.insert(3, self._do_request_calculate)
         self._lst_icons.insert(0, "insert_sibling")
         self._lst_icons.insert(1, "insert_child")
@@ -170,35 +170,6 @@ class FMEAWorkView(RAMSTKWorkView):
 
         if self._pnlMethods.chkRPN.get_active():
             pub.sendMessage("request_calculate_rpn", method="mechanism")
-
-    def _do_request_delete(self, __button: Gtk.ToolButton) -> None:
-        """Request to delete the selected entity from the FMEA.
-
-        :param __button: the Gtk.ToolButton() that called this method.
-        :return: None
-        :rtype: None
-        """
-        _parent = self.get_parent().get_parent().get_parent().get_parent()
-        _model, _row = self._pnlPanel.tvwTreeView.get_selection().get_selected()
-        _node_id = _model.get_value(_row, 0)
-
-        _prompt = _(
-            "You are about to delete {1} item {0} and all "
-            "data associated with it.  Is this really what "
-            "you want to do?"
-        ).format(_node_id, self._tag.title())
-        _dialog = RAMSTKMessageDialog(parent=_parent)
-        _dialog.do_set_message(_prompt)
-        _dialog.do_set_message_type("question")
-
-        if _dialog.do_run() == Gtk.ResponseType.YES:
-            super().do_set_cursor_busy()
-            pub.sendMessage(
-                "request_delete_fmea",
-                node_id=_node_id,
-            )
-
-        _dialog.do_destroy()
 
     def _do_request_insert_child(self, __button: Gtk.ToolButton) -> None:
         """Request to insert a new entity to the FMEA.

--- a/src/ramstk/views/gtk3/pof/view.py
+++ b/src/ramstk/views/gtk3/pof/view.py
@@ -17,7 +17,7 @@ from ramstk.configuration import RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk, _
 from ramstk.views.gtk3.assistants import AddStressTestMethod
-from ramstk.views.gtk3.widgets import RAMSTKMessageDialog, RAMSTKPanel, RAMSTKWorkView
+from ramstk.views.gtk3.widgets import RAMSTKPanel, RAMSTKWorkView
 
 # RAMSTK Local Imports
 from . import PoFTreePanel
@@ -92,7 +92,7 @@ class PoFWorkView(RAMSTKWorkView):
         # Initialize private list attributes.
         self._lst_callbacks.insert(0, self._do_request_insert_sibling)
         self._lst_callbacks.insert(1, self._do_request_insert_child)
-        self._lst_callbacks.insert(2, self._do_request_delete)
+        self._lst_callbacks.insert(2, super().do_request_delete)
         self._lst_icons.insert(0, "insert_sibling")
         self._lst_icons.insert(1, "insert_child")
         self._lst_icons.insert(2, "remove")
@@ -129,35 +129,6 @@ class PoFWorkView(RAMSTKWorkView):
         pub.subscribe(
             self._on_get_hardware_attributes, "succeed_get_hardware_attributes"
         )
-
-    def _do_request_delete(self, __button: Gtk.ToolButton) -> None:
-        """Request to delete the selected entity from the PoF.
-
-        :param __button: the Gtk.ToolButton() that called this method.
-        :return: None
-        :rtype: None
-        """
-        _parent = self.get_parent().get_parent().get_parent().get_parent()
-        _model, _row = self._pnlPanel.tvwTreeView.get_selection().get_selected()
-        _node_id = _model.get_value(_row, 0)
-
-        _prompt = _(
-            "You are about to delete {1} item {0} and all "
-            "data associated with it.  Is this really what "
-            "you want to do?"
-        ).format(_node_id, self._tag.title())
-        _dialog = RAMSTKMessageDialog(parent=_parent)
-        _dialog.do_set_message(_prompt)
-        _dialog.do_set_message_type("question")
-
-        if _dialog.do_run() == Gtk.ResponseType.YES:
-            super().do_set_cursor_busy()
-            pub.sendMessage(
-                "request_delete_pof",
-                node_id=_node_id,
-            )
-
-        _dialog.do_destroy()
 
     def _do_request_insert_child(self, __button: Gtk.ToolButton) -> None:
         """Request to insert a new child entity to the PoF.


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
To fix the problem with FMEA and PoF not being able to delete rows.

## Describe how this was implemented.
Removing the local _do_request_delete() method from the FMEA and PoF view classes and use the RAMSTKBaseClass do_request_delete() method.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Close #885

## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [ ] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
