### PR TITLE
fix: add method to ensure proper level description/remarks is updated

### DIFF
--- a/.github/workflows/on-pr-open.yml
+++ b/.github/workflows/on-pr-open.yml
@@ -68,3 +68,10 @@ jobs:
         with:
           release: "${{ steps.releasenotes.outputs.tag_name }}"
           append: "${{ steps.releasenotes.outputs.body }}"
+
+      - name: Commit and push changes
+        uses: actions-js/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          message: "docs: update CHANGELOG.md"

--- a/src/ramstk/views/gtk3/fmea/panel.py
+++ b/src/ramstk/views/gtk3/fmea/panel.py
@@ -564,8 +564,8 @@ class FMEATreePanel(RAMSTKTreePanel):
                 7,
                 Gtk.CellRendererText(),
                 "edited",
-                super().on_cell_edit,
-                self._on_edit_message,
+                self._on_cell_edit,
+                "wvw_editing_fmeca",
                 "",
                 {
                     "bg_color": "#FFFFFF",
@@ -1239,9 +1239,8 @@ class FMEATreePanel(RAMSTKTreePanel):
 
         self.tvwTreeView.set_tooltip_text(
             _(
-                "Displays the (Design) Failure Mode and Effects "
-                "(and Criticality) Analysis [(D)FME(C)A] for the "
-                "currently selected Hardware item."
+                "Displays the (Design) Failure Mode and Effects (and Criticality) "
+                "Analysis [(D)FME(C)A] for the currently selected Hardware item."
             )
         )
 
@@ -1309,6 +1308,32 @@ class FMEATreePanel(RAMSTKTreePanel):
             self.tvwTreeView.position["mission"]
         ).get_cells()
         _cell[0].connect("edited", self._on_mission_change)
+
+    def _on_cell_edit(
+        self,
+        cell: Gtk.CellRenderer,
+        path: str,
+        new_text: str,
+        key: str,
+        message: str,
+    ) -> None:
+        """Handle edits of description column to ensure proper level is updated.
+
+        :param cell: the Gtk.CellRenderer() that was edited.
+        :param path: the RAMSTKTreeView() path of the Gtk.CellRenderer()
+            that was edited.
+        :param new_text: the new text in the edited Gtk.CellRenderer().
+        :param key: the column key of the edited Gtk.CellRenderer().
+        :param message: the PyPubSub message to publish.
+        :return: None
+        """
+        super().on_cell_edit(
+            cell,
+            path,
+            new_text,
+            key,
+            f"wvw_editing_{self.level}",
+        )
 
     def _on_mission_change(
         self, __combo: Gtk.CellRendererCombo, path: str, new_text: str

--- a/src/ramstk/views/gtk3/pof/panel.py
+++ b/src/ramstk/views/gtk3/pof/panel.py
@@ -249,8 +249,8 @@ class PoFTreePanel(RAMSTKTreePanel):
                 6,
                 Gtk.CellRendererText(),
                 "edited",
-                super().on_cell_edit,
-                self._on_edit_message,
+                self._on_cell_edit,
+                "wvw_editing_pof",
                 "",
                 {
                     "bg_color": "#FFFFFF",
@@ -393,8 +393,8 @@ class PoFTreePanel(RAMSTKTreePanel):
                 15,
                 Gtk.CellRendererText(),
                 "edited",
-                super().on_cell_edit,
-                "wvw_editing_test_method",
+                self._on_cell_edit,
+                "wvw_editing_pof",
                 "",
                 {
                     "bg_color": "#FFFFFF",
@@ -484,6 +484,32 @@ class PoFTreePanel(RAMSTKTreePanel):
         ).get_cells()[0]
         _adjustment = _cell.get_property("adjustment")
         _adjustment.configure(5, 1, 5, -1, 0, 0)
+
+    def _on_cell_edit(
+        self,
+        cell: Gtk.CellRenderer,
+        path: str,
+        new_text: str,
+        key: str,
+        message: str,
+    ) -> None:
+        """Handle edits of description column to ensure proper level is updated.
+
+        :param cell: the Gtk.CellRenderer() that was edited.
+        :param path: the RAMSTKTreeView() path of the Gtk.CellRenderer()
+            that was edited.
+        :param new_text: the new text in the edited Gtk.CellRenderer().
+        :param key: the column key of the edited Gtk.CellRenderer().
+        :param message: the PyPubSub message to publish.
+        :return: None
+        """
+        super().on_cell_edit(
+            cell,
+            path,
+            new_text,
+            key,
+            f"wvw_editing_{self.level}",
+        )
 
     def _on_row_change(self, selection: Gtk.TreeSelection) -> None:
         """Handle events for the PoF Work View RAMSTKTreeView().


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
To allow the various levels in the FMEA/PoF description and remarks fields to be updated when edited.

## Describe how this was implemented.
Added a method to each analyses panel view to wrap the meta class on_cell_edit() method so the correct level (mode, mechanism, opload, etc.) is sent as the PyPubSub message "wvw_editing_<level>".

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #898 

## Pull Request Checklist

- Code Style
  - [ ] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [ ] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
