### PR TITLE
fix: add mission phase and environment to Usage Profile

### DIFF
--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -30,7 +30,7 @@ jobs:
           echo "::set-output name=new_version::$(echo $new_tag)"
           echo "New tag is: $new_tag"
           echo "GitHub ref: ${{ github.ref }}"
-          
+
       - name: Generate release changelog
         uses: heinrichreimer/github-changelog-generator-action@master
         with:

--- a/data/layouts/usage_profile.toml
+++ b/data/layouts/usage_profile.toml
@@ -3,7 +3,7 @@ pixbuf='True'
 [defaulttitle]
 revision_id='Revision ID'
 mission_id='Mission ID'
-phase_id='Phase ID'
+mission_phase_id='Phase ID'
 environment_id='Environment ID'
 name='Name'
 description='Description'
@@ -19,7 +19,7 @@ variance='Variance'
 [usertitle]
 revision_id='Revision ID'
 mission_id='Mission ID'
-phase_id='Phase ID'
+mission_phase_id='Phase ID'
 environment_id='Environment ID'
 name='Name'
 description='Description'
@@ -35,7 +35,7 @@ variance='Variance'
 [position]
 revision_id=0
 mission_id=1
-phase_id=2
+mission_phase_id=2
 environment_id=3
 name=4
 description=5
@@ -51,7 +51,7 @@ variance=13
 [editable]
 revision_id='False'
 mission_id='False'
-phase_id='False'
+mission_phase_id='False'
 environment_id='False'
 name='True'
 description='True'
@@ -67,7 +67,7 @@ variance='True'
 [visible]
 revision_id='False'
 mission_id='True'
-phase_id='True'
+mission_phase_id='True'
 environment_id='True'
 name='True'
 description='True'

--- a/data/postgres_program_db.sql
+++ b/data/postgres_program_db.sql
@@ -42,12 +42,12 @@ INSERT INTO "ramstk_mission" VALUES(1,1,'Default Mission',0.0,'hours');
 CREATE TABLE ramstk_mission_phase (
     fld_revision_id INTEGER NOT NULL,
     fld_mission_id INTEGER NOT NULL,
-    fld_phase_id INTEGER NOT NULL,
+    fld_mission_phase_id INTEGER NOT NULL,
     fld_description VARCHAR DEFAULT '',
     fld_name VARCHAR(256) DEFAULT '',
     fld_phase_start FLOAT DEFAULT 0.0,
     fld_phase_end FLOAT DEFAULT 0.0,
-    PRIMARY KEY (fld_phase_id),
+    PRIMARY KEY (fld_mission_phase_id),
     FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
     FOREIGN KEY(fld_mission_id) REFERENCES ramstk_mission (fld_mission_id) ON DELETE CASCADE
 );
@@ -55,7 +55,7 @@ INSERT INTO "ramstk_mission_phase" VALUES (1, 1,1,'Default Mission Phase 1','',0
 CREATE TABLE ramstk_environment (
     fld_revision_id INTEGER NOT NULL,
     fld_mission_id INTEGER NOT NULL,
-    fld_phase_id INTEGER NOT NULL,
+    fld_mission_phase_id INTEGER NOT NULL,
     fld_environment_id INTEGER NOT NULL,
     fld_name VARCHAR(256) DEFAULT '',
     fld_units VARCHAR(128) DEFAULT '',
@@ -69,7 +69,7 @@ CREATE TABLE ramstk_environment (
     PRIMARY KEY (fld_environment_id),
     FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
     FOREIGN KEY(fld_mission_id) REFERENCES ramstk_mission (fld_mission_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_phase_id) REFERENCES ramstk_mission_phase (fld_phase_id) ON DELETE CASCADE
+    FOREIGN KEY(fld_mission_phase_id) REFERENCES ramstk_mission_phase (fld_mission_phase_id) ON DELETE CASCADE
 );
 INSERT INTO "ramstk_environment" VALUES (1,1,1,1,'Environment','',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
 CREATE TABLE ramstk_program_info (

--- a/src/ramstk/models/programdb/environment/record.py
+++ b/src/ramstk/models/programdb/environment/record.py
@@ -36,11 +36,11 @@ class RAMSTKEnvironmentRecord(RAMSTK_BASE, RAMSTKBaseRecord):
     __tablename__ = "ramstk_environment"
     __table_args__ = (
         ForeignKeyConstraint(
-            ["fld_revision_id", "fld_mission_id", "fld_phase_id"],
+            ["fld_revision_id", "fld_mission_id", "fld_mission_phase_id"],
             [
                 "ramstk_mission_phase.fld_revision_id",
                 "ramstk_mission_phase.fld_mission_id",
-                "ramstk_mission_phase.fld_phase_id",
+                "ramstk_mission_phase.fld_mission_phase_id",
             ],
         ),
         {"extend_existing": True},
@@ -53,7 +53,9 @@ class RAMSTKEnvironmentRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         nullable=False,
     )
     mission_id = Column("fld_mission_id", Integer, primary_key=True, nullable=False)
-    phase_id = Column("fld_phase_id", Integer, primary_key=True, nullable=False)
+    mission_phase_id = Column(
+        "fld_mission_phase_id", Integer, primary_key=True, nullable=False
+    )
     environment_id = Column(
         "fld_environment_id",
         Integer,
@@ -82,20 +84,16 @@ class RAMSTKEnvironmentRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         back_populates="environment",
     )
 
-    is_mission = False
-    is_phase = False
-    is_env = True
-
     def get_attributes(self):
         """Retrieve current values of RAMSTKEnvironment data model attributes.
 
-        :return: {phase_id, environment_id, name, units, minimum,
+        :return: {mission_phase_id, environment_id, name, units, minimum,
                   maximum, mean, variance, ramp_rate, low_dwell_time,
                   high_dwell_time} pairs.
         :rtype: dict
         """
-        _attributes = {
-            "phase_id": self.phase_id,
+        return {
+            "mission_phase_id": self.mission_phase_id,
             "environment_id": self.environment_id,
             "name": self.name,
             "units": self.units,
@@ -107,5 +105,3 @@ class RAMSTKEnvironmentRecord(RAMSTK_BASE, RAMSTKBaseRecord):
             "low_dwell_time": self.low_dwell_time,
             "high_dwell_time": self.high_dwell_time,
         }
-
-        return _attributes

--- a/src/ramstk/models/programdb/environment/table.py
+++ b/src/ramstk/models/programdb/environment/table.py
@@ -42,7 +42,7 @@ class RAMSTKEnvironmentTable(RAMSTKBaseTable):
         self._lst_id_columns = [
             "revision_id",
             "mission_id",
-            "phase_id",
+            "mission_phase_id",
             "environment_id",
             "parent_id",
             "record_id",
@@ -72,7 +72,7 @@ class RAMSTKEnvironmentTable(RAMSTKBaseTable):
         _new_record = self._record()
         _new_record.revision_id = attributes["revision_id"]
         _new_record.mission_id = attributes["mission_id"]
-        _new_record.phase_id = attributes["phase_id"]
+        _new_record.mission_phase_id = attributes["mission_phase_id"]
         _new_record.environment_id = self.last_id + 1
 
         return _new_record

--- a/src/ramstk/models/programdb/mission/record.py
+++ b/src/ramstk/models/programdb/mission/record.py
@@ -23,7 +23,11 @@ class RAMSTKMissionRecord(RAMSTK_BASE, RAMSTKBaseRecord):
     shares a One-to-Many relationship with ramstk_mission_phase.
     """
 
-    __defaults__ = {"description": "", "mission_time": 0.0, "time_units": "hours"}
+    __defaults__ = {
+        "description": "",
+        "mission_time": 0.0,
+        "time_units": "hours",
+    }
     __tablename__ = "ramstk_mission"
     __table_args__ = (
         UniqueConstraint(
@@ -60,10 +64,6 @@ class RAMSTKMissionRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         cascade="all,delete",
     )
 
-    is_mission = True
-    is_phase = False
-    is_env = False
-
     def get_attributes(self):
         """Retrieve current values of the RAMSTKMission data model attributes.
 
@@ -71,12 +71,10 @@ class RAMSTKMissionRecord(RAMSTK_BASE, RAMSTKBaseRecord):
                   time_units)
         :rtype: tuple
         """
-        _attributes = {
+        return {
             "revision_id": self.revision_id,
             "mission_id": self.mission_id,
             "description": self.description,
             "mission_time": self.mission_time,
             "time_units": self.time_units,
         }
-
-        return _attributes

--- a/src/ramstk/models/programdb/mission_phase/record.py
+++ b/src/ramstk/models/programdb/mission_phase/record.py
@@ -23,7 +23,12 @@ class RAMSTKMissionPhaseRecord(RAMSTK_BASE, RAMSTKBaseRecord):
     shares a One-to-Many relationship with ramstk_environment.
     """
 
-    __defaults__ = {"description": "", "name": "", "phase_start": 0.0, "phase_end": 0.0}
+    __defaults__ = {
+        "description": "",
+        "name": "",
+        "phase_start": 0.0,
+        "phase_end": 0.0,
+    }
     __tablename__ = "ramstk_mission_phase"
     __table_args__ = (
         ForeignKeyConstraint(
@@ -48,8 +53,8 @@ class RAMSTKMissionPhaseRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         primary_key=True,
         nullable=False,
     )
-    phase_id = Column(
-        "fld_phase_id",
+    mission_phase_id = Column(
+        "fld_mission_phase_id",
         Integer,
         primary_key=True,
         autoincrement=True,
@@ -72,23 +77,17 @@ class RAMSTKMissionPhaseRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         cascade="all,delete",
     )
 
-    is_mission = False
-    is_phase = True
-    is_env = False
-
     def get_attributes(self):
         """Retrieve current values of the Mission Phase data model attributes.
 
         :return: value of instance attributes
         :rtype: tuple
         """
-        _values = {
+        return {
             "mission_id": self.mission_id,
-            "phase_id": self.phase_id,
+            "mission_phase_id": self.mission_phase_id,
             "description": self.description,
             "name": self.name,
             "phase_start": self.phase_start,
             "phase_end": self.phase_end,
         }
-
-        return _values

--- a/src/ramstk/models/programdb/mission_phase/table.py
+++ b/src/ramstk/models/programdb/mission_phase/table.py
@@ -22,7 +22,7 @@ class RAMSTKMissionPhaseTable(RAMSTKBaseTable):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
-    _db_id_colname = "fld_phase_id"
+    _db_id_colname = "fld_mission_phase_id"
     _db_tablename = "ramstk_mission_phase"
     _select_msg = "selected_revision"
     _tag = "mission_phase"
@@ -43,7 +43,7 @@ class RAMSTKMissionPhaseTable(RAMSTKBaseTable):
         self._lst_id_columns = [
             "revision_id",
             "mission_id",
-            "phase_id",
+            "mission_phase_id",
             "parent_id",
             "record_id",
         ]
@@ -56,7 +56,7 @@ class RAMSTKMissionPhaseTable(RAMSTKBaseTable):
         # Initialize public list attributes.
 
         # Initialize public scalar attributes.
-        self.pkey = "phase_id"
+        self.pkey = "mission_phase_id"
 
         # Subscribe to PyPubSub messages.
 
@@ -72,6 +72,6 @@ class RAMSTKMissionPhaseTable(RAMSTKBaseTable):
         _new_record = self._record()
         _new_record.revision_id = attributes["revision_id"]
         _new_record.mission_id = attributes["mission_id"]
-        _new_record.phase_id = self.last_id + 1
+        _new_record.mission_phase_id = self.last_id + 1
 
         return _new_record

--- a/src/ramstk/models/programdb/usage_profile/view.py
+++ b/src/ramstk/models/programdb/usage_profile/view.py
@@ -80,10 +80,10 @@ class RAMSTKUsageProfileView(RAMSTKBaseView):
         pub.subscribe(super().do_set_tree, "succeed_delete_mission")
         pub.subscribe(super().do_set_tree, "succeed_delete_mission_phase")
 
-    def _do_load_environments(self, phase_id: int, parent_id: str) -> None:
+    def _do_load_environments(self, mission_phase_id: int, parent_id: str) -> None:
         """Load the environments into the tree for the passed phase ID.
 
-        :param phase_id: the mission phase ID to load the environments for.
+        :param mission_phase_id: the mission phase ID to load the environments for.
         :param parent_id: the parent node ID.
         :return: None
         :rtype: None
@@ -92,7 +92,7 @@ class RAMSTKUsageProfileView(RAMSTKBaseView):
             _environment = _node.data["environment"]
             _node_id = f"{parent_id}.{_environment.environment_id}"
 
-            if _environment.phase_id == phase_id:
+            if _environment.mission_phase_id == mission_phase_id:
                 self.tree.create_node(
                     tag="environment",
                     identifier=_node_id,
@@ -131,7 +131,7 @@ class RAMSTKUsageProfileView(RAMSTKBaseView):
         """
         for _node in self._dic_trees["mission_phase"].all_nodes()[1:]:
             _mission_phase = _node.data["mission_phase"]
-            _node_id = f"{mission_id}.{_mission_phase.phase_id}"
+            _node_id = f"{mission_id}.{_mission_phase.mission_phase_id}"
 
             if _mission_phase.mission_id == mission_id:
                 self.tree.create_node(
@@ -143,6 +143,6 @@ class RAMSTKUsageProfileView(RAMSTKBaseView):
 
                 if self._dic_trees["environment"].depth() > 0:
                     self._dic_load_functions["environment"](  # type: ignore
-                        _mission_phase.phase_id,
+                        _mission_phase.mission_phase_id,
                         _node_id,
                     )

--- a/src/ramstk/models/programdb/usage_profile/view.py
+++ b/src/ramstk/models/programdb/usage_profile/view.py
@@ -90,9 +90,9 @@ class RAMSTKUsageProfileView(RAMSTKBaseView):
         """
         for _node in self._dic_trees["environment"].all_nodes()[1:]:
             _environment = _node.data["environment"]
-            _node_id = f"{parent_id}.{_environment.environment_id}"
-
             if _environment.mission_phase_id == mission_phase_id:
+                _node_id = f"{parent_id}.{_environment.environment_id}"
+
                 self.tree.create_node(
                     tag="environment",
                     identifier=_node_id,

--- a/src/ramstk/views/gtk3/usage_profile/panel.py
+++ b/src/ramstk/views/gtk3/usage_profile/panel.py
@@ -39,7 +39,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
             False,
             False,
         ],
-        "phase": [
+        "mission_phase": [
             False,
             False,
             True,
@@ -136,7 +136,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 _("Mission ID"),
                 "gint",
             ],
-            "phase_id": [
+            "mission_phase_id": [
                 2,
                 Gtk.CellRendererText(),
                 "edited",
@@ -237,7 +237,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                "wvw_editing_phase",
+                "wvw_editing_mission_phase",
                 0.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -253,7 +253,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
                 Gtk.CellRendererText(),
                 "edited",
                 super().on_cell_edit,
-                "wvw_editing_phase",
+                "wvw_editing_mission_phase",
                 1.0,
                 {
                     "bg_color": "#FFFFFF",
@@ -369,7 +369,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
 
         self.level = {
             "100": "mission",
-            "110": "phase",
+            "110": "mission_phase",
             "111": "environment",
         }[_cid]
 
@@ -449,7 +449,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         _attributes = [
             _entity.revision_id,
             _entity.mission_id,
-            _entity.phase_id,
+            _entity.mission_phase_id,
             _entity.environment_id,
             _entity.name,
             "",
@@ -548,7 +548,7 @@ class UsageProfileTreePanel(RAMSTKTreePanel):
         _attributes = [
             _entity.revision_id,
             _entity.mission_id,
-            _entity.phase_id,
+            _entity.mission_phase_id,
             0,
             _entity.name,
             _entity.description,

--- a/tests/__data/test_program_db.sql
+++ b/tests/__data/test_program_db.sql
@@ -45,12 +45,12 @@ INSERT INTO "ramstk_mission" VALUES(1,3,'Test Mission 3',0.0,'hours');
 CREATE TABLE ramstk_mission_phase (
     fld_revision_id INTEGER NOT NULL,
     fld_mission_id INTEGER NOT NULL,
-    fld_phase_id INTEGER NOT NULL,
+    fld_mission_phase_id INTEGER NOT NULL,
     fld_description VARCHAR,
     fld_name VARCHAR(256),
     fld_phase_start FLOAT,
     fld_phase_end FLOAT,
-    PRIMARY KEY (fld_phase_id),
+    PRIMARY KEY (fld_mission_phase_id),
     FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
     FOREIGN KEY(fld_mission_id) REFERENCES ramstk_mission (fld_mission_id) ON DELETE CASCADE
 );
@@ -60,7 +60,7 @@ INSERT INTO "ramstk_mission_phase" VALUES(1,3,3,'Test Mission Phase 3','',0.0,0.
 CREATE TABLE ramstk_environment (
     fld_revision_id INTEGER NOT NULL,
     fld_mission_id INTEGER NOT NULL,
-    fld_phase_id INTEGER NOT NULL,
+    fld_mission_phase_id INTEGER NOT NULL,
     fld_environment_id INTEGER NOT NULL,
     fld_name VARCHAR(256),
     fld_units VARCHAR(128),
@@ -74,7 +74,7 @@ CREATE TABLE ramstk_environment (
     PRIMARY KEY (fld_environment_id),
     FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
     FOREIGN KEY(fld_mission_id) REFERENCES ramstk_mission (fld_mission_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_phase_id) REFERENCES ramstk_mission_phase (fld_phase_id) ON DELETE CASCADE
+    FOREIGN KEY(fld_mission_phase_id) REFERENCES ramstk_mission_phase (fld_mission_phase_id) ON DELETE CASCADE
 );
 INSERT INTO "ramstk_environment" VALUES(1,1,1,1,'Condition Name','Units',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
 INSERT INTO "ramstk_environment" VALUES(1,2,2,2,'Condition Name 2','Units',0.0,0.0,0.0,0.0,0.0,0.0,0.0);

--- a/tests/models/programdb/environment/conftest.py
+++ b/tests/models/programdb/environment/conftest.py
@@ -11,7 +11,7 @@ def mock_program_dao(monkeypatch):
     _environment_1 = RAMSTKEnvironmentRecord()
     _environment_1.revision_id = 1
     _environment_1.mission_id = 1
-    _environment_1.phase_id = 1
+    _environment_1.mission_phase_id = 1
     _environment_1.environment_id = 1
     _environment_1.name = "Condition Name"
     _environment_1.units = "Units"
@@ -26,7 +26,7 @@ def mock_program_dao(monkeypatch):
     _environment_2 = RAMSTKEnvironmentRecord()
     _environment_2.revision_id = 1
     _environment_2.mission_id = 1
-    _environment_2.phase_id = 1
+    _environment_2.mission_phase_id = 1
     _environment_2.environment_id = 2
     _environment_2.name = "Condition Name"
     _environment_2.units = "Units"
@@ -41,7 +41,7 @@ def mock_program_dao(monkeypatch):
     _environment_3 = RAMSTKEnvironmentRecord()
     _environment_3.revision_id = 1
     _environment_3.mission_id = 1
-    _environment_3.phase_id = 1
+    _environment_3.mission_phase_id = 1
     _environment_3.environment_id = 3
     _environment_3.name = "Condition Name"
     _environment_3.units = "Units"
@@ -68,7 +68,7 @@ def test_attributes():
     yield {
         "revision_id": 1,
         "mission_id": 1,
-        "phase_id": 1,
+        "mission_phase_id": 1,
         "environment_id": 1,
         "name": "Condition Name",
         "units": "Units",

--- a/tests/models/programdb/environment/environment_integration_test.py
+++ b/tests/models/programdb/environment/environment_integration_test.py
@@ -27,7 +27,7 @@ def test_tablemodel(test_program_dao):
     dut.do_select_all(
         attributes={
             "revision_id": 1,
-            "phase_id": 1,
+            "mission_phase_id": 1,
         }
     )
 
@@ -78,7 +78,7 @@ class TestInsertMethods:
     def on_fail_insert_no_parent(self, error_message):
         assert error_message == (
             "do_insert: Database error when attempting to add a record.  Database "
-            "returned:\n\tKey (fld_phase_id)=(20) is not present in table "
+            "returned:\n\tKey (fld_mission_phase_id)=(20) is not present in table "
             '"ramstk_mission_phase".'
         )
         print("\033[35m\nfail_insert_environment topic was broadcast.")
@@ -105,7 +105,7 @@ class TestInsertMethods:
         """should send the fail message when the mission phase ID does not exist."""
         pub.subscribe(self.on_fail_insert_no_parent, "fail_insert_environment")
 
-        test_attributes["phase_id"] = 20
+        test_attributes["mission_phase_id"] = 20
         pub.sendMessage("request_insert_environment", attributes=test_attributes)
 
         pub.unsubscribe(self.on_fail_insert_no_parent, "fail_insert_environment")
@@ -286,7 +286,7 @@ class TestGetterSetter:
 
     def on_succeed_get_attributes(self, attributes):
         assert isinstance(attributes, dict)
-        assert attributes["phase_id"] == 1
+        assert attributes["mission_phase_id"] == 1
         assert attributes["environment_id"] == 1
         assert attributes["name"] == "Condition Name"
         print("\033[36m\nsucceed_get_environment_attributes topic was broadcast")

--- a/tests/models/programdb/environment/environment_unit_test.py
+++ b/tests/models/programdb/environment/environment_unit_test.py
@@ -191,7 +191,7 @@ class TestGetterSetter:
         """should return None on success."""
         test_attributes.pop("revision_id")
         test_attributes.pop("mission_id")
-        test_attributes.pop("phase_id")
+        test_attributes.pop("mission_phase_id")
         test_attributes.pop("environment_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")
@@ -206,7 +206,7 @@ class TestGetterSetter:
 
         test_attributes.pop("revision_id")
         test_attributes.pop("mission_id")
-        test_attributes.pop("phase_id")
+        test_attributes.pop("mission_phase_id")
         test_attributes.pop("environment_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")
@@ -220,7 +220,7 @@ class TestGetterSetter:
         """should raise an AttributeError when passed an unknown attribute."""
         test_attributes.pop("revision_id")
         test_attributes.pop("mission_id")
-        test_attributes.pop("phase_id")
+        test_attributes.pop("mission_phase_id")
         test_attributes.pop("environment_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")

--- a/tests/models/programdb/mission_phase/conftest.py
+++ b/tests/models/programdb/mission_phase/conftest.py
@@ -11,7 +11,7 @@ def mock_program_dao(monkeypatch):
     _mission_phase_1 = RAMSTKMissionPhaseRecord()
     _mission_phase_1.revision_id = 1
     _mission_phase_1.mission_id = 1
-    _mission_phase_1.phase_id = 1
+    _mission_phase_1.mission_phase_id = 1
     _mission_phase_1.description = "Phase #1 for mission #1"
     _mission_phase_1.name = "Start Up"
     _mission_phase_1.phase_start = 0.0
@@ -20,7 +20,7 @@ def mock_program_dao(monkeypatch):
     _mission_phase_2 = RAMSTKMissionPhaseRecord()
     _mission_phase_2.revision_id = 1
     _mission_phase_2.mission_id = 1
-    _mission_phase_2.phase_id = 2
+    _mission_phase_2.mission_phase_id = 2
     _mission_phase_2.description = "Phase #2 for mission #1"
     _mission_phase_2.name = "Operation"
     _mission_phase_2.phase_start = 0.0
@@ -29,7 +29,7 @@ def mock_program_dao(monkeypatch):
     _mission_phase_3 = RAMSTKMissionPhaseRecord()
     _mission_phase_3.revision_id = 1
     _mission_phase_3.mission_id = 1
-    _mission_phase_3.phase_id = 3
+    _mission_phase_3.mission_phase_id = 3
     _mission_phase_3.description = "Phase #3 for mission #1"
     _mission_phase_3.name = "Shut Down"
     _mission_phase_3.phase_start = 0.0
@@ -50,7 +50,7 @@ def test_attributes():
     yield {
         "revision_id": 1,
         "mission_id": 1,
-        "phase_id": 1,
+        "mission_phase_id": 1,
         "description": "",
         "name": "",
         "phase_start": 0.0,

--- a/tests/models/programdb/mission_phase/mission_phase_integration_test.py
+++ b/tests/models/programdb/mission_phase/mission_phase_integration_test.py
@@ -295,7 +295,7 @@ class TestGetterSetter:
     def on_succeed_get_attributes(self, attributes):
         assert isinstance(attributes, dict)
         assert attributes["mission_id"] == 1
-        assert attributes["phase_id"] == 1
+        assert attributes["mission_phase_id"] == 1
         assert attributes["description"] == "Test Mission Phase 1"
         print("\033[36m\nsucceed_get_mission_phase_attributes topic was broadcast")
 

--- a/tests/models/programdb/mission_phase/mission_phase_unit_test.py
+++ b/tests/models/programdb/mission_phase/mission_phase_unit_test.py
@@ -67,7 +67,7 @@ class TestCreateModels:
         assert isinstance(test_tablemodel, RAMSTKMissionPhaseTable)
         assert isinstance(test_tablemodel.tree, Tree)
         assert isinstance(test_tablemodel.dao, MockDAO)
-        assert test_tablemodel._db_id_colname == "fld_phase_id"
+        assert test_tablemodel._db_id_colname == "fld_mission_phase_id"
         assert test_tablemodel._db_tablename == "ramstk_mission_phase"
         assert test_tablemodel._tag == "mission_phase"
         assert test_tablemodel._root == 0
@@ -121,7 +121,7 @@ class TestSelectMethods:
         _mission_phase = test_tablemodel.do_select(1)
 
         assert isinstance(_mission_phase, RAMSTKMissionPhaseRecord)
-        assert _mission_phase.phase_id == 1
+        assert _mission_phase.mission_phase_id == 1
 
     @pytest.mark.unit
     def test_do_select_non_existent_id(self, test_attributes, test_tablemodel):
@@ -173,7 +173,7 @@ class TestGetterSetter:
         _attributes = test_recordmodel.get_attributes()
 
         assert isinstance(_attributes, dict)
-        assert _attributes["phase_id"] == 1
+        assert _attributes["mission_phase_id"] == 1
         assert _attributes["description"] == "Phase #1 for mission #1"
         assert _attributes["name"] == "Start Up"
         assert _attributes["phase_start"] == 0.0
@@ -184,7 +184,7 @@ class TestGetterSetter:
         """should return None on success."""
         test_attributes.pop("revision_id")
         test_attributes.pop("mission_id")
-        test_attributes.pop("phase_id")
+        test_attributes.pop("mission_phase_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")
         assert test_recordmodel.set_attributes(test_attributes) is None
@@ -198,7 +198,7 @@ class TestGetterSetter:
 
         test_attributes.pop("revision_id")
         test_attributes.pop("mission_id")
-        test_attributes.pop("phase_id")
+        test_attributes.pop("mission_phase_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")
         assert test_recordmodel.set_attributes(test_attributes) is None
@@ -211,7 +211,7 @@ class TestGetterSetter:
         """should raise an AttributeError when passed an unknown attribute."""
         test_attributes.pop("revision_id")
         test_attributes.pop("mission_id")
-        test_attributes.pop("phase_id")
+        test_attributes.pop("mission_phase_id")
         test_attributes.pop("parent_id")
         test_attributes.pop("record_id")
         with pytest.raises(AttributeError):

--- a/tests/models/programdb/usage_profile/usage_profile_integration_test.py
+++ b/tests/models/programdb/usage_profile/usage_profile_integration_test.py
@@ -80,7 +80,7 @@ def test_environment(test_program_dao):
     # Create the device under test (dut) and connect to the database.
     dut = RAMSTKEnvironmentTable()
     dut.do_connect(test_program_dao)
-    dut.do_select_all(attributes={"revision_id": 1, "phase_id": 1})
+    dut.do_select_all(attributes={"revision_id": 1, "mission_phase_id": 1})
 
     yield dut
 
@@ -147,7 +147,9 @@ class TestSelectMethods:
 
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 1})
-        test_environment.do_select_all(attributes={"revision_id": 1, "phase_id": 1})
+        test_environment.do_select_all(
+            attributes={"revision_id": 1, "mission_phase_id": 1}
+        )
 
         assert isinstance(
             test_viewmodel.tree.get_node("1").data["usage_profile"], RAMSTKMissionRecord
@@ -192,7 +194,9 @@ class TestSelectMethods:
         """should clear existing nodes from the records tree and then re-populate."""
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 1})
-        test_environment.do_select_all(attributes={"revision_id": 1, "phase_id": 1})
+        test_environment.do_select_all(
+            attributes={"revision_id": 1, "mission_phase_id": 1}
+        )
 
         assert isinstance(
             test_viewmodel.tree.get_node("1").data["usage_profile"], RAMSTKMissionRecord
@@ -269,7 +273,9 @@ class TestInsertMethods:
         """should add a new mission record to the records tree."""
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 1})
-        test_environment.do_select_all(attributes={"revision_id": 1, "phase_id": 1})
+        test_environment.do_select_all(
+            attributes={"revision_id": 1, "mission_phase_id": 1}
+        )
 
         assert not test_viewmodel.tree.contains("4")
 
@@ -296,7 +302,9 @@ class TestInsertMethods:
         """should add a new mission phase record to the records tree."""
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 1})
-        test_environment.do_select_all(attributes={"revision_id": 1, "phase_id": 1})
+        test_environment.do_select_all(
+            attributes={"revision_id": 1, "mission_phase_id": 1}
+        )
 
         assert not test_viewmodel.tree.contains("1.4")
 
@@ -309,7 +317,7 @@ class TestInsertMethods:
             attributes={
                 "revision_id": 1,
                 "mission_id": 1,
-                "phase_id": 1,
+                "mission_phase_id": 1,
                 "parent_id": 1,
                 "record_id": 1,
             },
@@ -329,7 +337,7 @@ class TestInsertMethods:
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 1})
         test_environment.do_select_all(
-            attributes={"revision_id": 1, "mission_id": 1, "phase_id": 1}
+            attributes={"revision_id": 1, "mission_id": 1, "mission_phase_id": 1}
         )
 
         assert not test_viewmodel.tree.contains("1.1.4")
@@ -343,7 +351,7 @@ class TestInsertMethods:
             attributes={
                 "revision_id": 1,
                 "mission_id": 1,
-                "phase_id": 1,
+                "mission_phase_id": 1,
                 "environment_id": 1,
                 "parent_id": 1,
                 "record_id": 1,
@@ -401,7 +409,9 @@ class TestDeleteMethods:
         """should remove deleted environment record from the records tree."""
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 3})
-        test_environment.do_select_all(attributes={"revision_id": 1, "phase_id": 3})
+        test_environment.do_select_all(
+            attributes={"revision_id": 1, "mission_phase_id": 3}
+        )
 
         assert test_viewmodel.tree.contains("3.3.3")
         assert test_viewmodel.tree.contains("3.3")
@@ -424,7 +434,9 @@ class TestDeleteMethods:
         """should remove deleted phase and environment records from records tree."""
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 2})
-        test_environment.do_select_all(attributes={"revision_id": 1, "phase_id": 2})
+        test_environment.do_select_all(
+            attributes={"revision_id": 1, "mission_phase_id": 2}
+        )
 
         assert test_viewmodel.tree.contains("2.2.2")
         assert test_viewmodel.tree.contains("2.2")
@@ -447,7 +459,9 @@ class TestDeleteMethods:
         """should remove deleted mission, phase, and environment from records tree."""
         test_mission.do_select_all(attributes={"revision_id": 1})
         test_phase.do_select_all(attributes={"revision_id": 1, "mission_id": 1})
-        test_environment.do_select_all(attributes={"revision_id": 1, "phase_id": 1})
+        test_environment.do_select_all(
+            attributes={"revision_id": 1, "mission_phase_id": 1}
+        )
 
         assert test_viewmodel.tree.contains("1.1.1")
         assert test_viewmodel.tree.contains("1.1")


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To fix the problem of being able to add mission phases and environments to the Usage Profile.

## Describe how this was implemented.
Added a method that determines the selected level in the Usage Profile and then sets the proper ID values for the record and table models to use for the insert.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #956 
Closes #957 
Closes #958 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
