### PR TITLE
fix: prevent adding sibling to top level hardware item

### DIFF
--- a/.github/workflows/do_release.yml
+++ b/.github/workflows/do_release.yml
@@ -5,15 +5,15 @@
 #     - Get release version from VERSION.
 #     - IF 'Release' label:
 #         - Cut release.
+#     - IF release is cut:
+#         - Build artifacts.
+#         - Upload to Test PyPi if build succeeds.
+#         - Test install from Test PyPi.
+#         - Upload to PyPi if test install succeeds.
+#         - Add wheel to GitHub release.
+#         - Build pdf documentation.
+#         - Add pdf documentation to GitHub release.
 # - Job 2 (needs job 1):
-#     - Build artifacts.
-#     - Upload to Test PyPi.
-#     - Test install from Test PyPi.
-#     - Upload to PyPi.
-#     - Add wheel to GitHub release.
-#     - Build pdf documentation.
-#     - Add pdf documentation to GitHub release.
-# - Job 3 (needs job 1):
 #     - Close old milestone.
 #     - Create new minor version milestone.
 #     - Create new major version milestone.
@@ -43,11 +43,13 @@ jobs:
       - name: Get release version
         id: relversion
         if: contains(steps.prlabels.outputs.labels, ' Release ')
-        run: echo "::set-output name=rel_version::$(echo $(cat VERSION))"
+        run: |
+          echo "::set-output name=rel_version::$(echo $(cat VERSION))"
+          echo echo "cut_release=1" >> $GITHUB_ENV
 
-      - name: Cut release
+      - name: Cut the release
         id: cutrelease
-        if: contains(steps.prlabels.outputs.labels, ' Release ')
+        if: ${{ env.cut_release == 1 }}
         uses: release-drafter/release-drafter@master
         with:
           name: "v${{ steps.relversion.outputs.rel_version }}"
@@ -63,20 +65,11 @@ jobs:
           echo ${{ steps.cutrelease.outputs.id }}
           echo ${{ steps.cutrelease.outputs.name }}
           echo ${{ steps.cutrelease.outputs.tag_name }}
-          echo ${{ steps.cutrelease.outputs.body }}
           echo ${{ steps.cutrelease.outputs.html_url }}
           echo ${{ steps.cutrelease.outputs.upload_url }}
 
-  build-deploy:
-    name: Build and Deploy RAMSTK
-    needs: cut-release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
       - name: Build release
+        if: startsWith(steps.cutrelease.outputs.tag_name, 'v')
         id: build
         run: |
           pip install -U pip poetry twine
@@ -106,6 +99,13 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+      - name: Upload wheel to Release
+        id: upload-wheel
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.cutrelease.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./dist/*.whl
+
   create_new_milestone:
     name: Create New Milestone
     needs: cut-release
@@ -117,8 +117,7 @@ jobs:
 
       - name: Get new version
         id: newversion
-        run: |
-          echo "::set-output name=version::$(echo $(cat VERSION))"
+        run: echo "::set-output name=version::$(echo $(cat VERSION))"
 
       - name: Get next semantic version
         id: nextversion

--- a/.github/workflows/on-issue-assign.yml
+++ b/.github/workflows/on-issue-assign.yml
@@ -1,3 +1,13 @@
+# This workflow runs when an issue is assigned.
+#
+# - Job 1:
+#     - Checks for dobranch label
+#     - IF dobranch label exists:
+#         - Creates a new branch in the repository using the rules in
+#           issue-branch.yml
+# - Job 2:
+#     - Removes status: backlog label and adds status: inprogress label to
+#       issue.
 name: Issue Assigned Workflow
 on:
   issues:

--- a/.github/workflows/on-pr-assign.yml
+++ b/.github/workflows/on-pr-assign.yml
@@ -1,0 +1,19 @@
+# This workflow runs when a pull request is assigned.
+#
+# - Job 1:
+#     - Adds status: inprogress label to PR
+name: Pull Request Assign Workflow
+
+on:
+  pull_request:
+    types:
+      - assigned
+
+jobs:
+  label_pr_in_progress:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add in progress label
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "status: inprogress"

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -55,10 +55,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Execute Sphinx
-        uses: ammaraskar/sphinx-action@master
-        with:
-          docs-folder: "docs/"
+      - name: Build html documentation
+        run: |
+          cd docs
+          make html
+          cd ..
+
+      - name: Build pdf documentation
+        run: |
+          cd docs
+          make latexpdf LATEXMKOPTS="-silent -f"
+          cd ..
 
       - name: Import GPG key
         id: import_gpg
@@ -69,7 +76,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Commit RAMSTK Documentation Changes
+      - name: Commit RAMSTK documentation changes
         run: |
           git clone https://github.com/ReliaQualAssociates/ramstk.git --branch gh-pages --single-branch gh-pages
           cp -fvr docs/_build/html/* gh-pages/
@@ -79,7 +86,7 @@ jobs:
           git add .
           git commit -a -m "Update documentation" && echo "do_push=1" >> $GITHUB_ENV || echo "Nothing to commit, working tree clean."
 
-      - name: Push RAMSTK Documentation Changes
+      - name: Push RAMSTK documentation changes
         if: env.do_push == 1
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -14,8 +14,8 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  create-release:
-    name: Create Release
+  request-release:
+    name: Request Release PR
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -66,7 +66,7 @@ jobs:
             ./pyproject.toml
             ./docs/conf.py
 
-      - name: Cut release pull request
+      - name: Request release pull request
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: "release: ${{ steps.newversion.outputs.new_version }}"

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ help:
 	@echo "	install 				install RAMSTK and all data files in the current (virtualenv) environment."
 	@echo "	install.dev				install only the RAMSTK code in the current (virtualenv) environment."
 	@echo "	uninstall 				remove RAMSTK from the current (virtualenv) environment."
-	@echo "	dist					build source and wheel packages."
+	@echo "	build					build source and wheel packages."
 	@echo "	release					package and upload a release to PyPi."
 	@echo ""
 	@echo "The following variables are recognized by this Makefile.  They can be changed in this file or passed on the command line."

--- a/src/ramstk/views/gtk3/hardware/panel.py
+++ b/src/ramstk/views/gtk3/hardware/panel.py
@@ -617,6 +617,7 @@ class HardwareTreePanel(RAMSTKTreePanel):
         self.lst_manufacturers: List[str] = [""]
 
         # Initialize public scalar class attributes.
+        self.part: int = 0
 
         super().do_set_properties()
         super().do_make_panel()
@@ -710,6 +711,7 @@ class HardwareTreePanel(RAMSTKTreePanel):
         if _attributes:
             self._record_id = _attributes["hardware_id"]
             self._parent_id = _attributes["parent_id"]
+            self.part = _attributes["part"]
 
             _attributes["category_id"] = self.lst_categories.index(
                 _attributes["category_id"]

--- a/src/ramstk/views/gtk3/hardware/view.py
+++ b/src/ramstk/views/gtk3/hardware/view.py
@@ -480,9 +480,10 @@ class HardwareGeneralDataView(RAMSTKWorkView):
         super().__init__(configuration, logger)
 
         # Initialize private dictionary attributes.
-        self._dic_icons["comp_ref_des"] = (
-            self.RAMSTK_USER_CONFIGURATION.RAMSTK_ICON_DIR + "/32x32/rollup.png"
-        )
+        self._dic_icons[
+            "comp_ref_des"
+        ] = f'{self.RAMSTK_USER_CONFIGURATION.RAMSTK_ICON_DIR}/32x32/rollup.png'
+
 
         # Initialize private list attributes.
 

--- a/src/ramstk/views/gtk3/hardware/view.py
+++ b/src/ramstk/views/gtk3/hardware/view.py
@@ -482,8 +482,7 @@ class HardwareGeneralDataView(RAMSTKWorkView):
         # Initialize private dictionary attributes.
         self._dic_icons[
             "comp_ref_des"
-        ] = f'{self.RAMSTK_USER_CONFIGURATION.RAMSTK_ICON_DIR}/32x32/rollup.png'
-
+        ] = f"{self.RAMSTK_USER_CONFIGURATION.RAMSTK_ICON_DIR}/32x32/rollup.png"
 
         # Initialize private list attributes.
 

--- a/src/ramstk/views/gtk3/hardware/view.py
+++ b/src/ramstk/views/gtk3/hardware/view.py
@@ -212,21 +212,39 @@ class HardwareModuleView(RAMSTKModuleView):
             "record_id": self.dic_pkeys["record_id"],
         }
 
+        if self._pnlPanel.part == 1:
+            _message = _(
+                "You cannot add a sibling item to a part.  First set the "
+                "component category to nothing to convert this part to an "
+                "assembly and then try again."
+            )
+            _parent = (
+                self.get_parent().get_parent().get_parent().get_parent().get_parent()
+            )
+            _dialog = super().do_raise_dialog(parent=_parent)
+            _dialog.do_set_message(message=_message)
+            _dialog.do_set_message_type(message_type="information")
+            _dialog.do_run()
+            _dialog.do_destroy()
+            return
+
         super().do_set_cursor_busy()
         pub.sendMessage(
             "request_insert_hardware",
             attributes=copy(_attributes),
         )
+
+        # See Issue #985.
         _attributes.pop("part")
-        for _message in [
-            "request_insert_design_electric",
-            "request_insert_design_mechanic",
-            "request_insert_milhdbk217f",
-            "request_insert_nswc",
-            "request_insert_reliability",
+        for _table in [
+            "design_electric",
+            "design_mechanic",
+            "milhdbk217f",
+            "nswc",
+            "reliability",
         ]:
             pub.sendMessage(
-                _message,
+                f"request_insert_{_table}",
                 attributes=copy(_attributes),
             )
 
@@ -244,21 +262,39 @@ class HardwareModuleView(RAMSTKModuleView):
             "record_id": self.dic_pkeys["record_id"],
         }
 
+        if self._pnlPanel.part == 1:
+            _message = _(
+                "You cannot add a part to another part.  First set the "
+                "component category to nothing to convert this part to an "
+                "assembly and then try again."
+            )
+            _parent = (
+                self.get_parent().get_parent().get_parent().get_parent().get_parent()
+            )
+            _dialog = super().do_raise_dialog(parent=_parent)
+            _dialog.do_set_message(message=_message)
+            _dialog.do_set_message_type(message_type="information")
+            _dialog.do_run()
+            _dialog.do_destroy()
+            return
+
         super().do_set_cursor_busy()
         pub.sendMessage(
             "request_insert_hardware",
             attributes=copy(_attributes),
         )
+
+        # See Issue #985.
         _attributes.pop("part")
-        for _message in [
-            "request_insert_design_electric",
-            "request_insert_design_mechanic",
-            "request_insert_milhdbk217f",
-            "request_insert_nswc",
-            "request_insert_reliability",
+        for _table in [
+            "design_electric",
+            "design_mechanic",
+            "milhdbk217f",
+            "nswc",
+            "reliability",
         ]:
             pub.sendMessage(
-                _message,
+                f"request_insert_{_table}",
                 attributes=copy(_attributes),
             )
 
@@ -276,21 +312,41 @@ class HardwareModuleView(RAMSTKModuleView):
             "record_id": self.dic_pkeys["record_id"],
         }
 
+        if self.dic_pkeys["parent_id"] == 0:
+            _message = _(
+                "You cannot have two top-level items for a single revision.  "
+                "If you want to add a new system, you need create a new RAMSTK "
+                "Program database.  If you want to add a new configuration, "
+                "variant, etc. of the system in this Program database, "
+                "add a new Revision."
+            )
+            _parent = (
+                self.get_parent().get_parent().get_parent().get_parent().get_parent()
+            )
+            _dialog = super().do_raise_dialog(parent=_parent)
+            _dialog.do_set_message(message=_message)
+            _dialog.do_set_message_type(message_type="information")
+            _dialog.do_run()
+            _dialog.do_destroy()
+            return
+
         super().do_set_cursor_busy()
         pub.sendMessage(
             "request_insert_hardware",
             attributes=copy(_attributes),
         )
+
+        # See Issue #985.
         _attributes.pop("part")
-        for _message in [
-            "request_insert_design_electric",
-            "request_insert_design_mechanic",
-            "request_insert_milhdbk217f",
-            "request_insert_nswc",
-            "request_insert_reliability",
+        for _table in [
+            "design_electric",
+            "design_mechanic",
+            "milhdbk217f",
+            "nswc",
+            "reliability",
         ]:
             pub.sendMessage(
-                _message,
+                f"request_insert_{_table}",
                 attributes=copy(_attributes),
             )
 

--- a/src/ramstk/views/gtk3/widgets/dialog.py
+++ b/src/ramstk/views/gtk3/widgets/dialog.py
@@ -474,33 +474,18 @@ class RAMSTKMessageDialog(Gtk.MessageDialog):
         }
 
         _prompt = self.get_property("text")
-        # Set the prompt to bold text with a hyperlink to the RAMSTK bugs
-        # e-mail address.
-        _hyper = (
-            "<a href='mailto:bugs@reliaqual.com?subject=RAMSTK BUG "
-            "REPORT: <ADD SHORT PROBLEM DESCRIPTION>&amp;"
-            "body=RAMSTK MODULE:%0d%0a%0d%0a"
-            "RAMSTK VERSION:%20%0d%0a%0d%0a"
-            "YOUR HARDWARE:%20%0d%0a%0d%0a"
-            "YOUR OS:%20%0d%0a%0d%0a"
-            "DETAILED PROBLEM DESCRIPTION:%20%0d%0a'>"
-        )
-        _prompt = (
-            "<b>"
-            + _prompt
-            + _(
-                "  Check the error log for additional information "
-                "(if any).  Please e-mail <span foreground='blue' "
-                "underline='single'>",
+
+        if message_type == "error":
+            # Set the prompt to bold text with a hyperlink to the RAMSTK bugs
+            # e-mail address.
+            _prompt = (
+                f"<b>{_prompt}</b>\n\nCheck the error log for additional information "
+                f"(if any).  Please <span foreground='blue' underline='single'><a "
+                f"href='https://github.com/ReliaQualAssociates/ramstk/issues'>raise "
+                f"an issue</a></span> with a detailed description of the problem and "
+                f"the error log attached if the problem persists."
             )
-            + _hyper
-            + _(
-                "bugs@reliaqual.com</a></span> with a detailed "
-                "description of the problem, the workflow you are "
-                "using and the error log attached if the problem "
-                "persists.</b>",
-            )
-        )
+
         self.set_markup(_prompt)
         self.set_property("message-type", _dic_message_type[message_type])
 


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To prevent user from adding a sibling to the top level hardware item (system).

## Describe how this was implemented.
Added check for parent ID.  Parent ID = 0 indicates top level hardware item.  Now raises information dialog and returns.  Also added similar check to methods to insert sibling and part to check that user is not trying to add a sibling or part to a part.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #959


## Pull Request Checklist

- Code Style
  - [X] Code is following code style guidelines.

- Static Checks
  - [X] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [X] At least one test for all newly created functions/methods?

- Chores
  - [x] Problem areas outside the scope of this PR have an # ISSUE: comment
    decorating the code block.  These # ISSUE: comments are automatically
    converted to issues on successful merge.  Alternatively, you can manually
    raise an issue for each problem area you identify.
