### PR TITLE
refactor: move Stakeholder inputs to Requirements work view

### DIFF
--- a/.github/workflows/do-static-checks.yml
+++ b/.github/workflows/do-static-checks.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - master
+    branches-ignore:
+      - ci/*
+      - fix/*
+      - refactor/*
+      - release/*
 
 jobs:
   bandit:

--- a/.github/workflows/do-test-suite.yml
+++ b/.github/workflows/do-test-suite.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - master
+    branches-ignore:
+      - ci/*
+      - fix/*
+      - refactor/*
+      - release/*
 
 jobs:
   test_suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased](https://github.com/ReliaQualAssociates/ramstk/tree/HEAD)
+
+[Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.12...HEAD)
+
+**Merged pull requests:**
+
+- refactor: move usage profile to work view [\#927](https://github.com/ReliaQualAssociates/ramstk/pull/927) ([weibullguy](https://github.com/weibullguy))
+
 ## [v0.15.12](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.12) (2022-01-28)
 
 [Full Changelog](https://github.com/ReliaQualAssociates/ramstk/compare/v0.15.11...v0.15.12)

--- a/src/ramstk/views/gtk3/books/listbook.py
+++ b/src/ramstk/views/gtk3/books/listbook.py
@@ -16,7 +16,6 @@ from pubsub import pub
 from ramstk.configuration import RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3.failure_definition import FailureDefinitionListView
-from ramstk.views.gtk3.stakeholder import StakeholderListView
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook
 
 
@@ -49,9 +48,7 @@ class RAMSTKListBook(RAMSTKBaseBook):
                 FailureDefinitionListView(configuration, logger),
             ],
             "function": [],
-            "requirement": [
-                StakeholderListView(configuration, logger),
-            ],
+            "requirement": [],
             "hardware": [],
             "validation": [],
         }

--- a/src/ramstk/views/gtk3/books/workbook.py
+++ b/src/ramstk/views/gtk3/books/workbook.py
@@ -32,6 +32,7 @@ from ramstk.views.gtk3.requirement import (
 )
 from ramstk.views.gtk3.revision import RevisionWorkView
 from ramstk.views.gtk3.similar_item import SimilarItemWorkView
+from ramstk.views.gtk3.stakeholder import StakeholderWorkView
 from ramstk.views.gtk3.usage_profile import UsageProfileWorkView
 from ramstk.views.gtk3.validation import ValidationGeneralDataView
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook, RAMSTKBaseView
@@ -72,6 +73,7 @@ class RAMSTKWorkBook(RAMSTKBaseBook):
             "requirement": [
                 RequirementGeneralDataView(configuration, logger),
                 RequirementAnalysisView(configuration, logger),
+                StakeholderWorkView(configuration, logger),
             ],
             "hardware": [
                 HardwareGeneralDataView(configuration, logger),

--- a/src/ramstk/views/gtk3/stakeholder/__init__.py
+++ b/src/ramstk/views/gtk3/stakeholder/__init__.py
@@ -9,4 +9,4 @@
 
 # RAMSTK Local Imports
 from .panel import StakeholderTreePanel
-from .view import StakeholderListView
+from .view import StakeholderWorkView

--- a/src/ramstk/views/gtk3/stakeholder/view.py
+++ b/src/ramstk/views/gtk3/stakeholder/view.py
@@ -16,13 +16,13 @@ from pubsub import pub
 from ramstk.configuration import RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk, _
-from ramstk.views.gtk3.widgets import RAMSTKListView
+from ramstk.views.gtk3.widgets import RAMSTKWorkView
 
 # RAMSTK Local Imports
 from . import StakeholderTreePanel
 
 
-class StakeholderListView(RAMSTKListView):
+class StakeholderWorkView(RAMSTKWorkView):
     """Display Stakeholder Inputs associated with the selected Revision.
 
     The Stakeholder List View displays all the stakeholder inputs associated
@@ -173,7 +173,7 @@ class StakeholderListView(RAMSTKListView):
     def _do_set_record_id(self, attributes: Dict[str, Any]) -> None:
         """Set the stakeholder input's record ID.
 
-        :param attributes: the attributes dict for the selected stakeholder
+        :param attributes: the attribute dict for the selected stakeholder
             input.
         :return: None
         :rtype: None
@@ -188,7 +188,8 @@ class StakeholderListView(RAMSTKListView):
 
         :return: None
         """
-        super().make_ui()
+        super().do_make_layout()
+        super().do_embed_treeview_panel()
 
         self._pnlPanel.do_load_affinity_groups(
             self.RAMSTK_USER_CONFIGURATION.RAMSTK_AFFINITY_GROUPS

--- a/src/ramstk/views/gtk3/stakeholder/view.pyi
+++ b/src/ramstk/views/gtk3/stakeholder/view.pyi
@@ -12,7 +12,7 @@ from ramstk.views.gtk3.widgets import RAMSTKPanel as RAMSTKPanel
 # RAMSTK Local Imports
 from . import StakeholderTreePanel as StakeholderTreePanel
 
-class StakeholderListView(RAMSTKListView):
+class StakeholderWorkView(RAMSTKListView):
     _tag: str
     _tablabel: str
     _tabtooltip: str


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Describe the purpose of this pull request.
To move the Stakeholder inputs from the list view to the work view in preparation for retiring the List Book.

## Describe how this was implemented.
Renamed StakeholderListView() to StakeholderWorkView().  Removed the Stakeholder view from the List Book.  Added the Stakeholder view to the Work Book.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #909 

## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
