### PR TITLE
refactor: remove pubsub "fail_XX_YY" messages

### DIFF
--- a/src/ramstk/logger.py
+++ b/src/ramstk/logger.py
@@ -42,86 +42,11 @@ class RAMSTKLogManager:
         self.log_file = log_file
 
         # Subscribe to PyPubSub messages.
-        pub.subscribe(self._do_log_fail_message, "fail_connect_program_database")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_environment")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_failure_definition")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_fmea")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_function")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_hazard")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_mission")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_mission_phase")
-        pub.subscribe(self._do_log_fail_message, "fail_delete_revision")
-        pub.subscribe(self._do_log_fail_message, "fail_import_module")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_action")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_cause")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_control")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_environment")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_failure_definition")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_mechanism")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_mission")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_mission_phase")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_mode")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_function")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_hazard")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_hardware")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_validation")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_stakeholder")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_revision")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_requirement")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_opload")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_opstress")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_record")
-        pub.subscribe(self._do_log_fail_message, "fail_insert_test_method")
-        pub.subscribe(self._do_log_fail_message, "fail_update_fmea")
-        pub.subscribe(self._do_log_fail_message, "fail_update_function")
-        pub.subscribe(self._do_log_fail_message, "fail_update_hardware")
-        pub.subscribe(self._do_log_fail_message, "fail_update_record")
-        pub.subscribe(self._do_log_fail_message, "fail_update_requirement")
-        pub.subscribe(self._do_log_fail_message, "fail_update_revision")
-
         pub.subscribe(self.do_log_debug, "do_log_debug_msg")
         pub.subscribe(self.do_log_info, "do_log_info_msg")
         pub.subscribe(self.do_log_warning, "do_log_warning_msg")
         pub.subscribe(self.do_log_error, "do_log_error_msg")
         pub.subscribe(self.do_log_critical, "do_log_critical_msg")
-
-        # Create a logger for the pypubsub fail_* messages.
-        self.do_create_logger(__name__, "WARN")
-
-    def _do_log_fail_message(self, error_message: str) -> None:
-        """Log PyPubSub broadcast fail messages.
-
-        :param error_message: the error message that was part of the
-            broadcast package.
-        :return: None
-        :rtype: None
-        """
-        self.loggers[__name__].warning(error_message)
-
-    @staticmethod
-    def _get_console_handler(log_level: str) -> logging.Handler:
-        """Create the log handler for console output.
-
-        :return: _c_handler
-        :rtype: :class:`logging.Handler`
-        """
-        _c_handler = logging.StreamHandler(sys.stdout)
-        _c_handler.setLevel(log_level)
-        _c_handler.setFormatter(LOGFORMAT)
-
-        return _c_handler
-
-    def _get_file_handler(self, log_level: str) -> logging.Handler:
-        """Create the log handler for file output.
-
-        :return: _f_handler
-        :rtype: :class:`logging.Handler`
-        """
-        _f_handler = logging.FileHandler(self.log_file)
-        _f_handler.setLevel(log_level)
-        _f_handler.setFormatter(LOGFORMAT)
-
-        return _f_handler
 
     def do_create_logger(
         self, logger_name: str, log_level: str, to_tty: bool = False
@@ -154,17 +79,6 @@ class RAMSTKLogManager:
         """
         if self.loggers[logger_name].isEnabledFor(logging.DEBUG):
             self.loggers[logger_name].debug(message)
-
-    def do_log_exception(self, logger_name: str, exception: object) -> None:
-        """Log EXCEPTIONS.
-
-        :param logger_name: the name of the logger used in the application.
-        :param exception: the exception to log.
-        :return: None
-        :rtype: None
-        """
-        if self.loggers[logger_name].isEnabledFor(logging.WARNING):
-            self.loggers[logger_name].exception(exception)
 
     def do_log_info(self, logger_name: str, message: str) -> None:
         """Log INFO level messages.
@@ -208,3 +122,28 @@ class RAMSTKLogManager:
         :rtype: None
         """
         self.loggers[logger_name].critical(message)
+
+    @staticmethod
+    def _get_console_handler(log_level: str) -> logging.Handler:
+        """Create the log handler for console output.
+
+        :return: _c_handler
+        :rtype: :class:`logging.Handler`
+        """
+        _c_handler = logging.StreamHandler(sys.stdout)
+        _c_handler.setLevel(log_level)
+        _c_handler.setFormatter(LOGFORMAT)
+
+        return _c_handler
+
+    def _get_file_handler(self, log_level: str) -> logging.Handler:
+        """Create the log handler for file output.
+
+        :return: _f_handler
+        :rtype: :class:`logging.Handler`
+        """
+        _f_handler = logging.FileHandler(self.log_file)
+        _f_handler.setLevel(log_level)
+        _f_handler.setFormatter(LOGFORMAT)
+
+        return _f_handler

--- a/src/ramstk/models/basemodel.py
+++ b/src/ramstk/models/basemodel.py
@@ -19,6 +19,7 @@ from treelib.exceptions import NodeIDAbsentError
 from ramstk.db.base import BaseDatabase
 from ramstk.exceptions import DataAccessError
 from ramstk.utilities import none_to_default
+from ramstk.views.gtk3 import _
 
 
 def do_clear_tree(tree: treelib.Tree) -> treelib.Tree:
@@ -181,18 +182,13 @@ class RAMSTKBaseTable:
                 tree=self.tree,
             )
         except (AttributeError, DataAccessError, NodeIDAbsentError):
-            _error_msg: str = (
-                f"Attempted to delete non-existent "
-                f"{self._tag.replace('_', ' ').title()} ID {node_id}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                f"fail_delete_{self._tag}",
-                error_message=_error_msg,
+                message=_(
+                    f"Attempted to delete non-existent "
+                    f"{self._tag.replace('_', ' ').title()} ID {node_id}."
+                ),
             )
 
     def do_get_attributes(self, node_id: int, table: str = "") -> None:
@@ -210,19 +206,12 @@ class RAMSTKBaseTable:
                 attributes=self.do_select(node_id).get_attributes(),
             )
         except AttributeError:
-            _method_name = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = (
-                f"{_method_name}: No attributes found for record ID {node_id} in "
-                f"{self._tag} table."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                f"fail_get_{table}_attributes",
-                error_message=_error_msg,
+                message=_(
+                    f"No attributes found for record ID {node_id} in {self._tag} table."
+                ),
             )
 
     def do_get_tree(self) -> None:
@@ -276,20 +265,12 @@ class RAMSTKBaseTable:
                 logger_name="DEBUG",
                 message=_error_msg,
             )
-            pub.sendMessage(
-                f"fail_insert_{self._tag}",
-                error_message=_error.msg,
-            )
         except NodeIDAbsentError as _error:
             _error_msg = f"{_method_name}: {_error}"
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
                 message=str(_error),
-            )
-            pub.sendMessage(
-                f"fail_insert_{self._tag}",
-                error_message=_error_msg,
             )
 
     def do_select(self, node_id: Any) -> Any:
@@ -309,15 +290,12 @@ class RAMSTKBaseTable:
             treelib.tree.NodeIDAbsentError,
             TypeError,
         ):
-            _method_name = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg: str = (
-                f"{_method_name}: No data package for node ID {node_id} in module "
-                f"{self._tag}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"No data package for node ID {node_id} in module {self._tag}."
+                ),
             )
             _entity = None
 
@@ -393,15 +371,12 @@ class RAMSTKBaseTable:
         try:
             _attributes = self.do_select(node_id).get_attributes()
         except (AttributeError, KeyError):
-            _method_name = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg: str = (
-                f"{_method_name}: No data package for node ID {node_id} in module "
-                f"{self._tag}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"No data package for node ID {node_id} in module {self._tag}."
+                ),
             )
             _attributes = {}
 
@@ -452,9 +427,6 @@ class RAMSTKBaseTable:
         :return: None
         :rtype: None
         """
-        _fail_topic = f"fail_update_{self._tag}"
-        _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-
         try:
             self.dao.do_update(self.tree.get_node(node_id).data[self._tag])
             pub.sendMessage(
@@ -462,52 +434,35 @@ class RAMSTKBaseTable:
                 tree=self.tree,
             )
         except AttributeError:
-            _error_msg: str = (
-                f"{_method_name}: Attempted to save non-existent "
-                f"{self._tag.replace('_', ' ')} with {self._tag.replace('_', ' ')} "
-                f"ID {node_id}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                _fail_topic,
-                error_message=_error_msg,
+                message=_(
+                    f"Attempted to save non-existent {self._tag.replace('_', ' ')} "
+                    f"with {self._tag.replace('_', ' ')} ID {node_id}."
+                ),
             )
         except KeyError:
-            _error_msg = (
-                f"{_method_name}: No data package found for "
-                f"{self._tag.replace('_', ' ')} ID {node_id}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                _fail_topic,
-                error_message=_error_msg,
+                message=_(
+                    f"No data package found for {self._tag.replace('_', ' ')} ID "
+                    f"{node_id}."
+                ),
             )
         except (DataAccessError, TypeError):
             if node_id != 0:
-                _error_msg = (
-                    f"{_method_name}: The value for one or more attributes for "
+                _error_msg = _(
+                    f"The value for one or more attributes for "
                     f"{self._tag.replace('_', ' ')} ID {node_id} was the wrong type."
                 )
             else:
-                _error_msg = (
-                    f"{_method_name}: Attempting to update the root node {node_id}."
-                )
+                _error_msg = _(f"Attempting to update the root node {node_id}.")
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
                 message=_error_msg,
-            )
-            pub.sendMessage(
-                _fail_topic,
-                error_message=_error_msg,
             )
 
         pub.sendMessage("request_set_cursor_active")

--- a/src/ramstk/models/programdb/design_electric/record.py
+++ b/src/ramstk/models/programdb/design_electric/record.py
@@ -18,6 +18,7 @@ from sqlalchemy import Column, Float, ForeignKey, Integer, String
 from ramstk.analyses import derating, stress
 from ramstk.db import RAMSTK_BASE
 from ramstk.models import RAMSTKBaseRecord
+from ramstk.views.gtk3 import _
 
 
 def do_check_overstress(
@@ -403,19 +404,14 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
                 self.current_rated,
             )
         except ZeroDivisionError:
-            _error_msg: str = (
-                f"Failed to calculate current ratio for hardware ID "
-                f"{self.hardware_id}.  Rated current={self.current_rated}, operating "
-                f"current={self.current_operating}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                "fail_calculate_current_stress",
-                error_message=_error_msg,
+                message=_(
+                    f"Failed to calculate current ratio for hardware ID "
+                    f"{self.hardware_id}.  Rated current={self.current_rated}, "
+                    f"operating current={self.current_operating}."
+                ),
             )
 
     def do_calculate_power_ratio(self) -> None:
@@ -430,19 +426,14 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
                 self.power_rated,
             )
         except ZeroDivisionError:
-            _error_msg: str = (
-                f"Failed to calculate power ratio for hardware ID {self.hardware_id}.  "
-                f"Rated power={self.power_rated}, operating "
-                f"power={self.power_operating}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                "fail_calculate_power_stress",
-                error_message=_error_msg,
+                message=_(
+                    f"Failed to calculate power ratio for hardware ID "
+                    f"{self.hardware_id}.  Rated power={self.power_rated}, operating "
+                    f"power={self.power_operating}."
+                ),
             )
 
     def do_calculate_voltage_ratio(self) -> None:
@@ -458,20 +449,15 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):
                 _voltage_operating, self.voltage_rated
             )
         except ZeroDivisionError:
-            _error_msg: str = (
-                f"Failed to calculate voltage ratio for hardware ID "
-                f"{self.hardware_id}.  Rated voltage={self.voltage_rated}, "
-                f"operating ac voltage={self.voltage_ac_operating}, operating DC "
-                f"voltage={self.voltage_dc_operating}."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                "fail_calculate_voltage_stress",
-                error_message=_error_msg,
+                message=_(
+                    f"Failed to calculate voltage ratio for hardware ID "
+                    f"{self.hardware_id}.  Rated voltage={self.voltage_rated}, "
+                    f"operating ac voltage={self.voltage_ac_operating}, operating DC "
+                    f"voltage={self.voltage_dc_operating}."
+                ),
             )
 
     def do_derating_analysis(self, stress_limits: List[float]) -> None:

--- a/src/ramstk/models/programdb/design_electric/record.pyi
+++ b/src/ramstk/models/programdb/design_electric/record.pyi
@@ -8,9 +8,10 @@ from pubsub import pub
 from ramstk.analyses import derating, stress
 from ramstk.db import RAMSTK_BASE as RAMSTK_BASE
 from ramstk.models import RAMSTKBaseRecord as RAMSTKBaseRecord
+from ramstk.views.gtk3 import _
 
 def do_check_overstress(
-    overstress: Dict[str, List[float]], stress_type: str
+    overstress: Dict[str, List[float]], stress_type: str, limits: Dict[str, List[float]]
 ) -> Tuple[int, str]: ...
 
 class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):

--- a/src/ramstk/models/programdb/similar_item/table.py
+++ b/src/ramstk/models/programdb/similar_item/table.py
@@ -9,7 +9,7 @@
 
 # Standard Library Imports
 from collections import OrderedDict
-from typing import Any, Dict, Type
+from typing import Any, Callable, Dict, Type
 
 # Third Party Imports
 from pubsub import pub
@@ -17,6 +17,7 @@ from pubsub import pub
 # RAMSTK Package Imports
 from ramstk.analyses import similaritem
 from ramstk.models import RAMSTKBaseTable, RAMSTKSimilarItemRecord
+from ramstk.views.gtk3 import _
 
 
 class RAMSTKSimilarItemTable(RAMSTKBaseTable):
@@ -94,7 +95,7 @@ class RAMSTKSimilarItemTable(RAMSTKBaseTable):
         :return: None
         :rtype: None
         """
-        _dic_method = {
+        _dic_method: Dict[int, Callable] = {
             1: self._do_calculate_topic_633,
             2: self._do_calculate_user_defined,
         }
@@ -109,19 +110,14 @@ class RAMSTKSimilarItemTable(RAMSTKBaseTable):
                 tree=self.tree,
             )
         except KeyError:
-            _error_msg: str = (
-                f"Failed to calculate similar item reliability for hardware ID "
-                f"{node_id}.  Unknown similar item method ID "
-                f"{_record.similar_item_method_id} selected."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
-            )
-            pub.sendMessage(
-                "fail_calculate_similar_item",
-                error_message=_error_msg,
+                message=_(
+                    f"Failed to calculate similar item reliability for hardware ID "
+                    f"{node_id}.  Unknown similar item method ID "
+                    f"{_record.similar_item_method_id} selected."
+                ),
             )
 
     def do_roll_up_change_descriptions(self, node_id: int) -> None:

--- a/src/ramstk/views/gtk3/fmea/panel.py
+++ b/src/ramstk/views/gtk3/fmea/panel.py
@@ -14,7 +14,6 @@ import treelib
 from pubsub import pub
 
 # RAMSTK Package Imports
-from ramstk.models import RAMSTKCauseRecord, RAMSTKMechanismRecord
 from ramstk.views.gtk3 import GdkPixbuf, Gtk, _
 from ramstk.views.gtk3.widgets import (
     RAMSTKCheckButton,
@@ -1389,7 +1388,8 @@ class FMEATreePanel(RAMSTKTreePanel):
         self.tvwTreeView.filt_model.refilter()
 
     def __do_get_rpn_names(
-        self, entity: Union[RAMSTKCauseRecord, RAMSTKMechanismRecord]
+        self,
+        entity: object,
     ) -> Tuple[str, str, str, str]:
         """Retrieve the RPN category for the selected mechanism or cause.
 

--- a/src/ramstk/views/gtk3/widgets/panel.py
+++ b/src/ramstk/views/gtk3/widgets/panel.py
@@ -909,8 +909,6 @@ class RAMSTKTreePanel(RAMSTKPanel):
         :param package: the key:value for the data being updated.
         :return: None
         """
-        _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-
         [[_key, _value]] = package.items()
 
         try:

--- a/src/ramstk/views/gtk3/widgets/panel.py
+++ b/src/ramstk/views/gtk3/widgets/panel.py
@@ -354,16 +354,14 @@ class RAMSTKFixedPanel(RAMSTKPanel):
                     package={key: _new_text},
                 )
         except (KeyError, ValueError):
-            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while editing {self._tag} data "
-                f"for record ID {self._record_id} in the view.  Key {key} does not "
-                f"exist in attribute dictionary."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while editing {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  Key {key} does not exist in "
+                    f"attribute dictionary."
+                ),
             )
 
         combo.handler_unblock(combo.dic_handler_id["changed"])
@@ -481,7 +479,6 @@ class RAMSTKFixedPanel(RAMSTKPanel):
             the new attribute value as the value.
         :return: None
         """
-        _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
         [[_key, _value]] = package.items()
 
         try:
@@ -489,26 +486,24 @@ class RAMSTKFixedPanel(RAMSTKPanel):
             _signal = self.dic_attribute_widget_map[_key][2]
             _widget.do_update(_value, _signal)  # type: ignore
         except KeyError:
-            _error_msg = _(
-                f"{_method_name}: An error occurred while updating {self._tag} data "
-                f"for record ID {self._record_id} in the view.  No key {_key} in "
-                f"dic_attribute_widget_map."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while updating {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  No key {_key} in "
+                    f"dic_attribute_widget_map."
+                ),
             )
         except TypeError:
-            _error_msg = _(
-                f"{_method_name}: An error occurred while updating {self._tag} data "
-                f"for record ID {self._record_id} in the view.  Data for key {_key} is "
-                f"the wrong type."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while updating {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  Data for key {_key} is the wrong "
+                    f"type."
+                ),
             )
 
     def on_toggled(
@@ -536,16 +531,14 @@ class RAMSTKFixedPanel(RAMSTKPanel):
                 package={key: _new_text},
             )
         except KeyError:
-            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while updating {self._tag} data "
-                f"for record ID {self._record_id} in the view.  Key {key} does not "
-                f"exist in attribute dictionary."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while updating {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  Key {key} does not exist in "
+                    f"attribute dictionary."
+                ),
             )
 
         return {key: _new_text}
@@ -570,16 +563,14 @@ class RAMSTKFixedPanel(RAMSTKPanel):
             elif str(datatype) == "gchararray":
                 _new_text = str(entry.do_get_text())
         except (KeyError, ValueError):
-            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while reading {self._tag} data for "
-                f"record ID {self._record_id} in the view.  Key {key} does not exist "
-                f"in attribute dictionary."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while reading {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  Key {key} does not exist in "
+                    f"attribute dictionary."
+                ),
             )
 
         return {key: _new_text}
@@ -776,28 +767,24 @@ class RAMSTKTreePanel(RAMSTKPanel):
                 self.tvwTreeView.selection.select_iter(_row)
                 self.show_all()
         except TypeError:
-            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while loading {self._tag} data for "
-                f"Record ID {self._record_id} into the view.  One or more values from "
-                f"the database was the wrong type for the column it was trying to load."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while loading {self._tag} data for Record ID "
+                    f"{self._record_id} into the view.  One or more values from the "
+                    f"database was the wrong type for the column it was trying to load."
+                ),
             )
         except ValueError:
-            _method_name = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while loading {self._tag} data "
-                f"for Record ID {self._record_id} into the view.  One or more values "
-                f"from the database was missing."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while loading {self._tag} data for Record ID "
+                    f"{self._record_id} into the view.  One or more values from the "
+                    f"database was missing."
+                ),
             )
 
         pub.sendMessage("request_set_cursor_active")
@@ -932,26 +919,24 @@ class RAMSTKTreePanel(RAMSTKPanel):
             _model, _row = self.tvwTreeView.get_selection().get_selected()
             _model.set_value(_row, _position, _value)
         except KeyError:
-            _error_msg = _(
-                f"{_method_name}: An error occurred while refreshing {self._tag} data "
-                f"for Record ID {self._record_id} in the view.  Key {_key} does not "
-                f"exist in attribute dictionary."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while refreshing {self._tag} data for Record "
+                    f"ID {self._record_id} in the view.  Key {_key} does not exist in "
+                    f"attribute dictionary."
+                ),
             )
         except TypeError:
-            _error_msg = _(
-                f"{_method_name}: An error occurred while refreshing {self._tag} data "
-                f"for Record ID {self._record_id} in the view.  Data {_value} for "
-                f"{_key} is the wrong type."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while refreshing {self._tag} data "
+                    f"for Record ID {self._record_id} in the view.  Data {_value} for "
+                    f"{_key} is the wrong type."
+                ),
             )
 
     def do_set_callbacks(self) -> None:
@@ -1086,16 +1071,14 @@ class RAMSTKTreePanel(RAMSTKPanel):
                 package={key: _new_text},
             )
         except KeyError:
-            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while editing {self._tag} data "
-                f"for record ID {self._record_id} in the view.  One or more keys could "
-                f"not be found in the attribute dictionary."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while editing {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  One or more keys could not be "
+                    f"found in the attribute dictionary."
+                ),
             )
 
     def on_cell_edit(
@@ -1130,16 +1113,14 @@ class RAMSTKTreePanel(RAMSTKPanel):
                 package={key: new_text},
             )
         except KeyError:
-            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while editing {self._tag} data "
-                f"for record ID {self._record_id} in the view.  One or more keys could "
-                f"not be found in the attribute dictionary."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while editing {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  One or more keys could not be "
+                    f"found in the attribute dictionary."
+                ),
             )
 
     # pylint: disable=unused-argument
@@ -1166,16 +1147,14 @@ class RAMSTKTreePanel(RAMSTKPanel):
                     message, node_id=self._record_id, package={key: _new_text}
                 )
         except KeyError:
-            _method_name: str = inspect.currentframe().f_code.co_name  # type: ignore
-            _error_msg = _(
-                f"{_method_name}: An error occurred while editing {self._tag} data "
-                f"for record ID {self._record_id} in the view.  One or more keys could "
-                f"not be found in the attribute dictionary."
-            )
             pub.sendMessage(
                 "do_log_debug",
                 logger_name="DEBUG",
-                message=_error_msg,
+                message=_(
+                    f"An error occurred while editing {self._tag} data for record ID "
+                    f"{self._record_id} in the view.  One or more keys could not be "
+                    f"found in the attribute dictionary."
+                ),
             )
 
     # pylint: disable=unused-argument

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import xml.etree.ElementTree as ET
 from distutils import dir_util
+from pathlib import Path
 
 # Third Party Imports
 import psycopg2
@@ -754,6 +755,7 @@ def test_license_file():
 def test_log_file():
     """Create a log file."""
     _test_file = TMP_DIR + "/test_file.log"
+    Path(_test_file).touch()
 
     yield _test_file
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -750,6 +750,16 @@ def test_license_file():
     os.remove(_cwd + "/license.key")
 
 
+@pytest.fixture
+def test_log_file():
+    """Create a log file."""
+    _test_file = TMP_DIR + "/test_file.log"
+
+    yield _test_file
+
+    os.remove(_test_file)
+
+
 @pytest.fixture(scope="session")
 def test_toml_site_configuration(test_config_dir):
     """Create a toml site configuration file."""


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To deal with the "fail_XX_YY" messages being sent.  The original issue wanted to clean up the naming of the payload, but investigation found these messages were redundant and should just be removed.

## Describe how this was implemented.
Removed all the "fail_XX_YY" messages.  Where XX was insert, delete, select, etc.  Replaced with "do_log_debug" messages.

Messages such as "fail_calculate_YY" remain and need to be handled by a message dialog for the user.  The message dialog should also handle the "do_log_debug" messages since the user should be notified when one of these events occurs, but it doesn't necessarily need to be logged.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #333


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Issue(s) have been raised for problem areas outside the scope of
    this PR.  These problem areas have been decorated with an ISSUE: # comment.
