### PR TITLE
refactor: move failure definitions to Function work view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- refactor: associate failure definitions with functions [\#930](https://github.com/ReliaQualAssociates/ramstk/pull/930) ([weibullguy](https://github.com/weibullguy))
 - ci: lower case -s to sign tags [\#929](https://github.com/ReliaQualAssociates/ramstk/pull/929) ([weibullguy](https://github.com/weibullguy))
 - refactor: move Stakeholder inputs to Requirements work view [\#928](https://github.com/ReliaQualAssociates/ramstk/pull/928) ([weibullguy](https://github.com/weibullguy))
 - refactor: move usage profile to work view [\#927](https://github.com/ReliaQualAssociates/ramstk/pull/927) ([weibullguy](https://github.com/weibullguy))

--- a/data/layouts/failure_definition.toml
+++ b/data/layouts/failure_definition.toml
@@ -2,25 +2,30 @@ pixbuf='False'
 
 [defaulttitle]
 revision_id='Revision ID'
+function_id='Function ID'
 definition_id='Definition ID'
 definition='Failure Definition'
 
 [usertitle]
 revision_id='Revision ID'
+function_id='Function ID'
 definition_id='Definition ID'
 definition='Failure Definition'
 
 [position]
 revision_id=0
-definition_id=1
-definition=2
+function_id=1
+definition_id=2
+definition=3
 
 [editable]
 revision_id='False'
+function_id='False'
 definition_id='False'
 definition='True'
 
 [visible]
 revision_id='False'
+function_id='False'
 definition_id='True'
 definition='True'

--- a/src/ramstk/exceptions.py
+++ b/src/ramstk/exceptions.py
@@ -16,7 +16,7 @@ class RAMSTKError(Exception):
         :keyword str msg: the message to display to the user when this
             exception is raised.
         """
-        if msg == "":
+        if not msg:
             # Set some default useless error message
             msg = "An error occured with RAMSTK."
 

--- a/src/ramstk/exceptions.pyi
+++ b/src/ramstk/exceptions.pyi
@@ -1,0 +1,10 @@
+class RAMSTKError(Exception):
+    def __init__(self, msg: str = ...) -> None: ...
+
+class DataAccessError(RAMSTKError):
+    msg: str
+    def __init__(self, msg: str) -> None: ...
+
+class OutOfRangeError(RAMSTKError):
+    msg: str
+    def __init__(self, msg: str) -> None: ...

--- a/src/ramstk/models/programdb/failure_definition/table.py
+++ b/src/ramstk/models/programdb/failure_definition/table.py
@@ -24,7 +24,7 @@ class RAMSTKFailureDefinitionTable(RAMSTKBaseTable):
     _db_id_colname = "fld_definition_id"
     _db_tablename = "ramstk_failure_definition"
     _deprecated = False
-    _select_msg = "selected_function"
+    _select_msg = "selected_revision"
     _tag = "failure_definition"
 
     # Define public dictionary class attributes.

--- a/src/ramstk/models/programdb/failure_definition/table.py
+++ b/src/ramstk/models/programdb/failure_definition/table.py
@@ -23,7 +23,8 @@ class RAMSTKFailureDefinitionTable(RAMSTKBaseTable):
     # Define private scalar class attributes.
     _db_id_colname = "fld_definition_id"
     _db_tablename = "ramstk_failure_definition"
-    _select_msg = "selected_revision"
+    _deprecated = False
+    _select_msg = "selected_function"
     _tag = "failure_definition"
 
     # Define public dictionary class attributes.

--- a/src/ramstk/utilities.py
+++ b/src/ramstk/utilities.py
@@ -82,11 +82,7 @@ def none_to_default(field: Any, default: Any) -> Any:
         otherwise.
     :rtype: any
     """
-    _return = field
-    if field is None:
-        _return = default
-
-    return _return
+    return default if field is None else field
 
 
 def none_to_string(string: None) -> str:
@@ -127,9 +123,7 @@ def split_string(string: str) -> List[str]:
     :return: _strlist
     :rtype: list of strings
     """
-    _strlist = string.rsplit(":")
-
-    return _strlist
+    return string.rsplit(":")
 
 
 def boolean_to_integer(boolean: bool) -> int:
@@ -139,12 +133,7 @@ def boolean_to_integer(boolean: bool) -> int:
     :return: _result
     :rtype: int
     """
-    _result = 0
-
-    if boolean:
-        _result = 1
-
-    return _result
+    return 1 if boolean else 0
 
 
 def integer_to_boolean(integer: int) -> bool:
@@ -158,34 +147,19 @@ def integer_to_boolean(integer: int) -> bool:
     :rtype: bool
     :raise: TypeError if passed a string.
     """
-    _result = False
-
-    if integer > 0:
-        _result = True
-
-    return _result
+    return integer > 0
 
 
 def string_to_boolean(string: str) -> bool:
-    """Convert string representations of TRUE/FALSE to an boolean value.
+    """Convert string representations of TRUE/FALSE to a boolean value.
 
     :param string: the string to convert.
     :return: _result
     :rtype: bool
     """
-    _result = False
-
     _string = str(string)
 
-    if (
-        _string.lower() == "true"
-        or _string.lower() == "yes"
-        or _string.lower() == "t"
-        or _string.lower() == "y"
-    ):
-        _result = True
-
-    return _result
+    return _string.lower() in ["true", "yes", "t", "y"]
 
 
 def get_install_prefix() -> str:
@@ -200,7 +174,7 @@ def get_install_prefix() -> str:
         # To match: /usr/lib[64]/pythonX.Y/site-packages/project/prefix.py
         # Or: /usr/local/lib[64]/pythonX.Y/dist-packages/project/prefix.py
         lambda x: x in ["lib64", "lib"],  # nosec
-        lambda x: x == ("python%s" % sys.version[:3]),
+        lambda x: x == f"python{sys.version[:3]}",
         lambda x: x in ["site-packages", "dist-packages"],
         lambda x: x == _name,  # 'project'
         lambda x: x == _this,  # 'prefix.py'

--- a/src/ramstk/views/gtk3/books/listbook.py
+++ b/src/ramstk/views/gtk3/books/listbook.py
@@ -15,7 +15,6 @@ from pubsub import pub
 # RAMSTK Package Imports
 from ramstk.configuration import RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager
-from ramstk.views.gtk3.failure_definition import FailureDefinitionListView
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook
 
 
@@ -44,9 +43,7 @@ class RAMSTKListBook(RAMSTKBaseBook):
 
         # Initialize private dictionary attributes.
         self._dic_list_views: Dict[str, List[object]] = {
-            "revision": [
-                FailureDefinitionListView(configuration, logger),
-            ],
+            "revision": [],
             "function": [],
             "requirement": [],
             "hardware": [],

--- a/src/ramstk/views/gtk3/books/listbook.py
+++ b/src/ramstk/views/gtk3/books/listbook.py
@@ -14,7 +14,6 @@ from pubsub import pub
 
 # RAMSTK Package Imports
 from ramstk.configuration import RAMSTKUserConfiguration
-from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook
 
 
@@ -31,13 +30,10 @@ class RAMSTKListBook(RAMSTKBaseBook):
         that RAMSTK module.
     """
 
-    def __init__(
-        self, configuration: RAMSTKUserConfiguration, logger: RAMSTKLogManager
-    ) -> None:
+    def __init__(self, configuration: RAMSTKUserConfiguration) -> None:
         """Initialize an instance of the RAMSTK List View class.
 
         :param configuration: the RAMSTKUserConfiguration() class instance.
-        :param logger: the RAMSTKLogManager class instance.
         """
         RAMSTKBaseBook.__init__(self, configuration)
 

--- a/src/ramstk/views/gtk3/books/listbook.pyi
+++ b/src/ramstk/views/gtk3/books/listbook.pyi
@@ -4,9 +4,6 @@ from typing import Dict, List
 # RAMSTK Package Imports
 from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
-from ramstk.views.gtk3.failure_definition import (
-    FailureDefinitionListView as FailureDefinitionListView,
-)
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook as RAMSTKBaseBook
 
 class RAMSTKListBook(RAMSTKBaseBook):

--- a/src/ramstk/views/gtk3/books/workbook.py
+++ b/src/ramstk/views/gtk3/books/workbook.py
@@ -16,6 +16,7 @@ from pubsub import pub
 from ramstk.configuration import RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3.allocation import AllocationWorkView
+from ramstk.views.gtk3.failure_definition import FailureDefinitionWorkView
 from ramstk.views.gtk3.fmea import FMEAWorkView
 from ramstk.views.gtk3.function import FunctionWorkView
 from ramstk.views.gtk3.hardware import (
@@ -69,6 +70,7 @@ class RAMSTKWorkBook(RAMSTKBaseBook):
             "function": [
                 FunctionWorkView(configuration, logger),
                 HazardsWorkView(configuration, logger),
+                FailureDefinitionWorkView(configuration, logger),
             ],
             "requirement": [
                 RequirementGeneralDataView(configuration, logger),

--- a/src/ramstk/views/gtk3/desktop.py
+++ b/src/ramstk/views/gtk3/desktop.py
@@ -124,7 +124,7 @@ class RAMSTKDesktop(Gtk.Window):
         self.icoStatus: Gtk.StatusIcon = Gtk.StatusIcon()
 
         self.nbkListBook: RAMSTKListBook = RAMSTKListBook(
-            self.RAMSTK_USER_CONFIGURATION, logger
+            self.RAMSTK_USER_CONFIGURATION
         )
         self.nbkModuleBook: RAMSTKModuleBook = RAMSTKModuleBook(
             self.RAMSTK_USER_CONFIGURATION, logger

--- a/src/ramstk/views/gtk3/failure_definition/__init__.py
+++ b/src/ramstk/views/gtk3/failure_definition/__init__.py
@@ -9,4 +9,4 @@
 
 # RAMSTK Local Imports
 from .panel import FailureDefinitionTreePanel
-from .view import FailureDefinitionListView
+from .view import FailureDefinitionWorkView

--- a/src/ramstk/views/gtk3/failure_definition/view.py
+++ b/src/ramstk/views/gtk3/failure_definition/view.py
@@ -7,7 +7,7 @@
 """GTK3 Failure Definition Views."""
 
 # Standard Library Imports
-from typing import Any, Dict
+from typing import Dict, Union
 
 # Third Party Imports
 from pubsub import pub
@@ -123,10 +123,10 @@ class FailureDefinitionWorkView(RAMSTKWorkView):
 
         _dialog.do_destroy()
 
-    def _do_set_record_id(self, attributes: Dict[str, Any]) -> None:
+    def _do_set_record_id(self, attributes: Dict[str, Union[float, int, str]]) -> None:
         """Set the failure definition's record ID.
 
-        :param attributes: the attributes dict for the selected failure
+        :param attributes: the attribute dict for the selected failure
             definition.
         :return: None
         :rtype: None

--- a/src/ramstk/views/gtk3/failure_definition/view.py
+++ b/src/ramstk/views/gtk3/failure_definition/view.py
@@ -16,13 +16,13 @@ from pubsub import pub
 from ramstk.configuration import RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk, _
-from ramstk.views.gtk3.widgets import RAMSTKListView
+from ramstk.views.gtk3.widgets import RAMSTKWorkView
 
 # RAMSTK Local Imports
 from . import FailureDefinitionTreePanel
 
 
-class FailureDefinitionListView(RAMSTKListView):
+class FailureDefinitionWorkView(RAMSTKWorkView):
     """Display failure definitions associated with the selected revision.
 
     The attributes of the failure definition list view are:
@@ -83,7 +83,7 @@ class FailureDefinitionListView(RAMSTKListView):
         ]
 
         # Initialize private scalar attributes.
-        self._pnlPanel = FailureDefinitionTreePanel()
+        self._pnlPanel: FailureDefinitionTreePanel = FailureDefinitionTreePanel()
 
         # Initialize public dictionary attributes.
 
@@ -141,7 +141,8 @@ class FailureDefinitionListView(RAMSTKListView):
 
         :return: None
         """
-        super().make_ui()
+        super().do_make_layout()
+        super().do_embed_treeview_panel()
 
         self._pnlPanel.tvwTreeView.dic_handler_id[
             "button-press"

--- a/src/ramstk/views/gtk3/failure_definition/view.pyi
+++ b/src/ramstk/views/gtk3/failure_definition/view.pyi
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Any, Dict, List
+from typing import Dict, List, Union
 
 # RAMSTK Package Imports
 from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
@@ -12,7 +12,7 @@ from ramstk.views.gtk3.widgets import RAMSTKPanel as RAMSTKPanel
 # RAMSTK Local Imports
 from . import FailureDefinitionTreePanel as FailureDefinitionTreePanel
 
-class FailureDefinitionListView(RAMSTKListView):
+class FailureDefinitionWorkView(RAMSTKListView):
     _tag: str
     _tablabel: str
     _tabtooltip: str
@@ -24,5 +24,7 @@ class FailureDefinitionListView(RAMSTKListView):
     ) -> None: ...
     def _do_request_delete(self, __button: Gtk.ToolButton) -> None: ...
     _record_id: int
-    def _do_set_record_id(self, attributes: Dict[str, Any]) -> None: ...
+    def _do_set_record_id(
+        self, attributes: Dict[str, Union[float, int, str]]
+    ) -> None: ...
     def __make_ui(self) -> None: ...

--- a/tests/__data/test_program_db.sql
+++ b/tests/__data/test_program_db.sql
@@ -159,6 +159,7 @@ CREATE TABLE ramstk_failure_definition (
 );
 INSERT INTO "ramstk_failure_definition" VALUES(1,1,1,'Failure Definition');
 INSERT INTO "ramstk_failure_definition" VALUES(1,1,2,'Failure Definition');
+INSERT INTO "ramstk_failure_definition" VALUES(1,1,3,'Failure Definition');
 CREATE TABLE ramstk_hazard_analysis (
     fld_revision_id INTEGER NOT NULL,
     fld_function_id INTEGER NOT NULL,

--- a/tests/models/programdb/failure_definition/conftest.py
+++ b/tests/models/programdb/failure_definition/conftest.py
@@ -36,8 +36,6 @@ def test_attributes():
         "function_id": 1,
         "definition_id": 1,
         "definition": "Failure Definition",
-        "parent_id": 1,
-        "record_id": 1,
     }
 
 

--- a/tests/models/programdb/failure_definition/failure_definition_integration_test.py
+++ b/tests/models/programdb/failure_definition/failure_definition_integration_test.py
@@ -34,7 +34,7 @@ def test_tablemodel(test_program_dao):
     pub.unsubscribe(dut.do_set_attributes, "lvw_editing_failure_definition")
     pub.unsubscribe(dut.do_update, "request_update_failure_definition")
     pub.unsubscribe(dut.do_get_tree, "request_get_failure_definition_tree")
-    pub.unsubscribe(dut.do_select_all, "selected_function")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
     pub.unsubscribe(dut.do_delete, "request_delete_failure_definition")
     pub.unsubscribe(dut.do_insert, "request_insert_failure_definition")
 
@@ -63,7 +63,7 @@ class TestSelectMethods:
             self.on_succeed_select_all, "succeed_retrieve_failure_definitions"
         )
 
-        pub.sendMessage("selected_function", attributes=test_attributes)
+        pub.sendMessage("selected_revision", attributes=test_attributes)
 
         pub.unsubscribe(
             self.on_succeed_select_all, "succeed_retrieve_failure_definitions"

--- a/tests/models/programdb/failure_definition/failure_definition_integration_test.py
+++ b/tests/models/programdb/failure_definition/failure_definition_integration_test.py
@@ -24,7 +24,7 @@ def test_tablemodel(test_program_dao):
     # Create the device under test (dut) and connect to the database.
     dut = RAMSTKFailureDefinitionTable()
     dut.do_connect(test_program_dao)
-    dut.do_select_all(attributes={"revision_id": 1})
+    dut.do_select_all(attributes={"function_id": 1})
 
     yield dut
 
@@ -34,7 +34,7 @@ def test_tablemodel(test_program_dao):
     pub.unsubscribe(dut.do_set_attributes, "lvw_editing_failure_definition")
     pub.unsubscribe(dut.do_update, "request_update_failure_definition")
     pub.unsubscribe(dut.do_get_tree, "request_get_failure_definition_tree")
-    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_select_all, "selected_function")
     pub.unsubscribe(dut.do_delete, "request_delete_failure_definition")
     pub.unsubscribe(dut.do_insert, "request_insert_failure_definition")
 
@@ -63,7 +63,7 @@ class TestSelectMethods:
             self.on_succeed_select_all, "succeed_retrieve_failure_definitions"
         )
 
-        pub.sendMessage("selected_revision", attributes=test_attributes)
+        pub.sendMessage("selected_function", attributes=test_attributes)
 
         pub.unsubscribe(
             self.on_succeed_select_all, "succeed_retrieve_failure_definitions"
@@ -89,6 +89,14 @@ class TestInsertMethods:
         )
         print("\033[35m\nfail_insert_function topic was broadcast.")
 
+    def on_fail_insert_no_function(self, error_message):
+        assert error_message == (
+            "do_insert: Database error when attempting to add a record.  Database "
+            "returned:\n\tKey (fld_function_id)=(40) is not present in table "
+            '"ramstk_function".'
+        )
+        print("\033[35m\nfail_insert_function topic was broadcast.")
+
     @pytest.mark.integration
     def test_do_insert_sibling(self, test_attributes, test_tablemodel):
         """do_insert() should send the success message after successfully inserting a
@@ -97,12 +105,14 @@ class TestInsertMethods:
             self.on_succeed_insert_sibling, "succeed_insert_failure_definition"
         )
 
-        assert test_tablemodel.tree.get_node(3) is None
+        test_attributes["parent_id"] = 0
+        test_attributes["record_id"] = 0
+        assert test_tablemodel.tree.get_node(4) is None
 
         pub.sendMessage("request_insert_failure_definition", attributes=test_attributes)
 
         assert isinstance(
-            test_tablemodel.tree.get_node(3).data["failure_definition"],
+            test_tablemodel.tree.get_node(4).data["failure_definition"],
             RAMSTKFailureDefinitionRecord,
         )
 
@@ -117,11 +127,29 @@ class TestInsertMethods:
         ID."""
         pub.subscribe(self.on_fail_insert_no_revision, "fail_insert_failure_definition")
 
+        test_attributes["parent_id"] = 0
+        test_attributes["record_id"] = 0
         test_attributes["revision_id"] = 40
         pub.sendMessage("request_insert_failure_definition", attributes=test_attributes)
 
         pub.unsubscribe(
             self.on_fail_insert_no_revision, "fail_insert_failure_definition"
+        )
+
+    @pytest.mark.integration
+    def test_do_insert_no_function(self, test_attributes, test_tablemodel):
+        """do_insert() should send the fail_insert_failure_definition message when
+        attempting to insert a new failure definition with a non-existent function
+        ID."""
+        pub.subscribe(self.on_fail_insert_no_function, "fail_insert_failure_definition")
+
+        test_attributes["parent_id"] = 0
+        test_attributes["record_id"] = 0
+        test_attributes["function_id"] = 40
+        pub.sendMessage("request_insert_failure_definition", attributes=test_attributes)
+
+        pub.unsubscribe(
+            self.on_fail_insert_no_function, "fail_insert_failure_definition"
         )
 
 
@@ -146,7 +174,7 @@ class TestDeleteMethods:
         print("\033[35m\nfail_delete_failure_definition topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_delete(self):
+    def test_do_delete(self, test_tablemodel):
         """_do_delete_failure_definition() should send the success message after
         successfully deleting a definition."""
         pub.subscribe(self.on_succeed_delete, "succeed_delete_failure_definition")

--- a/tests/models/programdb/failure_definition/failure_definition_unit_test.py
+++ b/tests/models/programdb/failure_definition/failure_definition_unit_test.py
@@ -36,7 +36,7 @@ def test_tablemodel(mock_program_dao):
     pub.unsubscribe(dut.do_set_attributes, "lvw_editing_failure_definition")
     pub.unsubscribe(dut.do_update, "request_update_failure_definition")
     pub.unsubscribe(dut.do_get_tree, "request_get_failure_definition_tree")
-    pub.unsubscribe(dut.do_select_all, "selected_function")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
     pub.unsubscribe(dut.do_delete, "request_delete_failure_definition")
     pub.unsubscribe(dut.do_insert, "request_insert_failure_definition")
 
@@ -75,7 +75,7 @@ class TestCreateModels:
             test_tablemodel.do_get_attributes,
             "request_get_failure_definition_attributes",
         )
-        assert pub.isSubscribed(test_tablemodel.do_select_all, "selected_function")
+        assert pub.isSubscribed(test_tablemodel.do_select_all, "selected_revision")
         assert pub.isSubscribed(
             test_tablemodel.do_update, "request_update_failure_definition"
         )
@@ -90,7 +90,7 @@ class TestCreateModels:
             "request_set_failure_definition_attributes",
         )
         assert pub.isSubscribed(
-            test_tablemodel.do_set_attributes, "lvw_editing_failure_definition"
+            test_tablemodel.do_set_attributes, "wvw_editing_failure_definition"
         )
         assert pub.isSubscribed(
             test_tablemodel.do_delete, "request_delete_failure_definition"

--- a/tests/models/programdb/failure_definition/failure_definition_unit_test.py
+++ b/tests/models/programdb/failure_definition/failure_definition_unit_test.py
@@ -36,7 +36,7 @@ def test_tablemodel(mock_program_dao):
     pub.unsubscribe(dut.do_set_attributes, "lvw_editing_failure_definition")
     pub.unsubscribe(dut.do_update, "request_update_failure_definition")
     pub.unsubscribe(dut.do_get_tree, "request_get_failure_definition_tree")
-    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_select_all, "selected_function")
     pub.unsubscribe(dut.do_delete, "request_delete_failure_definition")
     pub.unsubscribe(dut.do_insert, "request_insert_failure_definition")
 
@@ -75,7 +75,7 @@ class TestCreateModels:
             test_tablemodel.do_get_attributes,
             "request_get_failure_definition_attributes",
         )
-        assert pub.isSubscribed(test_tablemodel.do_select_all, "selected_revision")
+        assert pub.isSubscribed(test_tablemodel.do_select_all, "selected_function")
         assert pub.isSubscribed(
             test_tablemodel.do_update, "request_update_failure_definition"
         )
@@ -144,6 +144,8 @@ class TestInsertMethods:
     @pytest.mark.unit
     def test_do_insert_sibling(self, test_attributes, test_tablemodel):
         """should add new record to record tree and update last_id."""
+        test_attributes["parent_id"] = 0
+        test_attributes["record_id"] = 0
         test_tablemodel.do_select_all(attributes=test_attributes)
         test_tablemodel.do_insert(attributes=test_attributes)
 
@@ -180,6 +182,7 @@ class TestGetterSetter:
 
         assert isinstance(_attributes, dict)
         assert _attributes["revision_id"] == 1
+        assert _attributes["function_id"] == 1
         assert _attributes["definition"] == "Mock Failure Definition 1"
 
     @pytest.mark.unit
@@ -188,8 +191,6 @@ class TestGetterSetter:
         test_attributes.pop("revision_id")
         test_attributes.pop("function_id")
         test_attributes.pop("definition_id")
-        test_attributes.pop("parent_id")
-        test_attributes.pop("record_id")
         assert test_recordmodel.set_attributes(test_attributes) is None
 
     @pytest.mark.unit
@@ -202,8 +203,6 @@ class TestGetterSetter:
         test_attributes.pop("revision_id")
         test_attributes.pop("function_id")
         test_attributes.pop("definition_id")
-        test_attributes.pop("parent_id")
-        test_attributes.pop("record_id")
         assert test_recordmodel.set_attributes(test_attributes) is None
         assert test_recordmodel.get_attributes()["definition"] == "Failure Definition"
 
@@ -215,7 +214,5 @@ class TestGetterSetter:
         test_attributes.pop("revision_id")
         test_attributes.pop("function_id")
         test_attributes.pop("definition_id")
-        test_attributes.pop("parent_id")
-        test_attributes.pop("record_id")
         with pytest.raises(AttributeError):
             test_recordmodel.set_attributes({"shibboly-bibbly-boo": 0.9998})


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Describe the purpose of this pull request.
To move the failure definitions to the Function work view in preparation for retiring the List Book.

## Describe how this was implemented.
Rename FailureDefinitionListView to FailureDefinitionWorkView.
Transform Failure Definition tree to filtered tree.
Remove Failure Definition from Revision List Book.
Add Failure Definition to Function Work Book.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #908 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
