### PR TITLE
refactor: move usage profile to work view

### DIFF
--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -136,6 +136,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Get PR labels
         id: prlabels
         uses: joerick/pr-labels-action@v1.0.6
@@ -148,9 +157,9 @@ jobs:
       - name: Push version tag
         if: contains(steps.prlabels.outputs.labels, ' Release ')
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git tag -a -m"v${{ steps.newversion.outputs.version }}" v${{ steps.newversion.outputs.version }}
+          git config --global user.email "${{ steps.import_gpg.outputs.email }}"
+          git config --global user.name "${{ steps.import_gpg.outputs.name }}"
+          git tag -S -a -m"v${{ steps.newversion.outputs.version }}" v${{ steps.newversion.outputs.version }}
           git push --tags
 
       - name: Create release notes

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -27,11 +27,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Push 'latest' tag
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git tag -f -a -m"push latest tag" latest
+          git config --global user.email "${{ steps.import_gpg.outputs.email }}"
+          git config --global user.name "${{ steps.import_gpg.outputs.name }}"
+          git tag -S -f -a -m"push latest tag" latest
           git push -f --tags
 
       - name: Draft 'latest' release notes

--- a/.github/workflows/on-pr-open.yml
+++ b/.github/workflows/on-pr-open.yml
@@ -55,13 +55,6 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: GPG user IDs
-        run: |
-          echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
-          echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
-          echo "name:        ${{ steps.import_gpg.outputs.name }}"
-          echo "email:       ${{ steps.import_gpg.outputs.email }}"
-
       - name: Get current version
         id: curversion
         run: |
@@ -74,6 +67,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sinceTag: "v0.10.0"
+          excludeTags: "latest"
           breakingLabel: "Breaking Changes"
           breakingLabels: "bump: major"
           enhancementLabel: "New Features"

--- a/.github/workflows/on-pr-open.yml
+++ b/.github/workflows/on-pr-open.yml
@@ -84,10 +84,14 @@ jobs:
           stripGeneratorNotice: true
           verbose: true
 
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+
       - name: Commit and push changes
         run: |
           git config --global user.email "${{ steps.import_gpg.outputs.email }}"
           git config --global user.name "${{ steps.import_gpg.outputs.name }}"
           git add ./CHANGELOG.md
           git commit -S -m "docs: update CHANGELOG.md"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin HEAD:${{ steps.branch-name.outputs.head_ref_branch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## [v0.15.12](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.12) (2022-01-28)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.11...v0.15.12)
+
+Bug Fixes
+
+- fix: verification plan calculate all updates wrong records [\#924](https://github.com/ReliaQualAssociates/ramstk/pull/924) ([weibullguy](https://github.com/weibullguy))
+
+**Merged pull requests:**
+
+- release: v0.15.12 [\#925](https://github.com/ReliaQualAssociates/ramstk/pull/925) ([github-actions[bot]](https://github.com/apps/github-actions))
+
 ## [v0.15.11](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.11) (2022-01-28)
 
-[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/latest...v0.15.11)
-
-## [latest](https://github.com/ReliaQualAssociates/ramstk/tree/latest) (2022-01-28)
-
-[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.10...latest)
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.10...v0.15.11)
 
 Bug Fixes
 

--- a/src/ramstk/views/gtk3/books/listbook.py
+++ b/src/ramstk/views/gtk3/books/listbook.py
@@ -17,7 +17,6 @@ from ramstk.configuration import RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3.failure_definition import FailureDefinitionListView
 from ramstk.views.gtk3.stakeholder import StakeholderListView
-from ramstk.views.gtk3.usage_profile import UsageProfileListView
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook
 
 
@@ -47,7 +46,6 @@ class RAMSTKListBook(RAMSTKBaseBook):
         # Initialize private dictionary attributes.
         self._dic_list_views: Dict[str, List[object]] = {
             "revision": [
-                UsageProfileListView(configuration, logger),
                 FailureDefinitionListView(configuration, logger),
             ],
             "function": [],

--- a/src/ramstk/views/gtk3/books/workbook.py
+++ b/src/ramstk/views/gtk3/books/workbook.py
@@ -32,6 +32,7 @@ from ramstk.views.gtk3.requirement import (
 )
 from ramstk.views.gtk3.revision import RevisionWorkView
 from ramstk.views.gtk3.similar_item import SimilarItemWorkView
+from ramstk.views.gtk3.usage_profile import UsageProfileWorkView
 from ramstk.views.gtk3.validation import ValidationGeneralDataView
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook, RAMSTKBaseView
 
@@ -60,7 +61,10 @@ class RAMSTKWorkBook(RAMSTKBaseBook):
 
         # Initialize public dictionary attributes.
         self.dic_work_views: Dict[str, List[RAMSTKBaseView]] = {
-            "revision": [RevisionWorkView(configuration, logger)],
+            "revision": [
+                RevisionWorkView(configuration, logger),
+                UsageProfileWorkView(configuration, logger),
+            ],
             "function": [
                 FunctionWorkView(configuration, logger),
                 HazardsWorkView(configuration, logger),

--- a/src/ramstk/views/gtk3/fmea/panel.py
+++ b/src/ramstk/views/gtk3/fmea/panel.py
@@ -1309,13 +1309,14 @@ class FMEATreePanel(RAMSTKTreePanel):
         ).get_cells()
         _cell[0].connect("edited", self._on_mission_change)
 
+    # noinspection PyUnusedLocal
     def _on_cell_edit(
         self,
         cell: Gtk.CellRenderer,
         path: str,
         new_text: str,
         key: str,
-        message: str,
+        message: str,  # pylint: disable=unused-argument
     ) -> None:
         """Handle edits of description column to ensure proper level is updated.
 
@@ -1365,13 +1366,15 @@ class FMEATreePanel(RAMSTKTreePanel):
         _attributes = super().on_row_change(selection)
         _model, _row = selection.get_selected()
 
-        if _row is not None:
-            self.do_get_fmea_level(_model, _row)
-            super().do_set_visible_columns(_attributes)
-            self._record_id = _attributes[f"{self.level}_id"]
+        if _row is None:
+            return
 
-            _mission = _model.get_value(_row, 8)
-            self.__do_load_mission_phases(_mission)
+        self.do_get_fmea_level(_model, _row)
+        super().do_set_visible_columns(_attributes)
+        self._record_id = _attributes[f"{self.level}_id"]
+
+        _mission = _model.get_value(_row, 8)
+        self.__do_load_mission_phases(_mission)
 
     def _on_select_hardware(
         self, attributes: Dict[str, Union[int, float, str]]
@@ -1921,7 +1924,6 @@ class FMEATreePanel(RAMSTKTreePanel):
         try:
             _new_row = self.tvwTreeView.unfilt_model.append(row, _attributes)
         except (AttributeError, TypeError, ValueError):
-            _new_row = None
             _message = _(
                 f"An error occurred when loading failure mode {node.identifier} in the "
                 f"FMEA.  This might indicate it was missing it's data package, "

--- a/src/ramstk/views/gtk3/fmea/view.py
+++ b/src/ramstk/views/gtk3/fmea/view.py
@@ -151,7 +151,7 @@ class FMEAWorkView(RAMSTKWorkView):
         self.__make_ui()
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(super().do_set_record_id, "selected_fmeca")
+        pub.subscribe(super().do_set_record_id, f"selected_{self._tag}")
         pub.subscribe(
             self._on_get_hardware_attributes, "succeed_get_hardware_attributes"
         )

--- a/src/ramstk/views/gtk3/pof/view.py
+++ b/src/ramstk/views/gtk3/pof/view.py
@@ -124,7 +124,7 @@ class PoFWorkView(RAMSTKWorkView):
         self.__make_ui()
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(super().do_set_record_id, "selected_pof")
+        pub.subscribe(super().do_set_record_id, f"selected_{self._tag}")
 
         pub.subscribe(
             self._on_get_hardware_attributes, "succeed_get_hardware_attributes"

--- a/src/ramstk/views/gtk3/revision/view.py
+++ b/src/ramstk/views/gtk3/revision/view.py
@@ -219,7 +219,7 @@ class RevisionWorkView(RAMSTKWorkView):
     def _do_set_record_id(self, attributes: Dict[str, Any]) -> None:
         """Set the Revision's record ID.
 
-        :param attributes: the attributes dict for the selected Revision.
+        :param attributes: the attribute dict for the selected Revision.
         :return: None
         :rtype: None
         """
@@ -233,5 +233,6 @@ class RevisionWorkView(RAMSTKWorkView):
         """
         super().do_make_layout()
 
-        self.pack_end(self._pnlGeneralData, True, True, 0)
+        self.pack_start(self._pnlGeneralData, True, True, 0)
+
         self.show_all()

--- a/src/ramstk/views/gtk3/usage_profile/__init__.py
+++ b/src/ramstk/views/gtk3/usage_profile/__init__.py
@@ -10,4 +10,4 @@
 
 # RAMSTK Local Imports
 from .panel import UsageProfileTreePanel
-from .view import UsageProfileListView
+from .view import UsageProfileWorkView

--- a/src/ramstk/views/gtk3/usage_profile/panel.py
+++ b/src/ramstk/views/gtk3/usage_profile/panel.py
@@ -22,6 +22,56 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
     """Panel to display hierarchical list of usage profiles."""
 
     # Define private dictionary class attributes.
+    _dic_visible_mask: Dict[str, List[bool]] = {
+        "mission": [
+            False,
+            True,
+            False,
+            False,
+            False,
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "phase": [
+            False,
+            False,
+            True,
+            False,
+            True,
+            True,
+            False,
+            False,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+        ],
+        "environment": [
+            False,
+            False,
+            False,
+            True,
+            True,
+            False,
+            False,
+            True,
+            False,
+            False,
+            True,
+            True,
+            True,
+            True,
+        ],
+    }
 
     # Define private list class attributes.
 
@@ -46,61 +96,11 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
             "mission_phase": self.__do_load_phase,
             "environment": self.__do_load_environment,
         }
-        self._dic_visible_mask: Dict[str, Dict[str, bool]] = {
-            "mission": {
-                "revision_id": False,
-                "mission_id": True,
-                "phase_id": False,
-                "environment_id": False,
-                "name": False,
-                "description": True,
-                "mission_time": True,
-                "units": True,
-                "phase_start": False,
-                "phase_end": False,
-                "minimum": False,
-                "maximum": False,
-                "mean": False,
-                "variance": False,
-            },
-            "mission_phase": {
-                "revision_id": False,
-                "mission_id": False,
-                "phase_id": True,
-                "environment_id": False,
-                "name": True,
-                "description": True,
-                "mission_time": False,
-                "units": False,
-                "phase_start": True,
-                "phase_end": True,
-                "minimum": False,
-                "maximum": False,
-                "mean": False,
-                "variance": False,
-            },
-            "environment": {
-                "revision_id": False,
-                "mission_id": False,
-                "phase_id": False,
-                "environment_id": True,
-                "name": True,
-                "description": False,
-                "mission_time": False,
-                "units": True,
-                "phase_start": False,
-                "phase_end": False,
-                "minimum": True,
-                "maximum": True,
-                "mean": True,
-                "variance": True,
-            },
-        }
 
         # Initialize private list class attributes.
 
         # Initialize private scalar class attributes.
-        self._on_edit_message: str = f"lvw_editing_{self._tag}"
+        self._on_edit_message: str = f"wvw_editing_{self._tag}"
 
         # Initialize public dictionary class attributes.
         self.dic_attribute_widget_map: Dict[str, List[Any]] = {
@@ -172,8 +172,8 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 4,
                 Gtk.CellRendererText(),
                 "edited",
-                super().on_cell_edit,
-                self._on_edit_message,
+                self._on_cell_edit,
+                "wvw_editing_usage_profile",
                 "",
                 {
                     "bg_color": "#FFFFFF",
@@ -188,8 +188,8 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 5,
                 Gtk.CellRendererText(),
                 "edited",
-                super().on_cell_edit,
-                self._on_edit_message,
+                self._on_cell_edit,
+                "wvw_editing_usage_profile",
                 "",
                 {
                     "bg_color": "#FFFFFF",
@@ -205,7 +205,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                self._on_edit_message,
+                "wvw_editing_mission",
                 1.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -220,8 +220,8 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 7,
                 Gtk.CellRendererCombo(),
                 "edited",
-                super().on_cell_edit,
-                self._on_edit_message,
+                self._on_cell_edit,
+                "wvw_editing_usage_profile",
                 "",
                 {
                     "bg_color": "#FFFFFF",
@@ -237,7 +237,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                self._on_edit_message,
+                "wvw_editing_phase",
                 0.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -253,7 +253,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                self._on_edit_message,
+                "wvw_editing_phase",
                 1.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -269,7 +269,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                self._on_edit_message,
+                "wvw_editing_environment",
                 0.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -285,7 +285,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                self._on_edit_message,
+                "wvw_editing_environment",
                 0.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -301,7 +301,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                self._on_edit_message,
+                "wvw_editing_environment",
                 0.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -317,7 +317,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                self._on_edit_message,
+                "wvw_editing_environment",
                 1.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -340,6 +340,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         # Initialize public list class attributes.
 
         # Initialize public scalar class attributes.
+        self.level: str = ""
 
         super().do_set_properties()
         super().do_make_panel()
@@ -350,7 +351,27 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         )
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(super()._do_set_attributes, f"lvw_editing_{self._tag}")
+
+    def do_get_usage_profile_level(
+        self, model: Gtk.TreeModel, row: Gtk.TreeIter
+    ) -> None:
+        """Determine the Usage Profile level of the selected Usage Profile row.
+
+        :param model: the Usage Profile Gtk.TreeModel().
+        :param row: the selected Gtk.TreeIter() in the Usage Profile.
+        :return: None
+        :rtype: None
+        """
+        _cid = ""
+
+        for _col in [1, 2, 3]:
+            _cid = f"{_cid}{int(bool(model.get_value(row, _col)))}"
+
+        self.level = {
+            "100": "mission",
+            "110": "phase",
+            "111": "environment",
+        }[_cid]
 
     def do_load_comboboxes(self) -> None:
         """Load the Gtk.CellRendererCombo()s.
@@ -362,6 +383,33 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         for __, _unit in self.dic_units.items():  # pylint: disable=unused-variable
             _model.append([_unit[1]])
 
+    # noinspection PyUnusedLocal
+    def _on_cell_edit(
+        self,
+        cell: Gtk.CellRenderer,
+        path: str,
+        new_text: str,
+        key: str,
+        message: str,  # pylint: disable=unused-argument
+    ) -> None:
+        """Handle edits of description column to ensure proper level is updated.
+
+        :param cell: the Gtk.CellRenderer() that was edited.
+        :param path: the RAMSTKTreeView() path of the Gtk.CellRenderer()
+            that was edited.
+        :param new_text: the new text in the edited Gtk.CellRenderer().
+        :param key: the column key of the edited Gtk.CellRenderer().
+        :param message: the PyPubSub message to publish.
+        :return: None
+        """
+        super().on_cell_edit(
+            cell,
+            path,
+            new_text,
+            key,
+            f"wvw_editing_{self.level}",
+        )
+
     def _on_row_change(self, selection: Gtk.TreeSelection) -> None:
         """Handle row changes for the Usage Profile package List View.
 
@@ -372,27 +420,14 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         :return: None
         """
         _attributes = super().on_row_change(selection)
-        __, _row = selection.get_selected()  # pylint: disable=unused-variable
+        _model, _row = selection.get_selected()
 
-        if _row is not None:
-            if (
-                _attributes["mission_id"]
-                * _attributes["phase_id"]
-                * _attributes["environment_id"]
-            ) > 0:
-                self._tag = "environment"
-                self._record_id = _attributes["environment_id"]
-            elif (_attributes["mission_id"] * _attributes["phase_id"]) > 0:
-                self._tag = "mission_phase"
-                self._record_id = _attributes["phase_id"]
-            else:
-                self._tag = "mission"
-                self._record_id = _attributes["mission_id"]
+        if _row is None:
+            return
 
-            self.tvwTreeView.visible = self._dic_visible_mask[self._tag]
-            self.tvwTreeView.do_set_visible_columns()
-
-            pub.sendMessage(f"selected_{self._tag}", attributes=_attributes)
+        self.do_get_usage_profile_level(_model, _row)
+        super().do_set_visible_columns(_attributes)
+        self._record_id = _attributes[f"{self.level}_id"]
 
     def __do_load_environment(
         self, node: treelib.Node, row: Gtk.TreeIter
@@ -407,8 +442,6 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         _new_row = None
 
         [[__, _entity]] = node.data.items()  # pylint: disable=unused-variable
-
-        _model = self.tvwTreeView.get_model()
 
         _pixbuf = GdkPixbuf.Pixbuf()
         _icon = _pixbuf.new_from_file_at_size(self.dic_icons["environment"], 22, 22)
@@ -432,9 +465,8 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         ]
 
         try:
-            _new_row = _model.append(row, _attributes)
+            _new_row = self.tvwTreeView.unfilt_model.append(row, _attributes)
         except (AttributeError, TypeError, ValueError):
-            _new_row = None
             _message = _(
                 "An error occurred when loading environment {0:s} in the "
                 "usage profile.  This might indicate it was missing it's data "
@@ -461,8 +493,6 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         # pylint: disable=unused-variable
         [[__, _entity]] = node.data.items()
 
-        _model = self.tvwTreeView.get_model()
-
         _pixbuf = GdkPixbuf.Pixbuf()
         _icon = _pixbuf.new_from_file_at_size(self.dic_icons["mission"], 22, 22)
 
@@ -485,9 +515,8 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         ]
 
         try:
-            _new_row = _model.append(row, _attributes)
+            _new_row = self.tvwTreeView.unfilt_model.append(row, _attributes)
         except (AttributeError, TypeError, ValueError):
-            _new_row = None
             _message = _(
                 "An error occurred when loading mission {0:s} in the usage "
                 "profile.  This might indicate it was missing it's data "
@@ -513,8 +542,6 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
 
         [[__, _entity]] = node.data.items()  # pylint: disable=unused-variable
 
-        _model = self.tvwTreeView.get_model()
-
         _pixbuf = GdkPixbuf.Pixbuf()
         _icon = _pixbuf.new_from_file_at_size(self.dic_icons["mission_phase"], 22, 22)
 
@@ -537,9 +564,8 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         ]
 
         try:
-            _new_row = _model.append(row, _attributes)
+            _new_row = self.tvwTreeView.unfilt_model.append(row, _attributes)
         except (AttributeError, TypeError, ValueError):
-            _new_row = None
             _message = _(
                 "An error occurred when loading mission phase {0:s} in the "
                 "usage profile.  This might indicate it was missing it's data "

--- a/src/ramstk/views/gtk3/usage_profile/view.pyi
+++ b/src/ramstk/views/gtk3/usage_profile/view.pyi
@@ -12,7 +12,7 @@ from ramstk.views.gtk3.widgets import RAMSTKPanel
 # RAMSTK Local Imports
 from . import UsageProfileTreePanel as UsageProfileTreePanel
 
-class UsageProfileListView(RAMSTKListView):
+class UsageProfileWorkView(RAMSTKListView):
     _tag: str
     _tablabel: str
     _tabtooltip: str

--- a/src/ramstk/views/gtk3/widgets/baseview.py
+++ b/src/ramstk/views/gtk3/widgets/baseview.py
@@ -29,7 +29,7 @@ from .panel import RAMSTKPanel
 from .treeview import RAMSTKTreeView
 
 
-# noinspection PyUnresolvedReferences
+# noinspection PyUnresolvedReferences,GrazieInspection
 class RAMSTKBaseView(Gtk.HBox):
     """Metaclass for all RAMSTK ListView, ModuleView, and WorkView classes.
 
@@ -540,9 +540,12 @@ class RAMSTKBaseView(Gtk.HBox):
         self.do_set_cursor(Gdk.CursorType.WATCH)
 
     def do_set_record_id(self, attributes: Dict[str, Any]) -> None:
-        """Set the record and revision ID when a hardware item is selected.
+        """Set the record ID and tag when am item is selected.
 
-        :param attributes: the hazard dict for the selected hardware ID.
+        This method is used with views containing tree panels that display database
+        views such as the FMEA.
+
+        :param attributes: the attribute dict for the selected item.
         :return: None
         :rtype: None
         """
@@ -689,7 +692,7 @@ class RAMSTKBaseView(Gtk.HBox):
 class RAMSTKListView(RAMSTKBaseView):
     """Class to display list and matrix type data in the RAMSTK List Book.
 
-    This is the meta class for all RAMSTK List View classes.  Attributes of the
+    This is the metaclass for all RAMSTK List View classes.  Attributes of the
     RAMSTKListView are:
 
     :ivar tab_label: the Gtk.Label() displaying text for the List View tab.
@@ -735,14 +738,14 @@ class RAMSTKListView(RAMSTKBaseView):
 class RAMSTKModuleView(RAMSTKBaseView):
     """Display data in the RAMSTK Module Book.
 
-    This is the meta class for all RAMSTK Module View classes. Attributes of the
+    This is the metaclass for all RAMSTK Module View classes. Attributes of the
     RAMSTKModuleView are:
     """
 
     def __init__(
         self, configuration: RAMSTKUserConfiguration, logger: RAMSTKLogManager
     ) -> None:
-        """Initialize the RAMSTKModuleView meta-class.
+        """Initialize the RAMSTKModuleView metaclass.
 
         :param configuration: the RAMSTKUserConfiguration class instance.
         :param logger: the RAMSTKLogManager class instance.
@@ -782,6 +785,6 @@ class RAMSTKModuleView(RAMSTKBaseView):
 class RAMSTKWorkView(RAMSTKBaseView):
     """Class to display data in the RAMSTK Work Book.
 
-    This is the meta class for all RAMSTK Work View classes.  Attributes of the
+    This is the metaclass for all RAMSTK Work View classes.  Attributes of the
     RAMSTKWorkView are:
     """


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
To move the Usage Profile to the Revision module's work view in preparation for retirement of the List Book.

## Describe how this was implemented.
Removed UsageProfileListView() from the List Book.  Renamed UsageProfileListView to UsageProfileWorkView.  Added UsageProfileWorkView() to the Work Book.

Also updated Usage Profile panel methods to the standard methods for a database view.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #906 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
