### PR TITLE
refactor: associate failure definitions with functions

### DIFF
--- a/.github/workflows/do-static-checks.yml
+++ b/.github/workflows/do-static-checks.yml
@@ -1,4 +1,4 @@
-# This workflow runs when a push is made to a pull request against the master branch.
+# This workflow runs when a push is made or a PR is opened, reopened, or synchronized.
 #
 # - Job 1:
 #     - Run bandit against the entire code base.
@@ -13,15 +13,14 @@
 name: Perform Static Checks on RAMSTK Code Base
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
-    branches:
-      - '!ci/**'
-      - '!fix/**'
-      - '!refactor/**'
-      - '!release/**'
+    tags-ignore:
+      - "*"
+  pull_request:
+    types:
+      - "opened"
+      - "reopened"
+      - "synchronize"
 
 jobs:
   bandit:

--- a/.github/workflows/do-static-checks.yml
+++ b/.github/workflows/do-static-checks.yml
@@ -1,14 +1,27 @@
+# This workflow runs when a push is made to a pull request against the master branch.
+#
+# - Job 1:
+#     - Run bandit against the entire code base.
+# - Job 2:
+#     - Run black, isort, and docformatter against the entire code base.
+# - Job 3:
+#     - Run pycodestyle and pydocstyle against the entire code base.
+# - Job 4:
+#     - Run mypy agaisnt the entire code base.
+# - Job 5:
+#     - Run pylint and flake8 (future) against the entire code base.
 name: Perform Static Checks on RAMSTK Code Base
 
 on:
   pull_request:
     branches:
       - master
-    branches-ignore:
-      - ci/*
-      - fix/*
-      - refactor/*
-      - release/*
+  push:
+    branches:
+      - '!ci/**'
+      - '!fix/**'
+      - '!refactor/**'
+      - '!release/**'
 
 jobs:
   bandit:

--- a/.github/workflows/do-test-suite.yml
+++ b/.github/workflows/do-test-suite.yml
@@ -1,14 +1,26 @@
+# This workflow runs when a push is made to a pull request against the master branch.
+#
+# - Job 1:
+#     - Set up the postgresql service.
+#     - Update and install non-pip packages (pygobject, etc.).
+#     - Set up the matrix of Python versions to test against.
+#     - Run the test suite with coverage for each Python version.
+#     - Upload the coverage results for each Python version to Codecov.
+#     - Create a coverage report for each Python version to use with Coveralls.
+# - Job 2:
+#     - Aggregate and upload each Python's version coverage report for Coveralls.
 name: Execute RAMSTK Test Suite with Coverage
 
 on:
   pull_request:
     branches:
       - master
-    branches-ignore:
-      - ci/*
-      - fix/*
-      - refactor/*
-      - release/*
+  push:
+    branches:
+      - '!ci/**'
+      - '!fix/**'
+      - '!refactor/**'
+      - '!release/**'
 
 jobs:
   test_suite:

--- a/.github/workflows/do-test-suite.yml
+++ b/.github/workflows/do-test-suite.yml
@@ -1,4 +1,4 @@
-# This workflow runs when a push is made to a pull request against the master branch.
+# This workflow runs when a push is made or a PR is opened, reopened, or synchronized.
 #
 # - Job 1:
 #     - Set up the postgresql service.
@@ -12,15 +12,14 @@
 name: Execute RAMSTK Test Suite with Coverage
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
-    branches:
-      - '!ci/**'
-      - '!fix/**'
-      - '!refactor/**'
-      - '!release/**'
+    tags-ignore:
+      - "*"
+  pull_request:
+    types:
+      - "opened"
+      - "reopened"
+      - "synchronize"
 
 jobs:
   test_suite:

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -5,9 +5,6 @@
 #     - Updates draft release notes.  This happens on every push to master.
 # - Job 2:
 #     - Creates issues from any issue comments.
-# Environment:
-#   DO_VERSION - Whether to create version tag (default: 0).  Set to 1 to create.
-
 name: Merge Pull Request Workflow
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Merged pull requests:**
 
+- ci: lower case -s to sign tags [\#929](https://github.com/ReliaQualAssociates/ramstk/pull/929) ([weibullguy](https://github.com/weibullguy))
+- refactor: move Stakeholder inputs to Requirements work view [\#928](https://github.com/ReliaQualAssociates/ramstk/pull/928) ([weibullguy](https://github.com/weibullguy))
 - refactor: move usage profile to work view [\#927](https://github.com/ReliaQualAssociates/ramstk/pull/927) ([weibullguy](https://github.com/weibullguy))
 
 ## [v0.15.12](https://github.com/ReliaQualAssociates/ramstk/tree/v0.15.12) (2022-01-28)

--- a/data/postgres_program_db.sql
+++ b/data/postgres_program_db.sql
@@ -29,13 +29,6 @@ CREATE TABLE ramstk_revision (
     PRIMARY KEY (fld_revision_id)
 );
 INSERT INTO "ramstk_revision" VALUES(1,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,'Revision -',1.0,1.0,X'',1,'',0.0,0.0,0.0,0.0);
-CREATE TABLE ramstk_failure_definition (
-    fld_revision_id INTEGER NOT NULL,
-    fld_definition_id INTEGER NOT NULL,
-    fld_definition VARCHAR(1024) DEFAULT '',
-    PRIMARY KEY (fld_definition_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
 CREATE TABLE ramstk_mission (
     fld_revision_id INTEGER NOT NULL,
     fld_mission_id INTEGER NOT NULL,
@@ -141,6 +134,15 @@ CREATE TABLE ramstk_function (
     fld_type_id INTEGER DEFAULT 0,
     PRIMARY KEY (fld_function_id),
     FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
+);
+CREATE TABLE ramstk_failure_definition (
+    fld_revision_id INTEGER NOT NULL,
+    fld_function_id INTEGER NOT NULL,
+    fld_definition_id INTEGER NOT NULL,
+    fld_definition VARCHAR(1024) DEFAULT '',
+    PRIMARY KEY (fld_definition_id),
+    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
+    FOREIGN KEY(fld_function_id) REFERENCES ramstk_function (fld_function_id) ON DELETE CASCADE
 );
 CREATE TABLE ramstk_hazard_analysis (
     fld_revision_id INTEGER NOT NULL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,8 +197,8 @@ markers = [
 ]
 
 [tool.pylint.master]
-ignore = [
-	'tests'
+ignore-paths = [
+	'tests*'
 ]
 persistent = true
 extension-pkg-whitelist = [

--- a/src/ramstk/models/programdb/failure_definition/record.py
+++ b/src/ramstk/models/programdb/failure_definition/record.py
@@ -31,6 +31,12 @@ class RAMSTKFailureDefinitionRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         ForeignKey("ramstk_revision.fld_revision_id", ondelete="CASCADE"),
         nullable=False,
     )
+    function_id = Column(
+        "fld_function_id",
+        Integer,
+        ForeignKey("ramstk_function.fld_function_id", ondelete="CASCADE"),
+        nullable=False,
+    )
     definition_id = Column(
         "fld_definition_id",
         Integer,
@@ -49,10 +55,9 @@ class RAMSTKFailureDefinitionRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         :return: {revision_id, definition_id, definition} pairs.
         :rtype: (int, int, str)
         """
-        _attributes = {
+        return {
             "revision_id": self.revision_id,
+            "function_id": self.function_id,
             "definition_id": self.definition_id,
             "definition": self.definition,
         }
-
-        return _attributes

--- a/src/ramstk/models/programdb/failure_definition/record.py
+++ b/src/ramstk/models/programdb/failure_definition/record.py
@@ -7,6 +7,9 @@
 # Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Failure Definition Record Model."""
 
+# Standard Library Imports
+from typing import Dict, Union
+
 # Third Party Imports
 from sqlalchemy import Column, ForeignKey, Integer, String
 
@@ -49,7 +52,7 @@ class RAMSTKFailureDefinitionRecord(RAMSTK_BASE, RAMSTKBaseRecord):
 
     # Define the relationships to other tables in the RAMSTK Program database.
 
-    def get_attributes(self):
+    def get_attributes(self) -> Dict[str, Union[float, int, str]]:
         """Retrieve current values of the RAMSTKFailureDefinition attributes.
 
         :return: {revision_id, definition_id, definition} pairs.

--- a/src/ramstk/models/programdb/failure_definition/record.pyi
+++ b/src/ramstk/models/programdb/failure_definition/record.pyi
@@ -1,15 +1,16 @@
 # Standard Library Imports
-from typing import Any, Dict
+from typing import Dict, Union
 
 # RAMSTK Package Imports
 from ramstk.db import RAMSTK_BASE
 from ramstk.models import RAMSTKBaseRecord
 
 class RAMSTKFailureDefinitionRecord(RAMSTK_BASE, RAMSTKBaseRecord):
-    __defaults__: Dict[str, Any]
+    __defaults__: Dict[str, str]
     __tablename__: str
     __table_args__: Dict[str, bool]
     revision_id: int
+    function_id: int
     definition_id: int
     definition: str
-    def get_attributes(self) -> Dict[str, Any]: ...
+    def get_attributes(self) -> Dict[str, Union[float, int, str]]: ...

--- a/src/ramstk/models/programdb/failure_definition/table.py
+++ b/src/ramstk/models/programdb/failure_definition/table.py
@@ -7,7 +7,7 @@
 """Failure Definition Table Model."""
 
 # Standard Library Imports
-from typing import Any, Dict, Type, Union
+from typing import Dict, Type, Union
 
 # RAMSTK Package Imports
 from ramstk.models import RAMSTKBaseTable, RAMSTKFailureDefinitionRecord
@@ -32,7 +32,7 @@ class RAMSTKFailureDefinitionTable(RAMSTKBaseTable):
 
     # Define public scalar class attributes.
 
-    def __init__(self, **kwargs: Dict[Any, Any]) -> None:
+    def __init__(self, **kwargs: Dict[str, Union[float, int, str]]) -> None:
         """Initialize a Failure Definition data manager instance."""
         super().__init__(**kwargs)
 

--- a/src/ramstk/models/programdb/failure_definition/table.py
+++ b/src/ramstk/models/programdb/failure_definition/table.py
@@ -7,7 +7,7 @@
 """Failure Definition Table Model."""
 
 # Standard Library Imports
-from typing import Any, Dict, Type
+from typing import Any, Dict, Type, Union
 
 # RAMSTK Package Imports
 from ramstk.models import RAMSTKBaseTable, RAMSTKFailureDefinitionRecord
@@ -41,6 +41,7 @@ class RAMSTKFailureDefinitionTable(RAMSTKBaseTable):
         # Initialize private list attributes.
         self._lst_id_columns = [
             "revision_id",
+            "function_id",
             "definition_id",
             "parent_id",
             "record_id",
@@ -61,7 +62,7 @@ class RAMSTKFailureDefinitionTable(RAMSTKBaseTable):
         # Subscribe to PyPubSub messages.
 
     def do_get_new_record(  # pylint: disable=method-hidden
-        self, attributes: Dict[str, Any]
+        self, attributes: Dict[str, Union[float, int, str]]
     ) -> object:
         """Gets a new record instance with attributes set.
 
@@ -71,6 +72,7 @@ class RAMSTKFailureDefinitionTable(RAMSTKBaseTable):
         """
         _new_record = self._record()
         _new_record.revision_id = attributes["revision_id"]
+        _new_record.function_id = attributes["function_id"]
         _new_record.definition_id = self.last_id + 1
 
         return _new_record

--- a/src/ramstk/models/programdb/failure_definition/table.pyi
+++ b/src/ramstk/models/programdb/failure_definition/table.pyi
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type, Union
 
 # RAMSTK Package Imports
 from ramstk.models import RAMSTKBaseTable as RAMSTKBaseTable
@@ -13,7 +13,7 @@ class RAMSTKFailureDefinitionTable(RAMSTKBaseTable):
     _lst_id_columns: List[str]
     _record: Type[RAMSTKFailureDefinitionRecord]
     pkey: str
-    def __init__(self, **kwargs: Dict[Any, Any]) -> None: ...
+    def __init__(self, **kwargs: Dict[str, Union[float, int, str]]) -> None: ...
     def do_get_new_record(
-        self, attributes: Dict[str, Any]
+        self, attributes: Dict[str, Union[float, int, str]]
     ) -> Type[RAMSTKFailureDefinitionRecord]: ...

--- a/tests/__data/test_program_db.sql
+++ b/tests/__data/test_program_db.sql
@@ -30,15 +30,6 @@ CREATE TABLE ramstk_revision (
 );
 INSERT INTO "ramstk_revision" VALUES(1,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,'Test Revision',1.0,1.0,X'',1,'',0.0,0.0,0.0,0.0);
 INSERT INTO "ramstk_revision" VALUES(2,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,'Test Revision 2',1.0,1.0,X'',1,'',0.0,0.0,0.0,0.0);
-CREATE TABLE ramstk_failure_definition (
-    fld_revision_id INTEGER,
-    fld_definition_id INTEGER NOT NULL,
-    fld_definition VARCHAR(1024),
-    PRIMARY KEY (fld_definition_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_failure_definition" VALUES(1,1,'Failure Definition');
-INSERT INTO "ramstk_failure_definition" VALUES(1,2,'Failure Definition');
 CREATE TABLE ramstk_mission (
     fld_revision_id INTEGER NOT NULL,
     fld_mission_id INTEGER NOT NULL,
@@ -157,6 +148,17 @@ CREATE TABLE ramstk_function (
 INSERT INTO "ramstk_function" VALUES(1,1,1.0,1.0,0.0,'FUNC-0001',0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,'Function Name',0,'',0,0,0,0);
 INSERT INTO "ramstk_function" VALUES(1,2,1.0,1.0,0.0,'FUNC-0002',0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,'Function Name',1,'',0,0,0,0);
 INSERT INTO "ramstk_function" VALUES(1,3,1.0,1.0,0.0,'FUNC-0003',0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,'Function Name',0,'',0,0,0,0);
+CREATE TABLE ramstk_failure_definition (
+    fld_revision_id INTEGER NOT NULL,
+    fld_function_id INTEGER NOT NULL,
+    fld_definition_id INTEGER NOT NULL,
+    fld_definition VARCHAR(1024),
+    PRIMARY KEY (fld_definition_id),
+    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
+    FOREIGN KEY(fld_function_id) REFERENCES ramstk_function (fld_function_id) ON DELETE CASCADE
+);
+INSERT INTO "ramstk_failure_definition" VALUES(1,1,1,'Failure Definition');
+INSERT INTO "ramstk_failure_definition" VALUES(1,1,2,'Failure Definition');
 CREATE TABLE ramstk_hazard_analysis (
     fld_revision_id INTEGER NOT NULL,
     fld_function_id INTEGER NOT NULL,

--- a/tests/models/programdb/failure_definition/conftest.py
+++ b/tests/models/programdb/failure_definition/conftest.py
@@ -10,11 +10,13 @@ from ramstk.models import RAMSTKFailureDefinitionRecord
 def mock_program_dao(monkeypatch):
     _definition_1 = RAMSTKFailureDefinitionRecord()
     _definition_1.revision_id = 1
+    _definition_1.function_id = 1
     _definition_1.definition_id = 1
     _definition_1.definition = "Mock Failure Definition 1"
 
     _definition_2 = RAMSTKFailureDefinitionRecord()
     _definition_2.revision_id = 1
+    _definition_1.function_id = 1
     _definition_2.definition_id = 2
     _definition_2.definition = "Mock Failure Definition 2"
 
@@ -31,6 +33,7 @@ def mock_program_dao(monkeypatch):
 def test_attributes():
     yield {
         "revision_id": 1,
+        "function_id": 1,
         "definition_id": 1,
         "definition": "Failure Definition",
         "parent_id": 1,

--- a/tests/models/programdb/failure_definition/failure_definition_unit_test.py
+++ b/tests/models/programdb/failure_definition/failure_definition_unit_test.py
@@ -56,10 +56,12 @@ class TestCreateModels:
         # Verify class attributes are properly initialized.
         assert test_recordmodel.__tablename__ == "ramstk_failure_definition"
         assert test_recordmodel.revision_id == 1
+        assert test_recordmodel.function_id == 1
+        assert test_recordmodel.definition_id == 1
         assert test_recordmodel.definition == "Mock Failure Definition 1"
 
     @pytest.mark.unit
-    def test_data_manager_create(self, test_tablemodel):
+    def test_table_model_create(self, test_tablemodel):
         """__init__() should return a Revision data manager."""
         assert isinstance(test_tablemodel, RAMSTKFailureDefinitionTable)
         assert isinstance(test_tablemodel.tree, Tree)
@@ -184,6 +186,7 @@ class TestGetterSetter:
     def test_set_record_model_attributes(self, test_attributes, test_recordmodel):
         """should return None on success."""
         test_attributes.pop("revision_id")
+        test_attributes.pop("function_id")
         test_attributes.pop("definition_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")
@@ -197,6 +200,7 @@ class TestGetterSetter:
         test_attributes["definition"] = None
 
         test_attributes.pop("revision_id")
+        test_attributes.pop("function_id")
         test_attributes.pop("definition_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")
@@ -209,6 +213,7 @@ class TestGetterSetter:
     ):
         """should raise an AttributeError when passed an unknown attribute."""
         test_attributes.pop("revision_id")
+        test_attributes.pop("function_id")
         test_attributes.pop("definition_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Describe the purpose of this pull request.
To associate failure definitions with functions rather than revisions (only).

## Describe how this was implemented.
Added function ID field to the failure definition database table.
Added foreign key to failure definition database table pointing to function ID field in the function table.
Added function ID field to failure definition record and table model.
Updated failure definition tests.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #907 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
