### PR TITLE
fix: fail to insert verification task

### DIFF
--- a/.github/workflows/on-pr-open.yml
+++ b/.github/workflows/on-pr-open.yml
@@ -60,16 +60,11 @@ jobs:
           sinceTag: "v0.10.0"
           issues-wo-labels: "false"
           breakingLabel: "Breaking Changes"
-          breakingLabels:
-            - "bump: major"
+          breakingLabels: "bump: major"
           enhancementLabel: "New Features"
-          enhancementLabels:
-            - "bump: minor"
-            - "type: feature"
+          enhancementLabels: "bump: minor"
           bugLabel: "Bug Fixes"
-          bugLabels:
-            - "bump: patch"
-            - "type: fix"
+          bugLabels: "bump: patch"
 
       - name: Commit and push changes
         uses: actions-js/push@master

--- a/src/ramstk/models/programdb/validation/record.py
+++ b/src/ramstk/models/programdb/validation/record.py
@@ -42,10 +42,10 @@ class RAMSTKValidationRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         "date_end": date.today() + timedelta(days=30),
         "date_start": date.today(),
         "description": "",
-        "measurement_unit": "",
+        "measurement_unit": 0,
         "name": "",
         "status": 0.0,
-        "task_type": "",
+        "task_type": 0,
         "task_specification": "",
         "time_average": 0.0,
         "time_ll": 0.0,
@@ -104,7 +104,7 @@ class RAMSTKValidationRecord(RAMSTK_BASE, RAMSTKBaseRecord):
     date_start = Column("fld_date_start", Date, default=__defaults__["date_start"])
     description = Column("fld_description", String, default=__defaults__["description"])
     measurement_unit = Column(
-        "fld_measurement_unit", String(256), default=__defaults__["measurement_unit"]
+        "fld_measurement_unit", Integer, default=__defaults__["measurement_unit"]
     )
     name = Column("fld_name", String(256), default=__defaults__["name"])
     status = Column("fld_status", Float, default=__defaults__["status"])
@@ -113,7 +113,7 @@ class RAMSTKValidationRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         String(512),
         default=__defaults__["task_specification"],
     )
-    task_type = Column("fld_type", String(256), default=__defaults__["task_type"])
+    task_type = Column("fld_type", Integer, default=__defaults__["task_type"])
     time_average = Column(
         "fld_time_average", Float, default=__defaults__["time_average"]
     )

--- a/src/ramstk/models/programdb/validation/table.py
+++ b/src/ramstk/models/programdb/validation/table.py
@@ -49,6 +49,8 @@ class RAMSTKValidationTable(RAMSTKBaseTable):
         self._lst_id_columns = [
             "revision_id",
             "validation_id",
+            "parent_id",
+            "record_id",
         ]
 
         # Initialize private scalar attributes.

--- a/tests/models/programdb/validation/validation_integration_test.py
+++ b/tests/models/programdb/validation/validation_integration_test.py
@@ -93,6 +93,8 @@ class TestInsertMethods:
         """should add a record to the record tree and update last_id."""
         pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_validation")
 
+        test_attributes["parent_id"] = 0
+        test_attributes["record_id"] = 0
         pub.sendMessage("request_insert_validation", attributes=test_attributes)
 
         pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_validation")
@@ -102,6 +104,8 @@ class TestInsertMethods:
         """should not add a record when passed a non-existent revision ID."""
         pub.subscribe(self.on_fail_insert_no_revision, "fail_insert_validation")
 
+        test_attributes["parent_id"] = 0
+        test_attributes["record_id"] = 0
         test_attributes["revision_id"] = 30
         pub.sendMessage("request_insert_validation", attributes=test_attributes)
 

--- a/tests/models/programdb/validation/validation_unit_test.py
+++ b/tests/models/programdb/validation/validation_unit_test.py
@@ -184,6 +184,8 @@ class TestInsertMethods:
     @pytest.mark.unit
     def test_do_insert_sibling(self, test_attributes, test_tablemodel):
         """should add a new record to the records tree and update last_id."""
+        test_attributes["parent_id"] = 0
+        test_attributes["record_id"] = 0
         test_tablemodel.do_select_all(attributes=test_attributes)
         test_tablemodel.do_insert(attributes=test_attributes)
 


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
To fix the problem of failing to insert Verification tasks.

## Describe how this was implemented.
Add "parent_id" and "record_id" to list of ID columns to pop from the attributes dict used during insert.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #914 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
