### PR TITLE
refactor: update do_set_attributes() node_id argument to integer

### DIFF
--- a/src/ramstk/models/basemodel.py
+++ b/src/ramstk/models/basemodel.py
@@ -378,7 +378,7 @@ class RAMSTKBaseTable:
             tree=self.tree,
         )
 
-    def do_set_attributes(self, node_id: List, package: Dict[str, Any]) -> None:
+    def do_set_attributes(self, node_id: int, package: Dict[str, Any]) -> None:
         """Set the attributes of the record associated with node ID.
 
         :param node_id: the ID of the record in the RAMSTK Program database
@@ -388,24 +388,13 @@ class RAMSTKBaseTable:
         :rtype: None
         """
         [[_key, _value]] = package.items()
-        # ISSUE: Make node_id an integer argument to do_set_attributes()
-        #
-        # The node_id argument to RAMSTKBaseTable.do_set_attributes() is currently a
-        # List type argument.  This is deprecated and all calls should replace this
-        # with an integer argument.  After fixing all calls, remove the try construct
-        # in do_set_attributes() that exists to handle the List and int types.
-        # labels: type: refactor
-        try:
-            _node_id = node_id[0]
-        except TypeError:
-            _node_id = node_id
 
         try:
-            _attributes = self.do_select(_node_id).get_attributes()
+            _attributes = self.do_select(node_id).get_attributes()
         except (AttributeError, KeyError):
             _method_name = inspect.currentframe().f_code.co_name  # type: ignore
             _error_msg: str = (
-                f"{_method_name}: No data package for node ID {_node_id} in module "
+                f"{_method_name}: No data package for node ID {node_id} in module "
                 f"{self._tag}."
             )
             pub.sendMessage(
@@ -424,7 +413,7 @@ class RAMSTKBaseTable:
         if _key in _attributes:
             _attributes[_key] = _value
 
-            self.do_select(_node_id).set_attributes(_attributes)
+            self.do_select(node_id).set_attributes(_attributes)
 
         # noinspection PyUnresolvedReferences
         self.do_get_tree()  # type: ignore

--- a/src/ramstk/models/programdb/allocation/table.py
+++ b/src/ramstk/models/programdb/allocation/table.py
@@ -112,15 +112,15 @@ class RAMSTKAllocationTable(RAMSTKBaseTable):
         _attributes = allocation.do_calculate_goals(**_attributes)
 
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"hazard_rate_goal": _attributes["hazard_rate_goal"]},
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"mtbf_goal": _attributes["mtbf_goal"]},
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"reliability_goal": _attributes["reliability_goal"]},
         )
 
@@ -329,7 +329,7 @@ class RAMSTKAllocationTable(RAMSTKBaseTable):
             _cum_weight += _attributes["weight_factor"]
 
             self.do_set_attributes(
-                node_id=[_node.identifier],
+                node_id=_node.identifier,
                 package={"weight_factor": _attributes["weight_factor"]},
             )
 

--- a/src/ramstk/models/programdb/hazard/table.py
+++ b/src/ramstk/models/programdb/hazard/table.py
@@ -119,7 +119,7 @@ class RAMSTKHazardTable(RAMSTKBaseTable):
             _attributes["assembly_severity"],
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"assembly_hri": _result},
         )
 
@@ -128,7 +128,7 @@ class RAMSTKHazardTable(RAMSTKBaseTable):
             _attributes["system_severity"],
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"system_hri": _result},
         )
 
@@ -137,7 +137,7 @@ class RAMSTKHazardTable(RAMSTKBaseTable):
             _attributes["assembly_severity_f"],
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"assembly_hri_f": _result},
         )
 
@@ -146,7 +146,7 @@ class RAMSTKHazardTable(RAMSTKBaseTable):
             _attributes["system_severity_f"],
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"system_hri_f": _result},
         )
 
@@ -227,22 +227,22 @@ class RAMSTKHazardTable(RAMSTKBaseTable):
         _fha = fha.calculate_user_defined(_fha)
 
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"result_1": float(_fha["res1"])},
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"result_2": float(_fha["res2"])},
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"result_3": float(_fha["res3"])},
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"result_4": float(_fha["res4"])},
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"result_5": float(_fha["res5"])},
         )

--- a/src/ramstk/models/programdb/program_status/table.py
+++ b/src/ramstk/models/programdb/program_status/table.py
@@ -89,13 +89,10 @@ class RAMSTKProgramStatusTable(RAMSTKBaseTable):
             dates and the remaining time/cost.
         :rtype: :class:`pandas.DataFrame`
         """
-        _dic_actual = {}
-
-        for _node in self.tree.all_nodes()[1:]:
-            _dic_actual[pd.to_datetime(_node.data["program_status"].date_status)] = [
+        _dic_actual = {pd.to_datetime(_node.data["program_status"].date_status): [
                 _node.data["program_status"].cost_remaining,
                 _node.data["program_status"].time_remaining,
-            ]
+            ] for _node in self.tree.all_nodes()[1:]}
 
         _status = pd.DataFrame(
             _dic_actual.values(), index=_dic_actual.keys(), columns=["cost", "time"]

--- a/src/ramstk/models/programdb/program_status/table.py
+++ b/src/ramstk/models/programdb/program_status/table.py
@@ -126,10 +126,10 @@ class RAMSTKProgramStatusTable(RAMSTKBaseTable):
             _node_id = self.last_id
 
         self.do_set_attributes(
-            node_id=[_node_id], package={"cost_remaining": cost_remaining}
+            node_id=_node_id, package={"cost_remaining": cost_remaining}
         )
         self.do_set_attributes(
-            node_id=[_node_id], package={"time_remaining": time_remaining}
+            node_id=_node_id, package={"time_remaining": time_remaining}
         )
 
         self.do_update(_node_id)

--- a/src/ramstk/models/programdb/program_status/table.py
+++ b/src/ramstk/models/programdb/program_status/table.py
@@ -89,10 +89,13 @@ class RAMSTKProgramStatusTable(RAMSTKBaseTable):
             dates and the remaining time/cost.
         :rtype: :class:`pandas.DataFrame`
         """
-        _dic_actual = {pd.to_datetime(_node.data["program_status"].date_status): [
+        _dic_actual = {
+            pd.to_datetime(_node.data["program_status"].date_status): [
                 _node.data["program_status"].cost_remaining,
                 _node.data["program_status"].time_remaining,
-            ] for _node in self.tree.all_nodes()[1:]}
+            ]
+            for _node in self.tree.all_nodes()[1:]
+        }
 
         _status = pd.DataFrame(
             _dic_actual.values(), index=_dic_actual.keys(), columns=["cost", "time"]

--- a/src/ramstk/models/programdb/similar_item/table.py
+++ b/src/ramstk/models/programdb/similar_item/table.py
@@ -176,61 +176,61 @@ class RAMSTKSimilarItemTable(RAMSTKBaseTable):
             )
 
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_1": _change_description_1,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_2": _change_description_2,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_3": _change_description_3,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_4": _change_description_4,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_5": _change_description_5,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_6": _change_description_6,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_7": _change_description_7,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_8": _change_description_8,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_9": _change_description_9,
             },
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={
                 "change_description_10": _change_description_10,
             },

--- a/src/ramstk/models/programdb/stakeholder/table.py
+++ b/src/ramstk/models/programdb/stakeholder/table.py
@@ -115,10 +115,10 @@ class RAMSTKStakeholderTable(RAMSTKBaseTable):
         )
 
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"improvement": _improvement},
         )
         self.do_set_attributes(
-            node_id=[node_id],
+            node_id=node_id,
             package={"overall_weight": _overall_weight},
         )

--- a/src/ramstk/views/gtk3/assistants/similaritem.py
+++ b/src/ramstk/views/gtk3/assistants/similaritem.py
@@ -218,26 +218,26 @@ class EditFunction(RAMSTKDialog):
         """
         pub.sendMessage(
             "wvw_editing_similar_item",
-            node_id=[hardware_id, -1],
+            node_id=hardware_id,
             package={"function_1": str(self.txtFunction1.get_text())},
         )
         pub.sendMessage(
             "wvw_editing_similar_item",
-            node_id=[hardware_id, -1],
+            node_id=hardware_id,
             package={"function_2": str(self.txtFunction2.get_text())},
         )
         pub.sendMessage(
             "wvw_editing_similar_item",
-            node_id=[hardware_id, -1],
+            node_id=hardware_id,
             package={"function_3": str(self.txtFunction3.get_text())},
         )
         pub.sendMessage(
             "wvw_editing_similar_item",
-            node_id=[hardware_id, -1],
+            node_id=hardware_id,
             package={"function_4": str(self.txtFunction4.get_text())},
         )
         pub.sendMessage(
             "wvw_editing_similar_item",
-            node_id=[hardware_id, -1],
+            node_id=hardware_id,
             package={"function_5": str(self.txtFunction5.get_text())},
         )

--- a/src/ramstk/views/gtk3/hardware/panel.py
+++ b/src/ramstk/views/gtk3/hardware/panel.py
@@ -1301,7 +1301,7 @@ class HardwareLogisticsPanel(RAMSTKFixedPanel):
         self.txtCAGECode.do_update(_cage_code, signal="changed")
         pub.sendMessage(
             f"wvw_editing_{self._tag}",
-            node_id=[self._record_id, -1],
+            node_id=self._record_id,
             package={"cage_code": _cage_code},
         )
 

--- a/src/ramstk/views/gtk3/hardware/panel.py
+++ b/src/ramstk/views/gtk3/hardware/panel.py
@@ -654,9 +654,7 @@ class HardwareTreePanel(RAMSTKTreePanel):
         :param selection: the Hardware class Gtk.TreeSelection().
         :return: None
         """
-        _attributes = super().on_row_change(selection)
-
-        if _attributes:
+        if _attributes := super().on_row_change(selection):
             self._record_id = _attributes["hardware_id"]
             self._parent_id = _attributes["parent_id"]
 
@@ -1037,10 +1035,7 @@ class HardwareGeneralDataPanel(RAMSTKFixedPanel):
         _model = self.cmbCategory.get_model()
         _model.clear()
 
-        _categories = []
-        # pylint: disable=unused-variable
-        for __, _key in enumerate(category):
-            _categories.append([category[_key]])
+        _categories = [[value] for value in category.values()]
         self.cmbCategory.do_load_combo(entries=_categories)  # type: ignore
 
     def _do_load_subcategories(self, category_id: int) -> None:
@@ -1054,9 +1049,7 @@ class HardwareGeneralDataPanel(RAMSTKFixedPanel):
 
         if category_id > 0:
             _subcategories = SortedDict(self.dicSubcategories[category_id])
-            _subcategory = []
-            for _key in _subcategories:
-                _subcategory.append([_subcategories[_key]])
+            _subcategory = [[_subcategories[_key]] for _key in _subcategories]
             self.cmbSubcategory.do_load_combo(entries=_subcategory, signal="changed")
 
     def _do_set_comp_ref_des(self, comp_ref_des: str) -> None:
@@ -1275,9 +1268,7 @@ class HardwareLogisticsPanel(RAMSTKFixedPanel):
 
         :return: None
         """
-        _manufacturer = []
-        for _key in manufacturers:
-            _manufacturer.append(manufacturers[_key])
+        _manufacturer = list(manufacturers.values())
         self.cmbManufacturer.do_load_combo(
             entries=_manufacturer,  # type: ignore
             simple=False,

--- a/src/ramstk/views/gtk3/hardware/panel.py
+++ b/src/ramstk/views/gtk3/hardware/panel.py
@@ -654,7 +654,9 @@ class HardwareTreePanel(RAMSTKTreePanel):
         :param selection: the Hardware class Gtk.TreeSelection().
         :return: None
         """
-        if _attributes := super().on_row_change(selection):
+        _attributes = super().on_row_change(selection)
+
+        if _attributes:
             self._record_id = _attributes["hardware_id"]
             self._parent_id = _attributes["parent_id"]
 

--- a/src/ramstk/views/gtk3/validation/panel.py
+++ b/src/ramstk/views/gtk3/validation/panel.py
@@ -615,7 +615,9 @@ class ValidationTreePanel(RAMSTKTreePanel):
         :param selection: the Validation class Gtk.TreeSelection().
         :return: None
         """
-        if _attributes := super().on_row_change(selection):
+        _attributes = super().on_row_change(selection)
+
+        if _attributes:
             self._record_id = _attributes["validation_id"]
 
             _title = _("Analyzing Verification Task {0}").format(

--- a/src/ramstk/views/gtk3/validation/panel.py
+++ b/src/ramstk/views/gtk3/validation/panel.py
@@ -1068,7 +1068,7 @@ class ValidationTaskDescriptionPanel(RAMSTKFixedPanel):
 
             pub.sendMessage(
                 "wvw_editing_validation",
-                node_id=[self._record_id, -1, ""],
+                node_id=self._record_id,
                 package={"name": _task_code},
             )
         except (AttributeError, KeyError):
@@ -1385,7 +1385,7 @@ class ValidationTaskEffortPanel(RAMSTKFixedPanel):
 
         pub.sendMessage(
             "wvw_editing_validation",
-            node_id=[self._record_id, -1, ""],
+            node_id=self._record_id,
             package={"name": _code},
         )
 

--- a/src/ramstk/views/gtk3/validation/panel.py
+++ b/src/ramstk/views/gtk3/validation/panel.py
@@ -563,9 +563,9 @@ class ValidationTreePanel(RAMSTKTreePanel):
         _cellmodel.append([""])
 
         # pylint: disable=unused-variable
-        for __, _key in enumerate(measurement_unit):
+        for _key, value in measurement_unit.items():
             self._lst_measurement_units.append(measurement_unit[_key][1])
-            _cellmodel.append([measurement_unit[_key][1]])
+            _cellmodel.append([value[1]])
 
     def do_load_verification_types(
         self, verification_type: Dict[int, Tuple[str, str]]
@@ -587,9 +587,9 @@ class ValidationTreePanel(RAMSTKTreePanel):
         _cellmodel.append([""])
 
         # pylint: disable=unused-variable
-        for __, _key in enumerate(verification_type):
+        for _key, value in verification_type.items():
             self._lst_verification_types.append(verification_type[_key][1])
-            _cellmodel.append([verification_type[_key][1]])
+            _cellmodel.append([value[1]])
 
     def _on_module_switch(self, module: str = "") -> None:
         """Respond to changes in selected Module View module (tab).
@@ -615,9 +615,7 @@ class ValidationTreePanel(RAMSTKTreePanel):
         :param selection: the Validation class Gtk.TreeSelection().
         :return: None
         """
-        _attributes = super().on_row_change(selection)
-
-        if _attributes:
+        if _attributes := super().on_row_change(selection):
             self._record_id = _attributes["validation_id"]
 
             _title = _("Analyzing Verification Task {0}").format(

--- a/src/ramstk/views/gtk3/widgets/panel.py
+++ b/src/ramstk/views/gtk3/widgets/panel.py
@@ -439,7 +439,7 @@ class RAMSTKFixedPanel(RAMSTKPanel):
 
         textview.handler_unblock(textview.dic_handler_id["changed"])
 
-        pub.sendMessage(message, node_id=[self._record_id, -1], package=_package)
+        pub.sendMessage(message, node_id=self._record_id, package=_package)
 
         return _package
 
@@ -527,7 +527,7 @@ class RAMSTKFixedPanel(RAMSTKPanel):
 
             pub.sendMessage(
                 message,
-                node_id=[self._record_id, -1, ""],
+                node_id=self._record_id,
                 package={key: _new_text},
             )
         except KeyError:

--- a/tests/models/commondb/site_info/site_info_integration_test.py
+++ b/tests/models/commondb/site_info/site_info_integration_test.py
@@ -239,12 +239,12 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_option_attributes",
-            node_id=[1, ""],
+            node_id=1,
             package={"function_enabled": 1},
         )
         pub.sendMessage(
             "request_set_option_attributes",
-            node_id=[1, ""],
+            node_id=1,
             package={"requirement_enabled": 1},
         )
 

--- a/tests/models/programdb/action/action_integration_test.py
+++ b/tests/models/programdb/action/action_integration_test.py
@@ -346,7 +346,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_action_attributes",
-            node_id=[4],
+            node_id=4,
             package={"action_owner": "John Jacob Jingleheimer Schmidt"},
         )
 

--- a/tests/models/programdb/allocation/allocation_integration_test.py
+++ b/tests/models/programdb/allocation/allocation_integration_test.py
@@ -431,7 +431,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_allocation_attributes",
-            node_id=[2],
+            node_id=2,
             package={"hazard_rate_goal": 0.00005},
         )
 

--- a/tests/models/programdb/cause/cause_integration_test.py
+++ b/tests/models/programdb/cause/cause_integration_test.py
@@ -322,7 +322,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_cause_attributes",
-            node_id=[4],
+            node_id=4,
             package={"rpn_detection": 4},
         )
 

--- a/tests/models/programdb/control/control_integration_test.py
+++ b/tests/models/programdb/control/control_integration_test.py
@@ -326,7 +326,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_control_attributes",
-            node_id=[4],
+            node_id=4,
             package={"type_id": "Detection"},
         )
 
@@ -341,6 +341,6 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_control_attributes",
-            node_id=[4],
+            node_id=4,
             package={"type_id": "New Type ID"},
         )

--- a/tests/models/programdb/design_electric/design_electric_integration_test.py
+++ b/tests/models/programdb/design_electric/design_electric_integration_test.py
@@ -453,7 +453,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_design_electric_attributes",
-            node_id=[2],
+            node_id=2,
             package={"temperature_active": 65.5},
         )
 

--- a/tests/models/programdb/design_mechanic/design_mechanic_integration_test.py
+++ b/tests/models/programdb/design_mechanic/design_mechanic_integration_test.py
@@ -458,7 +458,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_design_mechanic_attributes",
-            node_id=[2],
+            node_id=2,
             package={"rpm_design": 65.5},
         )
 

--- a/tests/models/programdb/environment/environment_integration_test.py
+++ b/tests/models/programdb/environment/environment_integration_test.py
@@ -338,7 +338,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_environment_attributes",
-            node_id=[1],
+            node_id=1,
             package={"name": "This is the environment name."},
         )
 

--- a/tests/models/programdb/failure_definition/failure_definition_integration_test.py
+++ b/tests/models/programdb/failure_definition/failure_definition_integration_test.py
@@ -380,7 +380,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_failure_definition_attributes",
-            node_id=[1],
+            node_id=1,
             package={"definition": "Test Description"},
         )
 

--- a/tests/models/programdb/function/function_integration_test.py
+++ b/tests/models/programdb/function/function_integration_test.py
@@ -376,7 +376,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_function_attributes",
-            node_id=[1],
+            node_id=1,
             package={"function_code": "-"},
         )
 

--- a/tests/models/programdb/hazard/hazards_integration_test.py
+++ b/tests/models/programdb/hazard/hazards_integration_test.py
@@ -343,7 +343,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_hazard_attributes",
-            node_id=[1],
+            node_id=1,
             package={"potential_hazard": "Donald Trump"},
         )
 

--- a/tests/models/programdb/mechanism/mechanism_integration_test.py
+++ b/tests/models/programdb/mechanism/mechanism_integration_test.py
@@ -330,7 +330,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_mechanism_attributes",
-            node_id=[4],
+            node_id=4,
             package={"rpn_detection": 4},
         )
 

--- a/tests/models/programdb/milhdbk217f/milhdbk217f_integration_test.py
+++ b/tests/models/programdb/milhdbk217f/milhdbk217f_integration_test.py
@@ -387,7 +387,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_milhdbk217f_attributes",
-            node_id=[2],
+            node_id=2,
             package={"lambdaBD": 0.00655},
         )
 

--- a/tests/models/programdb/mission/mission_integration_test.py
+++ b/tests/models/programdb/mission/mission_integration_test.py
@@ -320,8 +320,6 @@ class TestGetterSetter:
         """do_set_attributes() should send the success message."""
         pub.subscribe(self.on_succeed_set_attributes, "succeed_get_mission_tree")
 
-        test_tablemodel.do_set_attributes(
-            node_id=[1, ""], package={"mission_time": 12.86}
-        )
+        test_tablemodel.do_set_attributes(node_id=1, package={"mission_time": 12.86})
 
         pub.unsubscribe(self.on_succeed_set_attributes, "succeed_get_mission_tree")

--- a/tests/models/programdb/mission_phase/mission_phase_integration_test.py
+++ b/tests/models/programdb/mission_phase/mission_phase_integration_test.py
@@ -346,7 +346,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_mission_phase_attributes",
-            node_id=[1, ""],
+            node_id=1,
             package={"phase_start": 12.86},
         )
 

--- a/tests/models/programdb/mode/mode_integration_test.py
+++ b/tests/models/programdb/mode/mode_integration_test.py
@@ -337,7 +337,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_mode_attributes",
-            node_id=[4, ""],
+            node_id=4,
             package={"description": "Jared Kushner"},
         )
 

--- a/tests/models/programdb/nswc/nswc_integration_test.py
+++ b/tests/models/programdb/nswc/nswc_integration_test.py
@@ -382,7 +382,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_nswc_attributes",
-            node_id=[2],
+            node_id=2,
             package={"Cac": 65.5},
         )
 

--- a/tests/models/programdb/opload/opload_integration_test.py
+++ b/tests/models/programdb/opload/opload_integration_test.py
@@ -332,7 +332,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_opload_attributes",
-            node_id=[4],
+            node_id=4,
             package={"description": "Big test operating load."},
         )
 

--- a/tests/models/programdb/opstress/opstress_integration_test.py
+++ b/tests/models/programdb/opstress/opstress_integration_test.py
@@ -329,7 +329,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_opstress_attributes",
-            node_id=[3],
+            node_id=3,
             package={"description": "Big test operating load."},
         )
 

--- a/tests/models/programdb/program_info/program_info_integration_test.py
+++ b/tests/models/programdb/program_info/program_info_integration_test.py
@@ -264,7 +264,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_preference_attributes",
-            node_id=[1],
+            node_id=1,
             package={"function_active": 0},
         )
 
@@ -272,7 +272,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_preference_attributes",
-            node_id=[1],
+            node_id=1,
             package={"function_active": 1},
         )
         assert test_datamanager.do_select(1).function_active == 1

--- a/tests/models/programdb/program_status/program_status_integration_test.py
+++ b/tests/models/programdb/program_status/program_status_integration_test.py
@@ -366,7 +366,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_opstress_attributes",
-            node_id=[1, ""],
+            node_id=1,
             package={"description": "Big test operating load."},
         )
 

--- a/tests/models/programdb/reliability/reliability_integration_test.py
+++ b/tests/models/programdb/reliability/reliability_integration_test.py
@@ -392,7 +392,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_reliability_attributes",
-            node_id=[2],
+            node_id=2,
             package={"location_parameter": 65.5},
         )
 

--- a/tests/models/programdb/requirement/requirement_integration_test.py
+++ b/tests/models/programdb/requirement/requirement_integration_test.py
@@ -400,7 +400,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_requirement_attributes",
-            node_id=[1, -1],
+            node_id=1,
             package={"requirement_code": "REQ-0001"},
         )
 
@@ -416,7 +416,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_requirement_attributes",
-            node_id=[1, -1],
+            node_id=1,
             package={"validated_date": None},
         )
 

--- a/tests/models/programdb/revision/revision_integration_test.py
+++ b/tests/models/programdb/revision/revision_integration_test.py
@@ -315,7 +315,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_revision_attributes",
-            node_id=[1],
+            node_id=1,
             package={"revision_code": "ABC"},
         )
 

--- a/tests/models/programdb/similar_item/similar_item_integration_test.py
+++ b/tests/models/programdb/similar_item/similar_item_integration_test.py
@@ -463,7 +463,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_similar_item_attributes",
-            node_id=[1],
+            node_id=1,
             package={"change_description_1": "Testing set name from moduleview."},
         )
 

--- a/tests/models/programdb/stakeholder/stakeholder_integration_test.py
+++ b/tests/models/programdb/stakeholder/stakeholder_integration_test.py
@@ -349,7 +349,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_stakeholder_attributes",
-            node_id=[1],
+            node_id=1,
             package={"description": "Testing set description from moduleview."},
         )
 

--- a/tests/models/programdb/test_method/method_integration_test.py
+++ b/tests/models/programdb/test_method/method_integration_test.py
@@ -331,7 +331,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_test_method_attributes",
-            node_id=[1],
+            node_id=1,
             package={"boundary_conditions": "Big test boundary condition."},
         )
 

--- a/tests/models/programdb/validation/validation_integration_test.py
+++ b/tests/models/programdb/validation/validation_integration_test.py
@@ -334,7 +334,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_validation_attributes",
-            node_id=[1],
+            node_id=1,
             package={"task_specification": "MIL-HDBK-217F"},
         )
 


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
To only allow integer values for the node_id argument to do_set_attributes().

## Describe how this was implemented.
Removed the code that handled deprecated List node_id arguments.  Updated calls to only use an integer argument.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #681


## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [ ] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
