### PR TITLE
fix: verification plan calculate all updates wrong records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,50 +1,459 @@
 # Changelog
 
-## [Unreleased]
+## [v0.15.11](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.11) (2022-01-28)
 
-## [0.15.9]
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/latest...v0.15.11)
 
-## [latest]
+## [latest](https://github.com/ReliaQualAssociates/ramstk/tree/latest) (2022-01-28)
 
-## [0.15.5]
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.10...latest)
 
-## [0.15.4]
+Bug Fixes
 
-## [0.15.3]
-
-## [v0.12.0(https://github.com/ReliaQualAssociates/ramstk/tree/v0.12.0)]
-[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.11.0...v0.12.0)
-
-**Implemented features:**
-
-- feat: add support for Python 3.8 [\#449](https://github.com/ReliaQualAssociates/ramstk/pull/449) ([weibullguy](https://github.com/weibullguy))
-
-**Implemented enhancements:**
-
-- enhance: add refresh and save buttons to database dialog [\#450](https://github.com/ReliaQualAssociates/ramstk/pull/450) ([weibullguy](https://github.com/weibullguy))
-
-**Closed issues:**
-
-- Error When Trying to Build Wheel for Numpy with release v-1.0.0 [\#372](https://github.com/ReliaQualAssociates/ramstk/issues/372)
+- fix: DVP&R plan actual status not loading [\#921](https://github.com/ReliaQualAssociates/ramstk/pull/921) ([weibullguy](https://github.com/weibullguy))
+- fix: verification task calculation not completing [\#918](https://github.com/ReliaQualAssociates/ramstk/pull/918) ([weibullguy](https://github.com/weibullguy))
 
 **Merged pull requests:**
 
+- release: v0.15.11 [\#922](https://github.com/ReliaQualAssociates/ramstk/pull/922) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: add GPG key for auto actions [\#919](https://github.com/ReliaQualAssociates/ramstk/pull/919) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.10](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.10) (2022-01-27)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.9...v0.15.10)
+
+Bug Fixes
+
+- fix: fail to insert verification task [\#915](https://github.com/ReliaQualAssociates/ramstk/pull/915) ([weibullguy](https://github.com/weibullguy))
+- fix: add try block to convert datetime to string [\#912](https://github.com/ReliaQualAssociates/ramstk/pull/912) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.10 [\#916](https://github.com/ReliaQualAssociates/ramstk/pull/916) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: update on-pr-open action to use git for finding version [\#913](https://github.com/ReliaQualAssociates/ramstk/pull/913) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.9](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.9) (2022-01-26)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.8...v0.15.9)
+
+Bug Fixes
+
+- fix: verification task list now loads [\#903](https://github.com/ReliaQualAssociates/ramstk/pull/903) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.9 [\#905](https://github.com/ReliaQualAssociates/ramstk/pull/905) ([github-actions[bot]](https://github.com/apps/github-actions))
+- refactor: remove unused methods [\#901](https://github.com/ReliaQualAssociates/ramstk/pull/901) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.8](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.8) (2022-01-25)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.7...v0.15.8)
+
+Bug Fixes
+
+- fix: add method to ensure proper level description/remarks is updated [\#899](https://github.com/ReliaQualAssociates/ramstk/pull/899) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.8 [\#900](https://github.com/ReliaQualAssociates/ramstk/pull/900) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: add step to checkout repository [\#896](https://github.com/ReliaQualAssociates/ramstk/pull/896) ([weibullguy](https://github.com/weibullguy))
+- refactor: update do\_set\_attributes\(\) node\_id argument to integer [\#894](https://github.com/ReliaQualAssociates/ramstk/pull/894) ([weibullguy](https://github.com/weibullguy))
+- ci: update previous tag action [\#893](https://github.com/ReliaQualAssociates/ramstk/pull/893) ([weibullguy](https://github.com/weibullguy))
+- refactor: rewrite RAMSTKBaseTable do\_select\_all\(\) [\#890](https://github.com/ReliaQualAssociates/ramstk/pull/890) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.7](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.7) (2022-01-23)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/0.15.6...v0.15.7)
+
+Bug Fixes
+
+- fix: not able to delete FMEA or PoF row [\#886](https://github.com/ReliaQualAssociates/ramstk/pull/886) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- ci: update CHANGELOG.md when opening PR [\#888](https://github.com/ReliaQualAssociates/ramstk/pull/888) ([weibullguy](https://github.com/weibullguy))
+- release: v0.15.7 [\#887](https://github.com/ReliaQualAssociates/ramstk/pull/887) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: update on-merge workflow to use ref [\#884](https://github.com/ReliaQualAssociates/ramstk/pull/884) ([weibullguy](https://github.com/weibullguy))
+
+## [0.15.6](https://github.com/ReliaQualAssociates/ramstk/tree/0.15.6) (2022-01-23)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.5...0.15.6)
+
+Bug Fixes
+
+- fix: PoF changes can now be saved [\#882](https://github.com/ReliaQualAssociates/ramstk/pull/882) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.6 [\#883](https://github.com/ReliaQualAssociates/ramstk/pull/883) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: move job to update version files to PR close workflow [\#880](https://github.com/ReliaQualAssociates/ramstk/pull/880) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.5](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.5) (2022-01-22)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.4...v0.15.5)
+
+Bug Fixes
+
+- fix: able to insert PoF records [\#876](https://github.com/ReliaQualAssociates/ramstk/pull/876) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- ci: update workflows [\#879](https://github.com/ReliaQualAssociates/ramstk/pull/879) ([weibullguy](https://github.com/weibullguy))
+- release: v0.15.5 [\#878](https://github.com/ReliaQualAssociates/ramstk/pull/878) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: move documentation build and deploy action to separate workflow [\#874](https://github.com/ReliaQualAssociates/ramstk/pull/874) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.4](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.4) (2022-01-20)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.3...v0.15.4)
+
+Bug Fixes
+
+- fix: PoF analysis not loading correctly [\#872](https://github.com/ReliaQualAssociates/ramstk/pull/872) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.4 [\#873](https://github.com/ReliaQualAssociates/ramstk/pull/873) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: update action workflows [\#870](https://github.com/ReliaQualAssociates/ramstk/pull/870) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.3](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.3) (2022-01-19)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.2...v0.15.3)
+
+Bug Fixes
+
+- fix: add update methods to FMEA [\#868](https://github.com/ReliaQualAssociates/ramstk/pull/868) ([weibullguy](https://github.com/weibullguy))
+- fix: unable to insert FMEA item [\#865](https://github.com/ReliaQualAssociates/ramstk/pull/865) ([weibullguy](https://github.com/weibullguy))
+- fix: update workflow file [\#861](https://github.com/ReliaQualAssociates/ramstk/pull/861) ([weibullguy](https://github.com/weibullguy))
+- fix: Similar Item Analysis Now Loads [\#860](https://github.com/ReliaQualAssociates/ramstk/pull/860) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.3 [\#869](https://github.com/ReliaQualAssociates/ramstk/pull/869) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: update action workflows [\#857](https://github.com/ReliaQualAssociates/ramstk/pull/857) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.2](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.2) (2022-01-10)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.1...v0.15.2)
+
+Bug Fixes
+
+- ci: add step to label closed PR [\#855](https://github.com/ReliaQualAssociates/ramstk/pull/855) ([weibullguy](https://github.com/weibullguy))
+- fix: load Allocation worksheet [\#851](https://github.com/ReliaQualAssociates/ramstk/pull/851) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.2 [\#856](https://github.com/ReliaQualAssociates/ramstk/pull/856) ([github-actions[bot]](https://github.com/apps/github-actions))
+- ci: fix issue assign action [\#854](https://github.com/ReliaQualAssociates/ramstk/pull/854) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.15.1](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.1) (2022-01-09)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.0...v0.15.1)
+
+Bug Fixes
+
+- fix: handle no server connection error [\#848](https://github.com/ReliaQualAssociates/ramstk/pull/848) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- ci: set for release [\#849](https://github.com/ReliaQualAssociates/ramstk/pull/849) ([github-actions[bot]](https://github.com/apps/github-actions))
+
+## [v0.15.0](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.0) (2022-01-07)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.14.2...v0.15.0)
+
+New Features
+
+- release: v0.15.0 [\#840](https://github.com/ReliaQualAssociates/ramstk/pull/840) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- ci: set for release [\#843](https://github.com/ReliaQualAssociates/ramstk/pull/843) ([github-actions[bot]](https://github.com/apps/github-actions))
+- refactor: retire \_lst\_col\_order attribute from RAMSTKPanel [\#818](https://github.com/ReliaQualAssociates/ramstk/pull/818) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove calls to RAMSTKPanel methods in RAMSTKView classes [\#817](https://github.com/ReliaQualAssociates/ramstk/pull/817) ([weibullguy](https://github.com/weibullguy))
+- style: rename \_module attribute in RAMSTKViews [\#816](https://github.com/ReliaQualAssociates/ramstk/pull/816) ([weibullguy](https://github.com/weibullguy))
+- refactor: update format of RAMSTKTreeView layout files [\#814](https://github.com/ReliaQualAssociates/ramstk/pull/814) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Preferences panel methods to metaclass [\#810](https://github.com/ReliaQualAssociates/ramstk/pull/810) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Options panel method to metaclass [\#809](https://github.com/ReliaQualAssociates/ramstk/pull/809) ([weibullguy](https://github.com/weibullguy))
+- refactor: move PoF panel methods to metaclass [\#805](https://github.com/ReliaQualAssociates/ramstk/pull/805) ([weibullguy](https://github.com/weibullguy))
+- refactor: move FMEA panel methods to metaclass [\#802](https://github.com/ReliaQualAssociates/ramstk/pull/802) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Program Status panel methods to metaclass [\#801](https://github.com/ReliaQualAssociates/ramstk/pull/801) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Similar Item panel methods to metaclass [\#798](https://github.com/ReliaQualAssociates/ramstk/pull/798) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Allocation panel methods to metaclass [\#797](https://github.com/ReliaQualAssociates/ramstk/pull/797) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Stakeholder panel methods to metaclass [\#796](https://github.com/ReliaQualAssociates/ramstk/pull/796) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Hazards panel methods to metaclass [\#795](https://github.com/ReliaQualAssociates/ramstk/pull/795) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Usage Profile methods to panel.py and view.py [\#793](https://github.com/ReliaQualAssociates/ramstk/pull/793) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Failure Definition panel methods to metaclass [\#789](https://github.com/ReliaQualAssociates/ramstk/pull/789) ([weibullguy](https://github.com/weibullguy))
+- build: update dependencies [\#776](https://github.com/ReliaQualAssociates/ramstk/pull/776) ([weibullguy](https://github.com/weibullguy))
+- build\(deps\): bump lifelines from 0.25.11 to 0.26.3 [\#775](https://github.com/ReliaQualAssociates/ramstk/pull/775) ([dependabot[bot]](https://github.com/apps/dependabot))
+- refactor: move Hardware panel methods to RAMSTKPanel [\#774](https://github.com/ReliaQualAssociates/ramstk/pull/774) ([weibullguy](https://github.com/weibullguy))
+- build\(deps-dev\): bump mypy from 0.800 to 0.910 [\#773](https://github.com/ReliaQualAssociates/ramstk/pull/773) ([dependabot[bot]](https://github.com/apps/dependabot))
+- build\(deps-dev\): bump pre-commit-hooks from 3.4.0 to 4.0.1 [\#772](https://github.com/ReliaQualAssociates/ramstk/pull/772) ([dependabot[bot]](https://github.com/apps/dependabot))
+- build\(deps-dev\): bump pyroma from 2.6.1 to 3.2 [\#771](https://github.com/ReliaQualAssociates/ramstk/pull/771) ([dependabot[bot]](https://github.com/apps/dependabot))
+- build\(deps-dev\): bump pydocstyle from 5.1.1 to 6.1.1 [\#766](https://github.com/ReliaQualAssociates/ramstk/pull/766) ([dependabot[bot]](https://github.com/apps/dependabot))
+- refactor: add all tables to database model [\#762](https://github.com/ReliaQualAssociates/ramstk/pull/762) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Validation panel methods to RAMSTKPanel [\#759](https://github.com/ReliaQualAssociates/ramstk/pull/759) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Requirement panel methods to RAMSTKPanel [\#757](https://github.com/ReliaQualAssociates/ramstk/pull/757) ([weibullguy](https://github.com/weibullguy))
+- refactor: split RAMSTKPanel into separate classes [\#756](https://github.com/ReliaQualAssociates/ramstk/pull/756) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Function panel methods to RAMSTKPanel [\#753](https://github.com/ReliaQualAssociates/ramstk/pull/753) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Revision panel methods to RAMSTKPanel [\#751](https://github.com/ReliaQualAssociates/ramstk/pull/751) ([weibullguy](https://github.com/weibullguy))
+- refactor: add RAMSTKPanel methods for refactoring [\#749](https://github.com/ReliaQualAssociates/ramstk/pull/749) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Site Info models to record.py and table.py [\#746](https://github.com/ReliaQualAssociates/ramstk/pull/746) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Test Method models to ramstk.models.programdb.test\_method [\#745](https://github.com/ReliaQualAssociates/ramstk/pull/745) ([weibullguy](https://github.com/weibullguy))
+- refactor: move OpStress models to ramstk.models.opstress [\#742](https://github.com/ReliaQualAssociates/ramstk/pull/742) ([weibullguy](https://github.com/weibullguy))
+- refactor: move OpLoad models to ramstk.models.opload [\#741](https://github.com/ReliaQualAssociates/ramstk/pull/741) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Action models to ramstk.models.action [\#739](https://github.com/ReliaQualAssociates/ramstk/pull/739) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Control models to ramstk.models.control [\#737](https://github.com/ReliaQualAssociates/ramstk/pull/737) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Cause models to ramstk.models.cause [\#736](https://github.com/ReliaQualAssociates/ramstk/pull/736) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mechanism models to ramstk.models.mechanism [\#735](https://github.com/ReliaQualAssociates/ramstk/pull/735) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mode models to ramstk.models.mode [\#728](https://github.com/ReliaQualAssociates/ramstk/pull/728) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Program Info models to ramstk.models.program\_info [\#727](https://github.com/ReliaQualAssociates/ramstk/pull/727) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Program Status models to ramstk.models.program\_status [\#726](https://github.com/ReliaQualAssociates/ramstk/pull/726) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Validation models to ramstk.models.validation [\#722](https://github.com/ReliaQualAssociates/ramstk/pull/722) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Stakeholder models to ramstk.models.stakeholder [\#720](https://github.com/ReliaQualAssociates/ramstk/pull/720) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Requirement models to ramstk.models.requirement [\#719](https://github.com/ReliaQualAssociates/ramstk/pull/719) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Hazard to ramstk.models.hazard [\#718](https://github.com/ReliaQualAssociates/ramstk/pull/718) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Function models to ramstk.models.function [\#717](https://github.com/ReliaQualAssociates/ramstk/pull/717) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Environment models to ramstk.models.environment [\#715](https://github.com/ReliaQualAssociates/ramstk/pull/715) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mission Phase to ramstk.models.mission\_phase [\#712](https://github.com/ReliaQualAssociates/ramstk/pull/712) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mission models to ramstk.models.mission [\#709](https://github.com/ReliaQualAssociates/ramstk/pull/709) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Failure Definition to ramstk.models [\#708](https://github.com/ReliaQualAssociates/ramstk/pull/708) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Revision to Models package [\#703](https://github.com/ReliaQualAssociates/ramstk/pull/703) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Similar Item to models package [\#701](https://github.com/ReliaQualAssociates/ramstk/pull/701) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Allocation models to ramstk.models.allocation [\#698](https://github.com/ReliaQualAssociates/ramstk/pull/698) ([weibullguy](https://github.com/weibullguy))
+- refactor: move RAMSTKReliability to record.py [\#696](https://github.com/ReliaQualAssociates/ramstk/pull/696) ([weibullguy](https://github.com/weibullguy))
+- refactor: move RAMSTNSWC to record.py [\#694](https://github.com/ReliaQualAssociates/ramstk/pull/694) ([weibullguy](https://github.com/weibullguy))
+- refactor: move RAMSTKMilHdbk217F to record.py [\#692](https://github.com/ReliaQualAssociates/ramstk/pull/692) ([weibullguy](https://github.com/weibullguy))
+- refactor: move RAMSTKHardware to record.py [\#690](https://github.com/ReliaQualAssociates/ramstk/pull/690) ([weibullguy](https://github.com/weibullguy))
+- refactor: move RAMSTKDesignMechanic to record.py [\#688](https://github.com/ReliaQualAssociates/ramstk/pull/688) ([weibullguy](https://github.com/weibullguy))
+- refactor: move RAMSTKDesignElectric to record.py [\#686](https://github.com/ReliaQualAssociates/ramstk/pull/686) ([weibullguy](https://github.com/weibullguy))
+- build: move mypy configuration to pyproject.toml [\#683](https://github.com/ReliaQualAssociates/ramstk/pull/683) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Hardware controllers to table and view models [\#682](https://github.com/ReliaQualAssociates/ramstk/pull/682) ([weibullguy](https://github.com/weibullguy))
+- refactor: create Hardware table model [\#680](https://github.com/ReliaQualAssociates/ramstk/pull/680) ([weibullguy](https://github.com/weibullguy))
+- refactor: create Reliability table model [\#678](https://github.com/ReliaQualAssociates/ramstk/pull/678) ([weibullguy](https://github.com/weibullguy))
+- refactor: create NSWC table model [\#677](https://github.com/ReliaQualAssociates/ramstk/pull/677) ([weibullguy](https://github.com/weibullguy))
+- refactor: add MIL-HDBK-217F table model [\#676](https://github.com/ReliaQualAssociates/ramstk/pull/676) ([weibullguy](https://github.com/weibullguy))
+- refactor: create Design Mechanic table model [\#675](https://github.com/ReliaQualAssociates/ramstk/pull/675) ([weibullguy](https://github.com/weibullguy))
+- refactor: create Design Electric table model [\#674](https://github.com/ReliaQualAssociates/ramstk/pull/674) ([weibullguy](https://github.com/weibullguy))
+- build: create templates for record, table, and view models [\#667](https://github.com/ReliaQualAssociates/ramstk/pull/667) ([weibullguy](https://github.com/weibullguy))
+- refactor: move RPN calculations to Cause and Mechanism table managers [\#663](https://github.com/ReliaQualAssociates/ramstk/pull/663) ([weibullguy](https://github.com/weibullguy))
+- refactor: move aggregate data managers to view manager [\#661](https://github.com/ReliaQualAssociates/ramstk/pull/661) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Validation analysis methods to table manager [\#660](https://github.com/ReliaQualAssociates/ramstk/pull/660) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Program Status analysis methods to table manager [\#659](https://github.com/ReliaQualAssociates/ramstk/pull/659) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mode analysis methods to table manager [\#658](https://github.com/ReliaQualAssociates/ramstk/pull/658) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Similar Item analysis methods to table manager [\#657](https://github.com/ReliaQualAssociates/ramstk/pull/657) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Allocation analysis methods to table manager [\#652](https://github.com/ReliaQualAssociates/ramstk/pull/652) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Stakeholder analysis methods to table manager [\#651](https://github.com/ReliaQualAssociates/ramstk/pull/651) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Hazards analysis methods to table manager [\#649](https://github.com/ReliaQualAssociates/ramstk/pull/649) ([weibullguy](https://github.com/weibullguy))
+- refactor: move do\_set\_all\_attributes\(\) to metaclass [\#647](https://github.com/ReliaQualAssociates/ramstk/pull/647) ([weibullguy](https://github.com/weibullguy))
+- refactor: move pypubsub subscribers to metaclass [\#646](https://github.com/ReliaQualAssociates/ramstk/pull/646) ([weibullguy](https://github.com/weibullguy))
+- refactor: move do\_select\_all\(\) to metaclass [\#642](https://github.com/ReliaQualAssociates/ramstk/pull/642) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove \_do\_insert\_\<\> from table managers [\#641](https://github.com/ReliaQualAssociates/ramstk/pull/641) ([weibullguy](https://github.com/weibullguy))
+- refactor: move do\_delete\(\) to metaclass [\#640](https://github.com/ReliaQualAssociates/ramstk/pull/640) ([weibullguy](https://github.com/weibullguy))
+- Refactor/issue 631 [\#637](https://github.com/ReliaQualAssociates/ramstk/pull/637) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree from Validation [\#635](https://github.com/ReliaQualAssociates/ramstk/pull/635) ([weibullguy](https://github.com/weibullguy))
+- Refactor/issue 608 [\#634](https://github.com/ReliaQualAssociates/ramstk/pull/634) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Stakeholder [\#633](https://github.com/ReliaQualAssociates/ramstk/pull/633) ([weibullguy](https://github.com/weibullguy))
+- Refactor/issue 606 [\#632](https://github.com/ReliaQualAssociates/ramstk/pull/632) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Revision [\#630](https://github.com/ReliaQualAssociates/ramstk/pull/630) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Requirement [\#629](https://github.com/ReliaQualAssociates/ramstk/pull/629) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Program Status [\#628](https://github.com/ReliaQualAssociates/ramstk/pull/628) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Preferences [\#627](https://github.com/ReliaQualAssociates/ramstk/pull/627) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree from Options [\#625](https://github.com/ReliaQualAssociates/ramstk/pull/625) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree from OpStress [\#624](https://github.com/ReliaQualAssociates/ramstk/pull/624) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) OpLoad datamanager [\#623](https://github.com/ReliaQualAssociates/ramstk/pull/623) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Mode datamanager [\#622](https://github.com/ReliaQualAssociates/ramstk/pull/622) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Mission Phase Datamanager [\#621](https://github.com/ReliaQualAssociates/ramstk/pull/621) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Mission Datamanager [\#618](https://github.com/ReliaQualAssociates/ramstk/pull/618) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Mechanism datamanager [\#617](https://github.com/ReliaQualAssociates/ramstk/pull/617) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Hazard datamanager [\#616](https://github.com/ReliaQualAssociates/ramstk/pull/616) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Function datamanager [\#615](https://github.com/ReliaQualAssociates/ramstk/pull/615) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Failure Definition datamanager [\#613](https://github.com/ReliaQualAssociates/ramstk/pull/613) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Environment datamanager [\#612](https://github.com/ReliaQualAssociates/ramstk/pull/612) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from Control datamanager [\#611](https://github.com/ReliaQualAssociates/ramstk/pull/611) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree\(\) from cause datamanager [\#610](https://github.com/ReliaQualAssociates/ramstk/pull/610) ([weibullguy](https://github.com/weibullguy))
+- refactor: remove do\_get\_tree from Action datamanager [\#586](https://github.com/ReliaQualAssociates/ramstk/pull/586) ([weibullguy](https://github.com/weibullguy))
+- refactor: add do\_get\_tree to metaclass [\#584](https://github.com/ReliaQualAssociates/ramstk/pull/584) ([weibullguy](https://github.com/weibullguy))
+- refactor: move on insert to metaclass [\#583](https://github.com/ReliaQualAssociates/ramstk/pull/583) ([weibullguy](https://github.com/weibullguy))
+- test: add fmea analysis manager tests [\#581](https://github.com/ReliaQualAssociates/ramstk/pull/581) ([weibullguy](https://github.com/weibullguy))
+- refactor: add mode analysis manager [\#580](https://github.com/ReliaQualAssociates/ramstk/pull/580) ([weibullguy](https://github.com/weibullguy))
+- refactor: move fmea to structure manager [\#577](https://github.com/ReliaQualAssociates/ramstk/pull/577) ([weibullguy](https://github.com/weibullguy))
+- ci: rename workflow files [\#570](https://github.com/ReliaQualAssociates/ramstk/pull/570) ([weibullguy](https://github.com/weibullguy))
+- refactor: add action datamanager [\#568](https://github.com/ReliaQualAssociates/ramstk/pull/568) ([weibullguy](https://github.com/weibullguy))
+- test: Issue 565 update ramstkaction test attributes to a fixture [\#566](https://github.com/ReliaQualAssociates/ramstk/pull/566) ([weibullguy](https://github.com/weibullguy))
+- chore: update issue templates [\#560](https://github.com/ReliaQualAssociates/ramstk/pull/560) ([weibullguy](https://github.com/weibullguy))
+- refactor: create control datamanager [\#558](https://github.com/ReliaQualAssociates/ramstk/pull/558) ([weibullguy](https://github.com/weibullguy))
+- chore: add workflow to automate labels [\#557](https://github.com/ReliaQualAssociates/ramstk/pull/557) ([weibullguy](https://github.com/weibullguy))
+- refactor: create cause datamanager [\#556](https://github.com/ReliaQualAssociates/ramstk/pull/556) ([weibullguy](https://github.com/weibullguy))
+- refactor: move pof to aggregate manager [\#555](https://github.com/ReliaQualAssociates/ramstk/pull/555) ([weibullguy](https://github.com/weibullguy))
+- chore: add test.all and coverage.all targets [\#554](https://github.com/ReliaQualAssociates/ramstk/pull/554) ([weibullguy](https://github.com/weibullguy))
+- \[Snyk\] Fix for 4 vulnerabilities [\#494](https://github.com/ReliaQualAssociates/ramstk/pull/494) ([snyk-bot](https://github.com/snyk-bot))
+
+## [v0.14.2](https://github.com/ReliaQualAssociates/ramstk/tree/v0.14.2) (2021-07-19)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.14.1...v0.14.2)
+
+Bug Fixes
+
+- fix: Revision records tree not loading [\#552](https://github.com/ReliaQualAssociates/ramstk/pull/552) ([weibullguy](https://github.com/weibullguy))
+- fix: set no $HOME log directory [\#495](https://github.com/ReliaQualAssociates/ramstk/pull/495) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- chore: bump version files [\#553](https://github.com/ReliaQualAssociates/ramstk/pull/553) ([github-actions[bot]](https://github.com/apps/github-actions))
+- chore: setup\_gh\_actions\_automate\_proj\_mgmt [\#550](https://github.com/ReliaQualAssociates/ramstk/pull/550) ([weibullguy](https://github.com/weibullguy))
+- chore: update targets test runs [\#549](https://github.com/ReliaQualAssociates/ramstk/pull/549) ([weibullguy](https://github.com/weibullguy))
+- chore: black code base [\#548](https://github.com/ReliaQualAssociates/ramstk/pull/548) ([weibullguy](https://github.com/weibullguy))
+- refactor: move usage profile to structure manager [\#547](https://github.com/ReliaQualAssociates/ramstk/pull/547) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup mechanism test suite [\#546](https://github.com/ReliaQualAssociates/ramstk/pull/546) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup Hazards test suite [\#545](https://github.com/ReliaQualAssociates/ramstk/pull/545) ([weibullguy](https://github.com/weibullguy))
+- test: move Function pubsub tests to integration test file [\#544](https://github.com/ReliaQualAssociates/ramstk/pull/544) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup Failure Definition test suite [\#543](https://github.com/ReliaQualAssociates/ramstk/pull/543) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup allocation test suite [\#542](https://github.com/ReliaQualAssociates/ramstk/pull/542) ([weibullguy](https://github.com/weibullguy))
+- test: clean up Environment test suite [\#541](https://github.com/ReliaQualAssociates/ramstk/pull/541) ([weibullguy](https://github.com/weibullguy))
+- refactor: move environment do update to metaclass [\#540](https://github.com/ReliaQualAssociates/ramstk/pull/540) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup validation test suite [\#539](https://github.com/ReliaQualAssociates/ramstk/pull/539) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Validation do\_update\(\) to metaclass [\#538](https://github.com/ReliaQualAssociates/ramstk/pull/538) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup test method test suite [\#537](https://github.com/ReliaQualAssociates/ramstk/pull/537) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Test Method do\_update\(\) to metaclass [\#536](https://github.com/ReliaQualAssociates/ramstk/pull/536) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup stakeholder test suite [\#535](https://github.com/ReliaQualAssociates/ramstk/pull/535) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Stakeholder do\_update to metaclass [\#534](https://github.com/ReliaQualAssociates/ramstk/pull/534) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup Similar Item test suite [\#533](https://github.com/ReliaQualAssociates/ramstk/pull/533) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Similar Item do\_update\(\) to metaclass [\#532](https://github.com/ReliaQualAssociates/ramstk/pull/532) ([weibullguy](https://github.com/weibullguy))
+- test: clean up Revision test suite [\#531](https://github.com/ReliaQualAssociates/ramstk/pull/531) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup Requirements test suite [\#530](https://github.com/ReliaQualAssociates/ramstk/pull/530) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Requirement do\_update\(\) to metaclass [\#529](https://github.com/ReliaQualAssociates/ramstk/pull/529) ([weibullguy](https://github.com/weibullguy))
+- test: add Program Status mock db table [\#528](https://github.com/ReliaQualAssociates/ramstk/pull/528) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Program Status do\_update\(\) to metaclass [\#527](https://github.com/ReliaQualAssociates/ramstk/pull/527) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup preferences test suite [\#526](https://github.com/ReliaQualAssociates/ramstk/pull/526) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Preferences do\_update\(\) to metaclass [\#525](https://github.com/ReliaQualAssociates/ramstk/pull/525) ([weibullguy](https://github.com/weibullguy))
+- Test/cleanup options test suite [\#524](https://github.com/ReliaQualAssociates/ramstk/pull/524) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Options do\_update\(\) to metaclass [\#523](https://github.com/ReliaQualAssociates/ramstk/pull/523) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup opstress test suite [\#522](https://github.com/ReliaQualAssociates/ramstk/pull/522) ([weibullguy](https://github.com/weibullguy))
+- refactor: move OpStress do\_update\(\) to metaclass [\#521](https://github.com/ReliaQualAssociates/ramstk/pull/521) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup OpLoad test suite [\#520](https://github.com/ReliaQualAssociates/ramstk/pull/520) ([weibullguy](https://github.com/weibullguy))
+- refactor: move OpLoad do\_update\(\) to metaclass [\#519](https://github.com/ReliaQualAssociates/ramstk/pull/519) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup mode test suite [\#518](https://github.com/ReliaQualAssociates/ramstk/pull/518) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mode do\_update\(\) to metaclass [\#517](https://github.com/ReliaQualAssociates/ramstk/pull/517) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup mission phase test suite [\#516](https://github.com/ReliaQualAssociates/ramstk/pull/516) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mission Phase do\_update\(\) to metaclass [\#515](https://github.com/ReliaQualAssociates/ramstk/pull/515) ([weibullguy](https://github.com/weibullguy))
+- test: cleanup mission test suite [\#514](https://github.com/ReliaQualAssociates/ramstk/pull/514) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mission do\_update\(\) to metaclass [\#513](https://github.com/ReliaQualAssociates/ramstk/pull/513) ([weibullguy](https://github.com/weibullguy))
+- test: add mock RAMSTKMechanism for tests [\#512](https://github.com/ReliaQualAssociates/ramstk/pull/512) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Mechanism do\_update\(\) to metaclass [\#511](https://github.com/ReliaQualAssociates/ramstk/pull/511) ([weibullguy](https://github.com/weibullguy))
+- test: add mock RAMSTKFailureDefinition for tests [\#510](https://github.com/ReliaQualAssociates/ramstk/pull/510) ([weibullguy](https://github.com/weibullguy))
+- test: add hazard mock db table [\#509](https://github.com/ReliaQualAssociates/ramstk/pull/509) ([weibullguy](https://github.com/weibullguy))
+- refactor: move hazards do update to metaclass [\#508](https://github.com/ReliaQualAssociates/ramstk/pull/508) ([weibullguy](https://github.com/weibullguy))
+- test: new database per class [\#507](https://github.com/ReliaQualAssociates/ramstk/pull/507) ([weibullguy](https://github.com/weibullguy))
+- test: add fixtures for Revision managers [\#506](https://github.com/ReliaQualAssociates/ramstk/pull/506) ([weibullguy](https://github.com/weibullguy))
+- test: add mock RAMSTKRevision table for tests [\#505](https://github.com/ReliaQualAssociates/ramstk/pull/505) ([weibullguy](https://github.com/weibullguy))
+- refactor: move do\_update\(\) to metaclass [\#504](https://github.com/ReliaQualAssociates/ramstk/pull/504) ([weibullguy](https://github.com/weibullguy))
+- test: add function mgr fixtures [\#503](https://github.com/ReliaQualAssociates/ramstk/pull/503) ([weibullguy](https://github.com/weibullguy))
+- test: add mock RAMSTKAllocation [\#502](https://github.com/ReliaQualAssociates/ramstk/pull/502) ([weibullguy](https://github.com/weibullguy))
+- test: add mock RAMSTKFunction for tests [\#501](https://github.com/ReliaQualAssociates/ramstk/pull/501) ([weibullguy](https://github.com/weibullguy))
+- refactor: move function do update [\#500](https://github.com/ReliaQualAssociates/ramstk/pull/500) ([weibullguy](https://github.com/weibullguy))
+- refactor: move failure definition do update [\#499](https://github.com/ReliaQualAssociates/ramstk/pull/499) ([weibullguy](https://github.com/weibullguy))
+- test: split allocation test files [\#498](https://github.com/ReliaQualAssociates/ramstk/pull/498) ([weibullguy](https://github.com/weibullguy))
+- chore: add poetry support [\#492](https://github.com/ReliaQualAssociates/ramstk/pull/492) ([weibullguy](https://github.com/weibullguy))
+- chore: remove yapf in favor of black [\#491](https://github.com/ReliaQualAssociates/ramstk/pull/491) ([weibullguy](https://github.com/weibullguy))
+- chore\(deps\): bump cryptography from 3.3.1 to 3.3.2 [\#488](https://github.com/ReliaQualAssociates/ramstk/pull/488) ([dependabot[bot]](https://github.com/apps/dependabot))
+- chore\(deps\): bump pycairo from 1.19.1 to 1.20.0 [\#476](https://github.com/ReliaQualAssociates/ramstk/pull/476) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- chore: add mock database tables [\#462](https://github.com/ReliaQualAssociates/ramstk/pull/462) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.14.1](https://github.com/ReliaQualAssociates/ramstk/tree/v0.14.1) (2021-02-05)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.14.0...v0.14.1)
+
+New Features
+
+- feature: add default values for MIL217F semiconductor models [\#482](https://github.com/ReliaQualAssociates/ramstk/pull/482) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- chore\(deps\): bump scipy from 1.5.4 to 1.6.0 [\#472](https://github.com/ReliaQualAssociates/ramstk/pull/472) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+- chore\(deps\): bump lifelines from 0.14.6 to 0.25.8 [\#470](https://github.com/ReliaQualAssociates/ramstk/pull/470) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
+## [v0.14.0](https://github.com/ReliaQualAssociates/ramstk/tree/v0.14.0) (2021-02-04)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.13.0...v0.14.0)
+
+New Features
+
+- feat: add dormant hazard rates [\#467](https://github.com/ReliaQualAssociates/ramstk/pull/467) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- chore\(deps-dev\): bump mypy from 0.790 to 0.800 [\#480](https://github.com/ReliaQualAssociates/ramstk/pull/480) ([dependabot[bot]](https://github.com/apps/dependabot))
+- chore\(deps\): bump pytest from 6.2.1 to 6.2.2 [\#479](https://github.com/ReliaQualAssociates/ramstk/pull/479) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Create Dependabot config file [\#468](https://github.com/ReliaQualAssociates/ramstk/pull/468) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
+## [v0.13.0](https://github.com/ReliaQualAssociates/ramstk/tree/v0.13.0) (2021-01-26)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.12.3...v0.13.0)
+
+New Features
+
+- feat: add s-distribution support to prediction [\#459](https://github.com/ReliaQualAssociates/ramstk/pull/459) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.12.3](https://github.com/ReliaQualAssociates/ramstk/tree/v0.12.3) (2021-01-23)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.12.2...v0.12.3)
+
+Bug Fixes
+
+- fix: load the correct stress ratio in derating curve [\#458](https://github.com/ReliaQualAssociates/ramstk/pull/458) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.12.2](https://github.com/ReliaQualAssociates/ramstk/tree/v0.12.2) (2021-01-23)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.12.1...v0.12.2)
+
+Bug Fixes
+
+- fix: handle zero div error [\#457](https://github.com/ReliaQualAssociates/ramstk/pull/457) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.12.1](https://github.com/ReliaQualAssociates/ramstk/tree/v0.12.1) (2021-01-22)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.12.0...v0.12.1)
+
+Bug Fixes
+
+- fix: allow mission and mission phase to load in form [\#456](https://github.com/ReliaQualAssociates/ramstk/pull/456) ([weibullguy](https://github.com/weibullguy))
+- chore: improve import capability [\#453](https://github.com/ReliaQualAssociates/ramstk/pull/453) ([weibullguy](https://github.com/weibullguy))
+- enhance: update export capabilities [\#452](https://github.com/ReliaQualAssociates/ramstk/pull/452) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- chore: disable duplicate code checks in models [\#455](https://github.com/ReliaQualAssociates/ramstk/pull/455) ([weibullguy](https://github.com/weibullguy))
+
+## [v0.12.0](https://github.com/ReliaQualAssociates/ramstk/tree/v0.12.0) (2021-01-19)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.11.0...v0.12.0)
+
+New Features
+
+- feat: add support for Python 3.8 [\#449](https://github.com/ReliaQualAssociates/ramstk/pull/449) ([weibullguy](https://github.com/weibullguy))
+
+Bug Fixes
+
+- enhance: add refresh and save buttons to database dialog [\#450](https://github.com/ReliaQualAssociates/ramstk/pull/450) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- \[RELEASE\] v0.12.0 [\#451](https://github.com/ReliaQualAssociates/ramstk/pull/451) ([github-actions[bot]](https://github.com/apps/github-actions))
 - chore: update release workflow only cut release on major/minor [\#448](https://github.com/ReliaQualAssociates/ramstk/pull/448) ([weibullguy](https://github.com/weibullguy))
 - chore: add tests for configuration.py to increase coverage [\#446](https://github.com/ReliaQualAssociates/ramstk/pull/446) ([weibullguy](https://github.com/weibullguy))
 - chore: create install targets [\#444](https://github.com/ReliaQualAssociates/ramstk/pull/444) ([weibullguy](https://github.com/weibullguy))
 
-## [v0.11.0(https://github.com/ReliaQualAssociates/ramstk/tree/v0.11.0)]
+## [v0.11.0](https://github.com/ReliaQualAssociates/ramstk/tree/v0.11.0) (2021-01-16)
+
 [Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.10.0...v0.11.0)
 
-**Closed issues:**
+New Features
 
-- Add \_lst\_icons, \_lst\_callbacks, and \_lst\_tooltips ... [\#345](https://github.com/ReliaQualAssociates/ramstk/issues/345)
-- Update RAMSTKAnalysisManager.on\_get\_tree dmtree ar... [\#335](https://github.com/ReliaQualAssociates/ramstk/issues/335)
-- Handle exceptions in Revision module views. [\#325](https://github.com/ReliaQualAssociates/ramstk/issues/325)
+- feat: add db connection prompts [\#442](https://github.com/ReliaQualAssociates/ramstk/pull/442) ([weibullguy](https://github.com/weibullguy))
 
 **Merged pull requests:**
 
-- feat: add db connection prompts [\#442](https://github.com/ReliaQualAssociates/ramstk/pull/442) ([weibullguy](https://github.com/weibullguy))
+- \[RELEASE\] v0.11.0 [\#443](https://github.com/ReliaQualAssociates/ramstk/pull/443) ([github-actions[bot]](https://github.com/apps/github-actions))
 - chore: clean out and remove devtools [\#440](https://github.com/ReliaQualAssociates/ramstk/pull/440) ([weibullguy](https://github.com/weibullguy))
 - refactor: update Preferences assistant to use RAMSTKPanels [\#438](https://github.com/ReliaQualAssociates/ramstk/pull/438) ([weibullguy](https://github.com/weibullguy))
 - chore: Update workflows [\#437](https://github.com/ReliaQualAssociates/ramstk/pull/437) ([weibullguy](https://github.com/weibullguy))
@@ -52,26 +461,5 @@
 - refactor: split options and preferences data managers [\#435](https://github.com/ReliaQualAssociates/ramstk/pull/435) ([weibullguy](https://github.com/weibullguy))
 - test: create MockDAO and mock tables for testing [\#434](https://github.com/ReliaQualAssociates/ramstk/pull/434) ([weibullguy](https://github.com/weibullguy))
 
-## [Unreleased(https://github.com/ReliaQualAssociates/ramstk/tree/HEAD)]
-[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.0.0...HEAD)
 
-**Implemented enhancements:**
 
-- feat\(\*\): Update Layout Files to \*.toml Format [\#306](https://github.com/ReliaQualAssociates/ramstk/issues/306)
-- Group Data/Analyses By Revision [\#289](https://github.com/ReliaQualAssociates/ramstk/issues/289)
-- Add Hardware::Requirement Matrix [\#251](https://github.com/ReliaQualAssociates/ramstk/issues/251)
-- Add Hardware::Validation Matrix [\#250](https://github.com/ReliaQualAssociates/ramstk/issues/250)
--  Create and log a useful user and/or debug message in src/ramstk/gui/gtk/workviews/SimilarItem.py. [\#231](https://github.com/ReliaQualAssociates/ramstk/issues/231)
--  Create and log a useful user and/or debug message in src/ramstk/gui/gtk/workviews/SimilarItem.py. [\#230](https://github.com/ReliaQualAssociates/ramstk/issues/230)
--  Handle user/debug messages in workview.SimilarItem.\_do\_load\_children [\#229](https://github.com/ReliaQualAssociates/ramstk/issues/229)
-- Update to Python 3 and pygobject. [\#198](https://github.com/ReliaQualAssociates/ramstk/pull/198) ([weibullguy](https://github.com/weibullguy))
-
-**Fixed bugs:**
-
-- Handle TypeError in RTKDataMatrix.select\_all\(\) Method [\#59](https://github.com/ReliaQualAssociates/ramstk/issues/59)
-
-**Merged pull requests:**
-
-- \[ImgBot\] Optimize images [\#219](https://github.com/ReliaQualAssociates/ramstk/pull/219) ([imgbot[bot]](https://github.com/apps/imgbot))
-
-\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/src/ramstk/models/programdb/program_status/table.py
+++ b/src/ramstk/models/programdb/program_status/table.py
@@ -62,7 +62,7 @@ class RAMSTKProgramStatusTable(RAMSTKBaseTable):
 
         # Subscribe to PyPubSub messages.
         pub.subscribe(self.do_get_actual_status, "request_get_actual_status")
-        pub.subscribe(self._do_set_attributes, "succeed_calculate_all_validation_tasks")
+        pub.subscribe(self._do_set_attributes, "succeed_calculate_program_remaining")
 
     def do_get_new_record(  # pylint: disable=method-hidden
         self, attributes: Dict[str, Any]

--- a/src/ramstk/models/programdb/validation/table.py
+++ b/src/ramstk/models/programdb/validation/table.py
@@ -67,7 +67,7 @@ class RAMSTKValidationTable(RAMSTKBaseTable):
         pub.subscribe(self.do_calculate_plan, "request_calculate_plan")
         pub.subscribe(self._do_calculate_task, "request_calculate_validation_task")
         pub.subscribe(
-            self._do_calculate_all_tasks, "request_calculate_validation_tasks"
+            self._do_calculate_all_tasks, "request_calculate_all_validation_tasks"
         )
 
     def do_get_new_record(  # pylint: disable=method-hidden
@@ -193,6 +193,10 @@ class RAMSTKValidationTable(RAMSTKBaseTable):
 
         pub.sendMessage(
             "succeed_calculate_all_validation_tasks",
+            tree=self.tree,
+        )
+        pub.sendMessage(
+            "succeed_calculate_program_remaining",
             cost_remaining=_program_cost_remaining,
             time_remaining=_program_time_remaining,
         )

--- a/src/ramstk/views/gtk3/validation/panel.py
+++ b/src/ramstk/views/gtk3/validation/panel.py
@@ -8,10 +8,9 @@
 
 # Standard Library Imports
 from datetime import date
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 # Third Party Imports
-import treelib
 from pubsub import pub
 
 # RAMSTK Package Imports
@@ -542,6 +541,7 @@ class ValidationTreePanel(RAMSTKTreePanel):
         )
 
         # Subscribe to PyPubSub messages.
+        pub.subscribe(super().do_load_panel, "succeed_calculate_all_validation_tasks")
         pub.subscribe(self._on_module_switch, "mvwSwitchedPage")
 
     def do_load_measurement_units(
@@ -592,7 +592,7 @@ class ValidationTreePanel(RAMSTKTreePanel):
             _cellmodel.append([value[1]])
 
     def _on_module_switch(self, module: str = "") -> None:
-        """Respond to changes in selected Module View module (tab).
+        """Respond to change in selected Module View module (tab).
 
         :param module: the name of the module that was just selected.
         :return: None
@@ -1254,7 +1254,7 @@ class ValidationTaskEffortPanel(RAMSTKFixedPanel):
         super().do_set_callbacks()
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(super().do_load_panel, "succeed_calculate_validation_task")
+        pub.subscribe(self._on_calculate_task, "succeed_calculate_validation_task")
 
     def do_load_validation_types(
         self, validation_type: Dict[int, Tuple[str, str]]
@@ -1339,15 +1339,15 @@ class ValidationTaskEffortPanel(RAMSTKFixedPanel):
 
         return _date
 
-    def _on_calculate_task(self, tree: treelib.Tree) -> None:
+    def _on_calculate_task(self, attributes: Dict[str, Union[float, int, str]]) -> None:
         """Wrap _do_load_panel() on successful task calculation.
 
-        :param tree: the validation treelib.Tree().
+        :param attributes: the verification task attribute dict.
         :return: None
         :rtype: None
         """
-        _attributes = tree.get_node(self._record_id).data["validation"].get_attributes()
-        self._do_load_panel(_attributes)
+        if attributes["validation_id"] == self._record_id:
+            super().do_load_panel(attributes)
 
     def __do_adjust_widgets(self) -> None:
         """Adjust position of some widgets.

--- a/src/ramstk/views/gtk3/validation/view.py
+++ b/src/ramstk/views/gtk3/validation/view.py
@@ -286,7 +286,7 @@ class ValidationGeneralDataView(RAMSTKWorkView):
         """
         super().do_set_cursor_busy()
         pub.sendMessage(
-            "request_calculate_validation_tasks",
+            "request_calculate_all_validation_tasks",
         )
 
     def _do_set_record_id(self, attributes: Dict[str, Any]) -> None:

--- a/tests/models/programdb/program_status/program_status_integration_test.py
+++ b/tests/models/programdb/program_status/program_status_integration_test.py
@@ -41,7 +41,7 @@ def test_tablemodel(test_program_dao):
     pub.unsubscribe(dut.do_delete, "request_delete_program_status")
     pub.unsubscribe(dut.do_insert, "request_insert_program_status")
     pub.unsubscribe(dut.do_get_actual_status, "request_get_actual_status")
-    pub.unsubscribe(dut._do_set_attributes, "succeed_calculate_all_validation_tasks")
+    pub.unsubscribe(dut._do_set_attributes, "succeed_calculate_program_status")
 
     # Delete the device under test.
     del dut

--- a/tests/models/programdb/program_status/program_status_unit_test.py
+++ b/tests/models/programdb/program_status/program_status_unit_test.py
@@ -42,7 +42,7 @@ def test_tablemodel(mock_program_dao):
     pub.unsubscribe(dut.do_delete, "request_delete_program_status")
     pub.unsubscribe(dut.do_insert, "request_insert_program_status")
     pub.unsubscribe(dut.do_get_actual_status, "request_get_actual_status")
-    pub.unsubscribe(dut._do_set_attributes, "succeed_calculate_all_validation_tasks")
+    pub.unsubscribe(dut._do_set_attributes, "succeed_calculate_program_status")
 
     # Delete the device under test.
     del dut

--- a/tests/models/programdb/validation/validation_integration_test.py
+++ b/tests/models/programdb/validation/validation_integration_test.py
@@ -44,7 +44,9 @@ def test_tablemodel(test_program_dao):
     pub.unsubscribe(dut.do_insert, "request_insert_validation")
     pub.unsubscribe(dut.do_calculate_plan, "request_calculate_plan")
     pub.unsubscribe(dut._do_calculate_task, "request_calculate_validation_task")
-    pub.unsubscribe(dut._do_calculate_all_tasks, "request_calculate_validation_tasks")
+    pub.unsubscribe(
+        dut._do_calculate_all_tasks, "request_calculate_all_validation_tasks"
+    )
 
     # Delete the device under test.
     del dut
@@ -349,9 +351,8 @@ class TestGetterSetter:
 class TestAnalysisMethods:
     """Class for testing analytical methods."""
 
-    def on_succeed_calculate_all_tasks(self, cost_remaining, time_remaining):
-        assert cost_remaining == 3400.0
-        assert time_remaining == 80.0
+    def on_succeed_calculate_all_tasks(self, tree):
+        assert isinstance(tree, Tree)
         print("\033[36m\nsucceed_calculate_all_tasks topic was broadcast.")
 
     def on_succeed_calculate_plan(self, attributes):
@@ -412,7 +413,7 @@ class TestAnalysisMethods:
         _validation.cost_maximum = 3500.0
         _validation.confidence = 95.0
 
-        pub.sendMessage("request_calculate_validation_tasks")
+        pub.sendMessage("request_calculate_all_validation_tasks")
 
         assert test_tablemodel.tree.get_node(1).data[
             "validation"

--- a/tests/models/programdb/validation/validation_unit_test.py
+++ b/tests/models/programdb/validation/validation_unit_test.py
@@ -45,7 +45,9 @@ def test_tablemodel(mock_program_dao):
     pub.unsubscribe(dut.do_insert, "request_insert_validation")
     pub.unsubscribe(dut.do_calculate_plan, "request_calculate_plan")
     pub.unsubscribe(dut._do_calculate_task, "request_calculate_validation_task")
-    pub.unsubscribe(dut._do_calculate_all_tasks, "request_calculate_validation_tasks")
+    pub.unsubscribe(
+        dut._do_calculate_all_tasks, "request_calculate_all_validation_tasks"
+    )
 
     # Delete the device under test.
     del dut
@@ -96,7 +98,7 @@ class TestCreateModels:
         assert test_recordmodel.time_variance == 0.0
 
     @pytest.mark.unit
-    def test_data_manager_create(self, test_tablemodel):
+    def test_table_model_create(self, test_tablemodel):
         """should return a table manager instance."""
         assert isinstance(test_tablemodel, RAMSTKValidationTable)
         assert isinstance(test_tablemodel.tree, Tree)
@@ -129,7 +131,7 @@ class TestCreateModels:
         )
         assert pub.isSubscribed(
             test_tablemodel._do_calculate_all_tasks,
-            "request_calculate_validation_tasks",
+            "request_calculate_all_validation_tasks",
         )
 
 


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
Fixes the issue with the Verification plan 'Calculate All' updating the currently selected record with the results from the last record in the list.

## Describe how this was implemented.
Added condition to only update the record if the calculate record has the same record_id.  Added a new message for the program status model to listen for when calculating the entire program.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #923


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
