### PR TITLE
fix: validation tasks now load on insert

### DIFF
--- a/src/ramstk/models/programdb/validation/record.py
+++ b/src/ramstk/models/programdb/validation/record.py
@@ -8,7 +8,7 @@
 """Validation Record Model."""
 
 # Standard Library Imports
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 # Third Party Imports
 # noinspection PyPackageRequirements
@@ -152,16 +152,6 @@ class RAMSTKValidationRecord(RAMSTK_BASE, RAMSTKBaseRecord):
                   time_mean, time_minimum, time_ul, time_variance} pairs.
         :rtype: dict
         """
-        try:
-            self.date_end = datetime.strftime(self.date_end, "%Y-%m-%d")
-        except TypeError:
-            pass
-
-        try:
-            self.date_start = datetime.strftime(self.date_start, "%Y-%m-%d")
-        except TypeError:
-            pass
-
         return {
             "revision_id": self.revision_id,
             "validation_id": self.validation_id,

--- a/src/ramstk/views/gtk3/validation/panel.py
+++ b/src/ramstk/views/gtk3/validation/panel.py
@@ -687,6 +687,7 @@ class ValidationTreePanel(RAMSTKTreePanel):
         :rtype: :class:`Gtk.TreeIter`
         """
         _new_row = None
+        _date_format = "%Y-%m-%d"
 
         # pylint: disable=unused-variable
         _entity = node.data["validation"]
@@ -706,8 +707,8 @@ class ValidationTreePanel(RAMSTKTreePanel):
             _entity.cost_minimum,
             _entity.cost_ul,
             _entity.cost_variance,
-            _entity.date_end,
-            _entity.date_start,
+            _entity.date_end.strftime(_date_format),
+            _entity.date_start.strftime(_date_format),
             _entity.description,
             self._lst_measurement_units[_entity.measurement_unit],
             _entity.name,


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To fix the problem with the Validation and Verification tree view blanking when a new validation/verification task is added.

## Describe how this was implemented.
Removed code converting end_date and start_date attributes to string in validation.record.get_attributes().  Make conversion in panel.__do_load_validation() method instead.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #963 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Issue(s) have been raised for problem areas outside the scope of
    this PR.  These problem areas have been decorated with an ISSUE: # comment.
