### PR TITLE
fix: component widgets not loading saved values

### DIFF
--- a/.github/workflows/do-test-suite.yml
+++ b/.github/workflows/do-test-suite.yml
@@ -18,6 +18,8 @@ on:
       - master
     paths:
       - "**.py"
+    tags-ignore:
+      - "*"
   pull_request:
     paths:
       - "**.py"

--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -4,12 +4,6 @@
 #     - Remove 'status: inprogress' label.
 #     - Add 'status: closed' label.
 # - Job 2:
-#     - Get PR labels.
-#     - IF 'endgame:merged':
-#         - Imports signing GPG key.
-#         - Signs and pushes 'latest' tag.
-#         - Updates draft release notes.
-# - Job 3:
 #     - Gets list of PR labels.
 #     - Get current version from VERSION.
 #     - Determine next Semantic version.
@@ -37,45 +31,8 @@ jobs:
           add-labels: "status: closed"
           remove-labels: "status: inprogress"
 
-  tag-latest:
-    name: Tag Repository as 'latest'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: Push 'latest' tag
-        run: |
-          git config --global user.email "${{ steps.import_gpg.outputs.email }}"
-          git config --global user.name "${{ steps.import_gpg.outputs.name }}"
-          git tag -s -f -a -m"push latest tag" latest
-          git push -f --tags && echo "do_release_latest=1" >> $GITHUB_ENV
-
-      - name: Draft 'latest' release notes
-        if: ${{ env.do_release_latest == 1 }}
-        uses: release-drafter/release-drafter@master
-        with:
-          name: "Next Release"
-          tag: "latest"
-          version: "latest"
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   tag-version:
     name: Push Version Tag
-    needs: tag-latest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -14,6 +14,42 @@ on:
       - "*"
 
 jobs:
+  tag-latest:
+    name: Tag Repository as 'latest'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Push 'latest' tag
+        run: |
+          git config --global user.email "${{ steps.import_gpg.outputs.email }}"
+          git config --global user.name "${{ steps.import_gpg.outputs.name }}"
+          git tag -s -f -a -m"push latest tag" latest
+          git push -f --tags && echo "do_release_latest=1" >> $GITHUB_ENV
+
+      - name: Draft 'latest' release notes
+        if: ${{ env.do_release_latest == 1 }}
+        uses: release-drafter/release-drafter@master
+        with:
+          name: "Next Release"
+          tag: "latest"
+          version: "latest"
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_documentation:
     name: Build RAMSTK Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -66,20 +66,12 @@ jobs:
             ./pyproject.toml
             ./docs/conf.py
 
-      - name: Set release pull request variables
-        id: prvars
-        run: |
-          echo ::set-output name=title::"release: v${{ steps.newversion.outputs.new_version }}"
-          echo ::set-output name=body::"Please cut release v${{ steps.newversion.outputs.new_version }}"
-          echo ::set-output name=message::"release: v${{ steps.newversion.outputs.new_version }}"
-          echo ::set-output name=branch::"release/v${{ steps.newversion.outputs.new_version }}"
-
       - name: Cut release pull request
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: ${{ steps.prvars.outputs.message }}
-          title: ${{ steps.prvars.outputs.title }}
-          body: ${{ steps.prvars.outputs.body }}
-          branch: ${{ steps.prvars.outputs.branch }}
+          commit-message: "release: ${{ steps.newversion.outputs.new_version }}"
+          title: "release: ${{ steps.newversion.outputs.new_version }}"
+          body: "Please cut release ${{ steps.newversion.outputs.new_version }}"
+          branch: "release/${{ steps.newversion.outputs.new_version }}"
           base: master
           labels: Release

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -17,6 +17,7 @@ name: Publish Release Workflow
 on:
   release:
     types:
+      - created
       - published
 
 jobs:

--- a/src/ramstk/models/commondb/database.pyi
+++ b/src/ramstk/models/commondb/database.pyi
@@ -3,12 +3,8 @@ import gettext
 from typing import Dict, Tuple, Union
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKSiteConfiguration as RAMSTKSiteConfiguration,
-)
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKSiteConfiguration as RAMSTKSiteConfiguration
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.db import BaseDatabase as BaseDatabase
 from ramstk.db import do_create_program_db as do_create_program_db
 from ramstk.models import RAMSTKCategoryRecord as RAMSTKCategoryRecord

--- a/src/ramstk/models/programdb/design_electric/record.py
+++ b/src/ramstk/models/programdb/design_electric/record.py
@@ -8,7 +8,7 @@
 """RAMSTKDesignElectric Table Module."""
 
 # Standard Library Imports
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 # Third Party Imports
 from pubsub import pub
@@ -21,40 +21,42 @@ from ramstk.models import RAMSTKBaseRecord
 
 
 def do_check_overstress(
-    overstress: Dict[str, List[float]], stress_type: str
-) -> Tuple[bool, str]:
-    """Check the overstress condition and build a reason message.
+    overstress: Dict[str, List[float]], stress_type: str, limits: Dict[str, List[float]]
+) -> Tuple[int, str]:
+    """Check the over stress condition and build a reason message.
 
     :param overstress: the dict containing the results of the
-        overstress analysis.
-    :param stress_type: the overstress type being checked.
+        over stress analysis.
+    :param stress_type: the over stress type being checked.
     :return: (_overstress, _reason); whether a component is overstressed and the reason.
     :rtype: tuple
     """
-    _overstress = False
+    _overstress = 0
     _reason = ""
 
     if overstress["harsh"][0]:
-        _overstress = True
+        _overstress = 1
         _reason = _reason + (
-            f"Operating {stress_type} is less than limit in a harsh environment.\n"
+            f"Operating {stress_type} ratio is less than the harsh environment limit "
+            f"of {limits['harsh'][0]}.\n"
         )
     if overstress["harsh"][1]:
-        _overstress = True
+        _overstress = 1
         _reason = _reason + (
-            f"Operating {stress_type} is greater than limit "
-            f"in a harsh environment.\n"
+            f"Operating {stress_type} ratio is greater than the harsh environment "
+            f"limit of {limits['harsh'][1]}.\n"
         )
     if overstress["mild"][0]:
-        _overstress = True
+        _overstress = 1
         _reason = _reason + (
-            f"Operating {stress_type} is less than limit in a mild environment.\n"
+            f"Operating {stress_type} ratio is less than the mild environment limit of "
+            f"{limits['mild'][0]}.\n"
         )
     if overstress["mild"][1]:
-        _overstress = True
+        _overstress = 1
         _reason = _reason + (
-            f"Operating {stress_type} is greater than limit "
-            f"in a mild environment.\n"
+            f"Operating {stress_type} ratio is greater than the mild environment limit "
+            f"of {limits['mild'][1]}.\n"
         )
 
     return _overstress, _reason
@@ -309,7 +311,7 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
 
     # Define the relationships to other tables in the RAMSTK Program database.
 
-    def get_attributes(self) -> Dict[str, Any]:
+    def get_attributes(self) -> Dict[str, Union[float, int, str]]:
         """Retrieve current values of RAMSTKDesignElectric model attributes.
 
         :return: {hardware_id, application_id, area, capacitance,
@@ -331,7 +333,7 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
                   voltage_ratio, weight, years_in_production} pairs.
         :rtype: dict
         """
-        _attributes = {
+        return {
             "hardware_id": self.hardware_id,
             "application_id": self.application_id,
             "area": self.area,
@@ -388,8 +390,6 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
             "weight": self.weight,
             "years_in_production": self.years_in_production,
         }
-
-        return _attributes
 
     def do_calculate_current_ratio(self) -> None:
         """Calculate the current ratio.
@@ -481,7 +481,7 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         :return: None
         :rtype: None
         """
-        _overstress = False
+        _overstress = 0
         _reason = ""
 
         _current_limits = {
@@ -500,19 +500,23 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         _ostress, _rsn = do_check_overstress(
             derating.check_overstress(self.current_ratio, _current_limits),
             "current",
+            _current_limits,
         )
         _overstress = _overstress or _ostress
-        _reason = _reason + _rsn
+        _reason += _rsn
 
         _ostress, _rsn = do_check_overstress(
-            derating.check_overstress(self.power_ratio, _power_limits), "power"
+            derating.check_overstress(self.power_ratio, _power_limits),
+            "power",
+            _power_limits,
         )
         _overstress = _overstress or _ostress
-        _reason = _reason + _rsn
+        _reason += _rsn
 
         _ostress, _rsn = do_check_overstress(
             derating.check_overstress(self.voltage_ratio, _voltage_limits),
             "voltage",
+            _voltage_limits,
         )
         self.overstress = _overstress or _ostress
         self.reason = _reason + _rsn
@@ -524,11 +528,11 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
         :return: None
         :rtype: None
         """
-        if category_id in [1, 2, 5, 6, 7, 8]:
+        if category_id in {1, 2, 5, 6, 7, 8}:
             self.do_calculate_current_ratio()
 
         if category_id == 3:
             self.do_calculate_power_ratio()
 
-        if category_id in [4, 5, 8]:
+        if category_id in {4, 5, 8}:
             self.do_calculate_voltage_ratio()

--- a/src/ramstk/models/programdb/design_electric/record.pyi
+++ b/src/ramstk/models/programdb/design_electric/record.pyi
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 # Third Party Imports
 from pubsub import pub
@@ -11,69 +11,69 @@ from ramstk.models import RAMSTKBaseRecord as RAMSTKBaseRecord
 
 def do_check_overstress(
     overstress: Dict[str, List[float]], stress_type: str
-) -> Tuple[bool, str]: ...
+) -> Tuple[int, str]: ...
 
 class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
-    __defaults__: Any
+    __defaults__: Dict[str, Union[float, int, str]]
     __tablename__: str
-    __table_args__: Any
-    revision_id: Any
-    hardware_id: Any
-    application_id: Any
-    area: Any
-    capacitance: Any
-    configuration_id: Any
-    construction_id: Any
-    contact_form_id: Any
-    contact_gauge: Any
-    contact_rating_id: Any
-    current_operating: Any
-    current_rated: Any
-    current_ratio: Any
-    environment_active_id: Any
-    environment_dormant_id: Any
-    family_id: Any
-    feature_size: Any
-    frequency_operating: Any
-    insert_id: Any
-    insulation_id: Any
-    manufacturing_id: Any
-    matching_id: Any
-    n_active_pins: Any
-    n_circuit_planes: Any
-    n_cycles: Any
-    n_elements: Any
-    n_hand_soldered: Any
-    n_wave_soldered: Any
-    operating_life: Any
-    overstress: Any
-    package_id: Any
-    power_operating: Any
-    power_rated: Any
-    power_ratio: Any
-    reason: Any
-    resistance: Any
-    specification_id: Any
-    technology_id: Any
-    temperature_active: Any
-    temperature_case: Any
-    temperature_dormant: Any
-    temperature_hot_spot: Any
-    temperature_junction: Any
-    temperature_knee: Any
-    temperature_rated_max: Any
-    temperature_rated_min: Any
-    temperature_rise: Any
-    theta_jc: Any
-    type_id: Any
-    voltage_ac_operating: Any
-    voltage_dc_operating: Any
-    voltage_esd: Any
-    voltage_rated: Any
-    voltage_ratio: Any
-    weight: Any
-    years_in_production: Any
-    def get_attributes(self) -> Dict[str, Any]: ...
+    __table_args__: Dict[str, bool]
+    revision_id: int
+    hardware_id: int
+    application_id: int
+    area: float
+    capacitance: float
+    configuration_id: int
+    construction_id: int
+    contact_form_id: int
+    contact_gauge: float
+    contact_rating_id: int
+    current_operating: float
+    current_rated: float
+    current_ratio: float
+    environment_active_id: int
+    environment_dormant_id: int
+    family_id: int
+    feature_size: float
+    frequency_operating: float
+    insert_id: int
+    insulation_id: int
+    manufacturing_id: int
+    matching_id: int
+    n_active_pins: int
+    n_circuit_planes: int
+    n_cycles: int
+    n_elements: int
+    n_hand_soldered: int
+    n_wave_soldered: int
+    operating_life: float
+    overstress: int
+    package_id: int
+    power_operating: float
+    power_rated: float
+    power_ratio: float
+    reason: str
+    resistance: float
+    specification_id: int
+    technology_id: int
+    temperature_active: float
+    temperature_case: float
+    temperature_dormant: float
+    temperature_hot_spot: float
+    temperature_junction: float
+    temperature_knee: float
+    temperature_rated_max: float
+    temperature_rated_min: float
+    temperature_rise: float
+    theta_jc: float
+    type_id: int
+    voltage_ac_operating: float
+    voltage_dc_operating: float
+    voltage_esd: float
+    voltage_rated: float
+    voltage_ratio: float
+    weight: float
+    years_in_production: int
+    def get_attributes(self) -> Dict[str, Union[float, int, str]]: ...
     def do_calculate_current_ratio(self) -> None: ...
     def do_calculate_power_ratio(self) -> None: ...
     def do_calculate_voltage_ratio(self) -> None: ...

--- a/src/ramstk/models/programdb/design_electric/table.pyi
+++ b/src/ramstk/models/programdb/design_electric/table.pyi
@@ -5,9 +5,7 @@ from typing import Any, Dict, List
 from ramstk.analyses import derating as derating
 from ramstk.analyses import stress as stress
 from ramstk.models import RAMSTKBaseTable as RAMSTKBaseTable
-from ramstk.models import (
-    RAMSTKDesignElectricRecord as RAMSTKDesignElectricRecord,
-)
+from ramstk.models import RAMSTKDesignElectricRecord as RAMSTKDesignElectricRecord
 
 class RAMSTKDesignElectricTable(RAMSTKBaseTable):
     _db_id_colname: str

--- a/src/ramstk/models/programdb/design_mechanic/table.pyi
+++ b/src/ramstk/models/programdb/design_mechanic/table.pyi
@@ -3,9 +3,7 @@ from typing import Any, Dict
 
 # RAMSTK Package Imports
 from ramstk.models import RAMSTKBaseTable as RAMSTKBaseTable
-from ramstk.models import (
-    RAMSTKDesignMechanicRecord as RAMSTKDesignMechanicRecord,
-)
+from ramstk.models import RAMSTKDesignMechanicRecord as RAMSTKDesignMechanicRecord
 
 class RAMSTKDesignMechanicTable(RAMSTKBaseTable):
     _db_id_colname: str

--- a/src/ramstk/models/programdb/hardware/view.py
+++ b/src/ramstk/models/programdb/hardware/view.py
@@ -266,14 +266,11 @@ class RAMSTKHardwareBoMView(RAMSTKBaseView):
             multiplier=self._hr_multiplier,
         )
 
-        pub.sendMessage(
-            "request_get_milhdbk217f_attributes",
-            node_id=node_id,
-        )
-        pub.sendMessage(
-            "request_get_reliability_attributes",
-            node_id=node_id,
-        )
+        for _table in ["design_electric", "milhdbk217f", "reliability"]:
+            pub.sendMessage(
+                f"request_get_{_table}_attributes",
+                node_id=node_id,
+            )
 
     def do_calculate_part_count(self, node_id: int) -> None:
         """Calculate the total part count of a hardware item.

--- a/src/ramstk/models/programdb/program_status/table.pyi
+++ b/src/ramstk/models/programdb/program_status/table.pyi
@@ -3,9 +3,7 @@ from typing import Any, Dict
 
 # RAMSTK Package Imports
 from ramstk.models import RAMSTKBaseTable as RAMSTKBaseTable
-from ramstk.models import (
-    RAMSTKProgramStatusRecord as RAMSTKProgramStatusRecord,
-)
+from ramstk.models import RAMSTKProgramStatusRecord as RAMSTKProgramStatusRecord
 
 class RAMSTKProgramStatusTable(RAMSTKBaseTable):
     _db_id_colname: str

--- a/src/ramstk/views/gtk3/allocation/view.pyi
+++ b/src/ramstk/views/gtk3/allocation/view.pyi
@@ -2,9 +2,7 @@
 from typing import Dict, List, Union
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/assistants/export.pyi
+++ b/src/ramstk/views/gtk3/assistants/export.pyi
@@ -2,15 +2,11 @@
 from typing import Any
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _
 from ramstk.views.gtk3.widgets import RAMSTKFileChooser as RAMSTKFileChooser
-from ramstk.views.gtk3.widgets import (
-    RAMSTKMessageDialog as RAMSTKMessageDialog,
-)
+from ramstk.views.gtk3.widgets import RAMSTKMessageDialog as RAMSTKMessageDialog
 
 class ExportProject(RAMSTKFileChooser):
     RAMSTK_USER_CONFIGURATION: Any = ...

--- a/src/ramstk/views/gtk3/assistants/imports.pyi
+++ b/src/ramstk/views/gtk3/assistants/imports.pyi
@@ -2,9 +2,7 @@
 from typing import Any, List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.views.gtk3 import GObject as GObject
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/assistants/project.pyi
+++ b/src/ramstk/views/gtk3/assistants/project.pyi
@@ -2,9 +2,7 @@
 from typing import Any
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.db.base import BaseDatabase as BaseDatabase
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _
@@ -12,9 +10,7 @@ from ramstk.views.gtk3.widgets.dialog import (
     RAMSTKDatabaseSelect as RAMSTKDatabaseSelect,
 )
 from ramstk.views.gtk3.widgets.dialog import RAMSTKDialog as RAMSTKDialog
-from ramstk.views.gtk3.widgets.dialog import (
-    RAMSTKMessageDialog as RAMSTKMessageDialog,
-)
+from ramstk.views.gtk3.widgets.dialog import RAMSTKMessageDialog as RAMSTKMessageDialog
 from ramstk.views.gtk3.widgets.label import RAMSTKLabel as RAMSTKLabel
 
 class CreateProject:

--- a/src/ramstk/views/gtk3/books/modulebook.pyi
+++ b/src/ramstk/views/gtk3/books/modulebook.pyi
@@ -5,9 +5,7 @@ from typing import Any
 from treelib import Tree as Tree
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3.function import FunctionModuleView as FunctionModuleView

--- a/src/ramstk/views/gtk3/books/workbook.pyi
+++ b/src/ramstk/views/gtk3/books/workbook.pyi
@@ -2,9 +2,7 @@
 from typing import Any
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3.function import FunctionWorkView as FunctionWorkView
 from ramstk.views.gtk3.revision import RevisionWorkView as RevisionWorkView

--- a/src/ramstk/views/gtk3/design_electric/components/capacitor.py
+++ b/src/ramstk/views/gtk3/design_electric/components/capacitor.py
@@ -460,7 +460,7 @@ class CapacitorDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Capacitor Design Inputs")
 
@@ -666,20 +666,14 @@ class CapacitorDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_load_styles(self, combo: RAMSTKComboBox) -> None:
         """Load the style RAMSTKComboBox() when the specification changes.

--- a/src/ramstk/views/gtk3/design_electric/components/connection.py
+++ b/src/ramstk/views/gtk3/design_electric/components/connection.py
@@ -208,7 +208,7 @@ class ConnectionDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Connection Design Inputs")
 
@@ -489,20 +489,14 @@ class ConnectionDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected connection.

--- a/src/ramstk/views/gtk3/design_electric/components/inductor.py
+++ b/src/ramstk/views/gtk3/design_electric/components/inductor.py
@@ -82,7 +82,7 @@ class InductorDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Inductive Device Design Inputs")
 
@@ -285,20 +285,14 @@ class InductorDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected inductor.

--- a/src/ramstk/views/gtk3/design_electric/components/integrated_circuit.py
+++ b/src/ramstk/views/gtk3/design_electric/components/integrated_circuit.py
@@ -99,7 +99,7 @@ class ICDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field = "hardware_id"
-    _select_msg = "selected_hardware"
+    _select_msg = "succeed_get_design_electric_attributes"
     _tag = "design_electric"
     _title = _("Integrated Circuit Design Inputs")
 
@@ -491,20 +491,14 @@ class ICDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected IC.

--- a/src/ramstk/views/gtk3/design_electric/components/meter.py
+++ b/src/ramstk/views/gtk3/design_electric/components/meter.py
@@ -56,7 +56,7 @@ class MeterDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Meter Design Inputs")
 
@@ -184,20 +184,14 @@ class MeterDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected meter.

--- a/src/ramstk/views/gtk3/design_electric/components/miscellaneous.py
+++ b/src/ramstk/views/gtk3/design_electric/components/miscellaneous.py
@@ -41,7 +41,7 @@ class MiscDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Miscellaneous Device Design Inputs")
 
@@ -223,20 +223,14 @@ class MiscDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity for the selected Miscellaneous item.

--- a/src/ramstk/views/gtk3/design_electric/components/relay.py
+++ b/src/ramstk/views/gtk3/design_electric/components/relay.py
@@ -173,7 +173,7 @@ class RelayDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Relay Design Inputs")
 
@@ -359,20 +359,14 @@ class RelayDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected relay.

--- a/src/ramstk/views/gtk3/design_electric/components/resistor.py
+++ b/src/ramstk/views/gtk3/design_electric/components/resistor.py
@@ -176,7 +176,7 @@ class ResistorDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Resistor Design Inputs")
 
@@ -349,20 +349,14 @@ class ResistorDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected resistor.

--- a/src/ramstk/views/gtk3/design_electric/components/semiconductor.py
+++ b/src/ramstk/views/gtk3/design_electric/components/semiconductor.py
@@ -217,7 +217,7 @@ class SemiconductorDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Semiconductor Design Inputs")
 
@@ -419,20 +419,14 @@ class SemiconductorDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected semiconductor.

--- a/src/ramstk/views/gtk3/design_electric/components/switch.py
+++ b/src/ramstk/views/gtk3/design_electric/components/switch.py
@@ -82,7 +82,7 @@ class SwitchDesignElectricInputPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_design_electric_attributes"
     _tag: str = "design_electric"
     _title: str = _("Switch Design Inputs")
 
@@ -257,20 +257,14 @@ class SwitchDesignElectricInputPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._quality_id = attributes["quality_id"]
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._quality_id = attributes["quality_id"]
 
-            self.cmbQuality.set_sensitive(True)
-            self.cmbQuality.do_update(
-                self._quality_id,
-                signal="changed",
-            )
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self.cmbQuality.set_sensitive(True)
+        self.cmbQuality.do_update(
+            self._quality_id,
+            signal="changed",
+        )
 
     def _do_set_sensitive(self, attributes: Dict[str, Any]) -> None:
         """Set widget sensitivity as needed for the selected switch.

--- a/src/ramstk/views/gtk3/design_electric/panel.py
+++ b/src/ramstk/views/gtk3/design_electric/panel.py
@@ -608,7 +608,7 @@ class DesignElectricStressResultPanel(RAMSTKFixedPanel):
         # Subscribe to PyPubSub messages.
         pub.subscribe(
             self._do_set_hardware_attributes,
-            "succeed_get_hardware_attributes",
+            "selected_hardware",
         )
 
     def _do_load_derating_curve(
@@ -697,6 +697,8 @@ class DesignElectricStressResultPanel(RAMSTKFixedPanel):
             self._do_load_derating_curve(attributes, stress="power")
         elif self._category_id in [6, 7]:
             self._do_load_derating_curve(attributes, stress="current")
+        else:
+            self.pltPlot.axis.cla()
 
     def _do_set_hardware_attributes(self, attributes: Dict[str, Any]) -> None:
         """Set the attributes when the reliability attributes are retrieved.
@@ -705,10 +707,9 @@ class DesignElectricStressResultPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._category_id = attributes["category_id"]
-            self._part_number = attributes["part_number"]
-            self._ref_des = attributes["ref_des"]
+        self._category_id = attributes["category_id"]
+        self._part_number = attributes["part_number"]
+        self._ref_des = attributes["ref_des"]
 
     def __make_ui(self) -> None:
         """Make the Hardware stress results page.

--- a/src/ramstk/views/gtk3/failure_definition/view.pyi
+++ b/src/ramstk/views/gtk3/failure_definition/view.pyi
@@ -2,9 +2,7 @@
 from typing import Dict, List, Union
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/function/view.pyi
+++ b/src/ramstk/views/gtk3/function/view.pyi
@@ -2,9 +2,7 @@
 from typing import Any, Dict, List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import _ as _
 from ramstk.views.gtk3.widgets import RAMSTKModuleView as RAMSTKModuleView

--- a/src/ramstk/views/gtk3/hardware/panel.py
+++ b/src/ramstk/views/gtk3/hardware/panel.py
@@ -736,11 +736,14 @@ class HardwareTreePanel(RAMSTKTreePanel):
                 "request_set_title",
                 title=_title,
             )
+
+            # We need the reliability attributes to be requested first so the
+            # component panels will get reliability attributes first.  Some of the
+            # reliability attributes control widget sensitivity on the component panels.
             for _table in [
-                "design_electric",
-                "hardware",
-                "milhdbk217f",
                 "reliability",
+                "design_electric",
+                "milhdbk217f",
             ]:
                 pub.sendMessage(
                     f"request_get_{_table}_attributes",
@@ -1175,16 +1178,14 @@ class HardwareGeneralDataPanel(RAMSTKFixedPanel):
         :param combo: the RAMSTKComboBox() that called this method.
         :return: None
         """
+        pub.sendMessage(
+            "request_set_hardware_attributes",
+            node_id=self._record_id,
+            package={
+                "subcategory_id": combo.get_active(),
+            },
+        )
         pub.sendMessage("changed_subcategory", subcategory_id=combo.get_active())
-        for _table in [
-            "design_electric",
-            "hardware",
-            "reliability",
-        ]:
-            pub.sendMessage(
-                f"request_get_{_table}_attributes",
-                node_id=self._record_id,
-            )
 
     def _request_load_subcategories(self, combo: RAMSTKComboBox) -> None:
         """Request to have the subcategory RAMSTKComboBox() loaded.

--- a/src/ramstk/views/gtk3/hazard_analysis/view.pyi
+++ b/src/ramstk/views/gtk3/hazard_analysis/view.pyi
@@ -2,9 +2,7 @@
 from typing import Any, Dict, List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/milhdbk217f/components/capacitor.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/capacitor.py
@@ -76,6 +76,8 @@ class CapacitorMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Capacitor MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/connection.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/connection.py
@@ -67,6 +67,8 @@ class ConnectionMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Connection MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/inductor.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/inductor.py
@@ -47,6 +47,8 @@ class InductorMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private list attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Inductive Device MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/integrated_circuit.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/integrated_circuit.py
@@ -73,6 +73,8 @@ class ICMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private class list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Integrated Circuit MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/meter.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/meter.py
@@ -41,6 +41,8 @@ class MeterMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private class list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Meter MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/miscellaneous.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/miscellaneous.py
@@ -47,6 +47,8 @@ class MiscellaneousMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private class list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Miscellaneous Component MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/relay.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/relay.py
@@ -43,6 +43,8 @@ class RelayMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Relay MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/resistor.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/resistor.py
@@ -71,6 +71,8 @@ class ResistorMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Resistor MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/semiconductor.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/semiconductor.py
@@ -78,6 +78,8 @@ class SemiconductorMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Semiconductor MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/components/switch.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/components/switch.py
@@ -53,6 +53,8 @@ class SwitchMilHdbk217FResultPanel(MilHdbk217FResultPanel):
     # Define private list class attributes.
 
     # Define private scalar class attributes.
+    _record_field: str = "hardware_id"
+    _tag: str = "milhdbk217f"
     _title: str = _("Switch MIL-HDBK-217F Results")
 
     # Define public dictionary class attributes.

--- a/src/ramstk/views/gtk3/milhdbk217f/panel.py
+++ b/src/ramstk/views/gtk3/milhdbk217f/panel.py
@@ -40,7 +40,7 @@ class MilHdbk217FResultPanel(RAMSTKFixedPanel):
 
     # Define private scalar class attributes.
     _record_field: str = "hardware_id"
-    _select_msg: str = "selected_hardware"
+    _select_msg: str = "succeed_get_milhdbk217f_attributes"
     _tag: str = "milhdbk217f"
 
     # Define public dictionary class attributes.
@@ -78,7 +78,7 @@ class MilHdbk217FResultPanel(RAMSTKFixedPanel):
         # Subscribe to PyPubSub messages.
         pub.subscribe(
             self._do_set_hardware_attributes,
-            "succeed_get_hardware_attributes",
+            "selected_hardware",
         )
         pub.subscribe(
             self._do_set_reliability_attributes,
@@ -119,9 +119,8 @@ class MilHdbk217FResultPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self.category_id = attributes["category_id"]
-            self.subcategory_id = attributes["subcategory_id"]
+        self.category_id = attributes["category_id"]
+        self.subcategory_id = attributes["subcategory_id"]
 
     def _do_set_reliability_attributes(self, attributes: Dict[str, Any]) -> None:
         """Set the attributes when the reliability attributes are retrieved.
@@ -130,14 +129,8 @@ class MilHdbk217FResultPanel(RAMSTKFixedPanel):
         :return: None
         :rtype: None
         """
-        if attributes["hardware_id"] == self._record_id:
-            self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
-            self._lambda_b = attributes["lambda_b"]
-
-            pub.sendMessage(
-                f"request_get_{self._tag}_attributes",
-                node_id=self._record_id,
-            )
+        self._hazard_rate_method_id = attributes["hazard_rate_method_id"]
+        self._lambda_b = attributes["lambda_b"]
 
     def __do_set_model_label(self) -> None:
         """Set the text displayed in the hazard rate model RAMSTKLabel().

--- a/src/ramstk/views/gtk3/pof/view.pyi
+++ b/src/ramstk/views/gtk3/pof/view.pyi
@@ -2,18 +2,12 @@
 from typing import Any, Dict, List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _
-from ramstk.views.gtk3.assistants import (
-    AddStressTestMethod as AddStressTestMethod,
-)
-from ramstk.views.gtk3.widgets import (
-    RAMSTKMessageDialog as RAMSTKMessageDialog,
-)
+from ramstk.views.gtk3.assistants import AddStressTestMethod as AddStressTestMethod
+from ramstk.views.gtk3.widgets import RAMSTKMessageDialog as RAMSTKMessageDialog
 from ramstk.views.gtk3.widgets import RAMSTKPanel as RAMSTKPanel
 from ramstk.views.gtk3.widgets import RAMSTKWorkView as RAMSTKWorkView
 

--- a/src/ramstk/views/gtk3/preferences/view.pyi
+++ b/src/ramstk/views/gtk3/preferences/view.pyi
@@ -2,9 +2,7 @@
 from typing import Callable, List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.utilities import integer_to_boolean as integer_to_boolean
 from ramstk.views.gtk3 import Gtk as Gtk

--- a/src/ramstk/views/gtk3/program_status/view.pyi
+++ b/src/ramstk/views/gtk3/program_status/view.pyi
@@ -2,9 +2,7 @@
 from typing import Any, Callable, Dict, List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/requirement/view.pyi
+++ b/src/ramstk/views/gtk3/requirement/view.pyi
@@ -2,17 +2,13 @@
 from typing import Any, Dict, List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _
 from ramstk.views.gtk3.widgets import RAMSTKEntry as RAMSTKEntry
 from ramstk.views.gtk3.widgets import RAMSTKFixedPanel as RAMSTKFixedPanel
-from ramstk.views.gtk3.widgets import (
-    RAMSTKMessageDialog as RAMSTKMessageDialog,
-)
+from ramstk.views.gtk3.widgets import RAMSTKMessageDialog as RAMSTKMessageDialog
 from ramstk.views.gtk3.widgets import RAMSTKModuleView as RAMSTKModuleView
 from ramstk.views.gtk3.widgets import RAMSTKWorkView as RAMSTKWorkView
 

--- a/src/ramstk/views/gtk3/revision/view.pyi
+++ b/src/ramstk/views/gtk3/revision/view.pyi
@@ -5,15 +5,11 @@ from typing import Any, Dict, List
 import treelib
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _
-from ramstk.views.gtk3.widgets import (
-    RAMSTKMessageDialog as RAMSTKMessageDialog,
-)
+from ramstk.views.gtk3.widgets import RAMSTKMessageDialog as RAMSTKMessageDialog
 from ramstk.views.gtk3.widgets import RAMSTKModuleView as RAMSTKModuleView
 from ramstk.views.gtk3.widgets import RAMSTKPanel as RAMSTKPanel
 from ramstk.views.gtk3.widgets import RAMSTKWorkView as RAMSTKWorkView

--- a/src/ramstk/views/gtk3/similar_item/view.pyi
+++ b/src/ramstk/views/gtk3/similar_item/view.pyi
@@ -2,9 +2,7 @@
 from typing import Dict, List, Union
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/stakeholder/view.pyi
+++ b/src/ramstk/views/gtk3/stakeholder/view.pyi
@@ -2,9 +2,7 @@
 from typing import Any, Dict
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/usage_profile/view.pyi
+++ b/src/ramstk/views/gtk3/usage_profile/view.pyi
@@ -2,9 +2,7 @@
 from typing import List
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _

--- a/src/ramstk/views/gtk3/validation/view.pyi
+++ b/src/ramstk/views/gtk3/validation/view.pyi
@@ -2,15 +2,11 @@
 from typing import Any, Dict
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.logger import RAMSTKLogManager as RAMSTKLogManager
 from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import _ as _
-from ramstk.views.gtk3.widgets import (
-    RAMSTKMessageDialog as RAMSTKMessageDialog,
-)
+from ramstk.views.gtk3.widgets import RAMSTKMessageDialog as RAMSTKMessageDialog
 from ramstk.views.gtk3.widgets import RAMSTKModuleView as RAMSTKModuleView
 from ramstk.views.gtk3.widgets import RAMSTKPanel as RAMSTKPanel
 from ramstk.views.gtk3.widgets import RAMSTKWorkView as RAMSTKWorkView

--- a/src/ramstk/views/gtk3/widgets/__init__.py
+++ b/src/ramstk/views/gtk3/widgets/__init__.py
@@ -29,12 +29,7 @@ from .dialog import (
 from .entry import RAMSTKEntry, RAMSTKTextView
 from .frame import RAMSTKFrame
 from .label import RAMSTKLabel, do_make_label_group
-from .panel import (
-    RAMSTKFixedPanel,
-    RAMSTKPanel,
-    RAMSTKPlotPanel,
-    RAMSTKTreePanel,
-)
+from .panel import RAMSTKFixedPanel, RAMSTKPanel, RAMSTKPlotPanel, RAMSTKTreePanel
 from .plot import RAMSTKPlot
 from .scrolledwindow import RAMSTKScrolledWindow
 from .treeview import RAMSTKTreeView

--- a/src/ramstk/views/gtk3/widgets/basebook.pyi
+++ b/src/ramstk/views/gtk3/widgets/basebook.pyi
@@ -2,9 +2,7 @@
 from typing import Any
 
 # RAMSTK Package Imports
-from ramstk.configuration import (
-    RAMSTKUserConfiguration as RAMSTKUserConfiguration,
-)
+from ramstk.configuration import RAMSTKUserConfiguration as RAMSTKUserConfiguration
 from ramstk.views.gtk3 import GObject as GObject
 from ramstk.views.gtk3 import Gtk as Gtk
 

--- a/src/ramstk/views/gtk3/widgets/dialog.pyi
+++ b/src/ramstk/views/gtk3/widgets/dialog.pyi
@@ -9,14 +9,10 @@ from ramstk.views.gtk3 import Gtk as Gtk
 from ramstk.views.gtk3 import Pango as Pango
 from ramstk.views.gtk3 import _ as _
 from ramstk.views.gtk3.widgets.button import RAMSTKButton as RAMSTKButton
-from ramstk.views.gtk3.widgets.button import (
-    RAMSTKCheckButton as RAMSTKCheckButton,
-)
+from ramstk.views.gtk3.widgets.button import RAMSTKCheckButton as RAMSTKCheckButton
 from ramstk.views.gtk3.widgets.combo import RAMSTKComboBox as RAMSTKComboBox
 from ramstk.views.gtk3.widgets.entry import RAMSTKEntry as RAMSTKEntry
-from ramstk.views.gtk3.widgets.label import (
-    do_make_label_group as do_make_label_group,
-)
+from ramstk.views.gtk3.widgets.label import do_make_label_group as do_make_label_group
 
 class RAMSTKDialog(Gtk.Dialog):
     def __init__(self, dlgtitle: str, **kwargs: Any) -> None: ...

--- a/src/ramstk/views/gtk3/widgets/panel.py
+++ b/src/ramstk/views/gtk3/widgets/panel.py
@@ -216,13 +216,6 @@ class RAMSTKFixedPanel(RAMSTKPanel):
                 signal=_value[2],
             )
 
-            if _value[4]:
-                pub.sendMessage(
-                    _value[4],
-                    node_id=self._record_id,
-                    package={_key: _new_text},
-                )
-
         pub.sendMessage("request_set_cursor_active")
 
     def do_make_panel(self, **kwargs: Dict[str, Any]) -> None:

--- a/tests/models/programdb/design_electric/design_electric_unit_test.py
+++ b/tests/models/programdb/design_electric/design_electric_unit_test.py
@@ -433,10 +433,10 @@ class TestAnalysisMethods:
         assert _design_electric.overstress
         assert (
             _design_electric.reason
-            == "Operating current is greater than limit in a harsh "
-            "environment.\nOperating current is greater than limit in a mild "
-            "environment.\nOperating power is greater than limit in a harsh "
-            "environment.\n"
+            == "Operating current ratio is greater than the harsh environment limit "
+            "of 1.0.\nOperating current ratio is greater than the mild environment "
+            "limit of 1.0.\nOperating power ratio is greater than the harsh "
+            "environment limit of 0.5.\n"
         )
 
         _design_electric.do_derating_analysis(
@@ -452,9 +452,10 @@ class TestAnalysisMethods:
         assert _design_electric.overstress
         assert (
             _design_electric.reason
-            == "Operating current is greater than limit in a harsh environment.\n"
-            "Operating current is greater than limit in a mild environment.\n"
-            "Operating voltage is greater than limit in a harsh environment.\n"
+            == "Operating current ratio is greater than the harsh environment limit "
+            "of 0.6.\nOperating current ratio is greater than the mild environment "
+            "limit of 0.9.\nOperating voltage ratio is greater than the harsh "
+            "environment limit of 0.5.\n"
         )
 
     @pytest.mark.unit
@@ -486,13 +487,13 @@ class TestAnalysisMethods:
         assert _design_electric.overstress
         assert (
             _design_electric.reason
-            == "Operating current is less than limit in a harsh "
-            "environment.\nOperating current is less than limit in a mild "
-            "environment.\nOperating power is less than limit in a harsh "
-            "environment.\nOperating power is less than limit in a mild "
-            "environment.\nOperating voltage is less than limit in a harsh "
-            "environment.\nOperating voltage is less than limit in a mild "
-            "environment.\n"
+            == "Operating current ratio is less than the harsh environment limit of "
+            "0.0.\nOperating current ratio is less than the mild environment limit "
+            "of 0.0.\nOperating power ratio is less than the harsh environment "
+            "limit of 0.0.\nOperating power ratio is less than the mild "
+            "environment limit of 0.0.\nOperating voltage ratio is less than the "
+            "harsh environment limit of 0.0.\nOperating voltage ratio is less than "
+            "the mild environment limit of 0.0.\n"
         )
 
     @pytest.mark.unit


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To make the component widgets load with saved values when component is selected in Hardware module tree.

## Describe how this was implemented.
Updated component panels to respond to "succeed_get_design_electric_attributes" message instead of "selected_hardware" message.  The "selected_hardware" message does not contain the necessary attributes in the payload to update the component widgets.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #961


## Pull Request Checklist

- Code Style
  - [X] Code is following code style guidelines.

- Static Checks
  - [X] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [X] At least one test for all newly created functions/methods?

- Chores
  - [ ] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
