### PR TITLE
refactor: rewrite RAMSTKBaseTable do_select_all()

### DIFF
--- a/src/ramstk/models/programdb/action/table.py
+++ b/src/ramstk/models/programdb/action/table.py
@@ -23,6 +23,7 @@ class RAMSTKActionTable(RAMSTKBaseTable):
     # Define private scalar class attributes.
     _db_id_colname = "fld_action_id"
     _db_tablename = "ramstk_action"
+    _deprecated = False
     _select_msg = "selected_revision"
     _tag = "action"
 

--- a/src/ramstk/models/programdb/cause/table.py
+++ b/src/ramstk/models/programdb/cause/table.py
@@ -27,6 +27,7 @@ class RAMSTKCauseTable(RAMSTKBaseTable):
     # Define private scalar class attributes.
     _db_id_colname = "fld_cause_id"
     _db_tablename = "ramstk_cause"
+    _deprecated = False
     _select_msg = "selected_revision"
     _tag = "cause"
 

--- a/tests/models/programdb/action/action_integration_test.py
+++ b/tests/models/programdb/action/action_integration_test.py
@@ -26,10 +26,6 @@ def test_tablemodel(test_program_dao):
     dut.do_select_all(
         {
             "revision_id": 1,
-            "hardware_id": 1,
-            "mode_id": 6,
-            "mechanism_id": 3,
-            "cause_id": 3,
         }
     )
 
@@ -49,7 +45,7 @@ def test_tablemodel(test_program_dao):
     del dut
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_tablemodel")
 class TestSelectMethods:
     """Class for testing data manager select_all() and select() methods."""
 
@@ -60,14 +56,19 @@ class TestSelectMethods:
         print("\033[36m\nsucceed_retrieve_action topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_select_all_populated_tree(self, test_attributes, test_tablemodel):
+    def test_do_select_all_populated_tree(self, test_tablemodel):
         """should return a Tree() object populated with RAMSTKActionRecord
         instances."""
-        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_action")
+        pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_all_action")
 
-        pub.sendMessage("selected_revision", attributes=test_attributes)
+        pub.sendMessage(
+            "selected_revision",
+            attributes={
+                "revision_id": 1,
+            },
+        )
 
-        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_action")
+        pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_all_action")
 
 
 @pytest.mark.usefixtures("test_attributes", "test_tablemodel")

--- a/tests/models/programdb/action/action_unit_test.py
+++ b/tests/models/programdb/action/action_unit_test.py
@@ -109,10 +109,6 @@ class TestSelectMethods:
         test_tablemodel.do_select_all(
             {
                 "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 3,
-                "cause_id": 3,
             }
         )
 
@@ -129,10 +125,6 @@ class TestSelectMethods:
         test_tablemodel.do_select_all(
             {
                 "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 3,
-                "cause_id": 3,
             }
         )
 
@@ -148,10 +140,6 @@ class TestSelectMethods:
         test_tablemodel.do_select_all(
             {
                 "revision_id": 1,
-                "hardware_id": 1,
-                "mode_id": 6,
-                "mechanism_id": 3,
-                "cause_id": 3,
             }
         )
 

--- a/tests/models/programdb/cause/cause_integration_test.py
+++ b/tests/models/programdb/cause/cause_integration_test.py
@@ -24,7 +24,9 @@ def test_tablemodel(test_program_dao):
     dut = RAMSTKCauseTable()
     dut.do_connect(test_program_dao)
     dut.do_select_all(
-        {"revision_id": 1, "hardware_id": 1, "mode_id": 6, "mechanism_id": 3}
+        {
+            "revision_id": 1,
+        }
     )
 
     yield dut
@@ -44,7 +46,7 @@ def test_tablemodel(test_program_dao):
     del dut
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_tablemodel")
 class TestSelectMethods:
     """Class for testing data manager select_all() and select() methods."""
 
@@ -54,11 +56,16 @@ class TestSelectMethods:
         print("\033[36m\nsucceed_retrieve_cause topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_select_all_populated_tree(self, test_attributes, test_tablemodel):
+    def test_do_select_all_populated_tree(self, test_tablemodel):
         """should return a Tree() object populated with RAMSTKCauseRecord instances."""
         pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_cause")
 
-        pub.sendMessage("selected_revision", attributes=test_attributes)
+        pub.sendMessage(
+            "selected_revision",
+            attributes={
+                "revision_id": 1,
+            },
+        )
 
         pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_cause")
 

--- a/tests/models/programdb/cause/cause_unit_test.py
+++ b/tests/models/programdb/cause/cause_unit_test.py
@@ -95,14 +95,18 @@ class TestCreateModels:
         )
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_tablemodel")
 class TestSelectMethods:
     """Class for testing select_all() and select() methods."""
 
     @pytest.mark.unit
-    def test_do_select_all(self, test_attributes, test_tablemodel):
+    def test_do_select_all(self, test_tablemodel):
         """should return a Tree() object populated with RAMSTKCauseRecord instances."""
-        test_tablemodel.do_select_all(test_attributes)
+        test_tablemodel.do_select_all(
+            {
+                "revision_id": 1,
+            }
+        )
 
         assert isinstance(
             test_tablemodel.tree.get_node(1).data["cause"], RAMSTKCauseRecord
@@ -112,10 +116,14 @@ class TestSelectMethods:
         )
 
     @pytest.mark.unit
-    def test_do_select(self, test_attributes, test_tablemodel):
+    def test_do_select(self, test_tablemodel):
         """do_select() should return an instance of the RAMSTKCauseRecord on
         success."""
-        test_tablemodel.do_select_all(test_attributes)
+        test_tablemodel.do_select_all(
+            {
+                "revision_id": 1,
+            }
+        )
 
         _cause = test_tablemodel.do_select(1)
 
@@ -129,9 +137,13 @@ class TestSelectMethods:
         assert _cause.rpn_occurrence == 4
 
     @pytest.mark.unit
-    def test_do_select_non_existent_id(self, test_attributes, test_tablemodel):
+    def test_do_select_non_existent_id(self, test_tablemodel):
         """do_select() should return None when a non-existent cause ID is requested."""
-        test_tablemodel.do_select_all(test_attributes)
+        test_tablemodel.do_select_all(
+            {
+                "revision_id": 1,
+            }
+        )
 
         assert test_tablemodel.do_select(100) is None
 


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
To rewrite the do_select_all() method in RAMSTKBaseTable to allow ultimate removal of cobbled together code.

## Describe how this was implemented.
Added if-else construct and _deprecated class attribute.  When _deprecated=True, use old code, otherwise use new.  Updated action and cause tables to use and test new code.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #889 

## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
