### PR TITLE
refactor: use keys instead of numbers for loading Hazard Analysis CellRendererCombos

### DIFF
--- a/.github/workflows/dont-static-checks.yml
+++ b/.github/workflows/dont-static-checks.yml
@@ -2,7 +2,7 @@
 # do-static-checks workflow aren't met.  This allows PRs to be merged when the
 # conditions aren't met for a protected branch.  See
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks
-name: Perform Static Checks on RAMSTK Code Base
+name: Dummy Static Checks on RAMSTK Code Base
 
 on:
   push:
@@ -20,35 +20,35 @@ on:
 
 jobs:
   bandit:
-    name: Check for Security Vulnerabilities
+    name: Dummy Check for Security Vulnerabilities
     runs-on: ubuntu-latest
     steps:
       - run:
           echo "No security check required."
 
   format-check:
-    name: Check Code Formatting
+    name: Dummy Check Code Formatting
     runs-on: ubuntu-latest
     steps:
       - run:
           echo "No files to be formatted."
 
   style-check:
-    name: Check Code Styling
+    name: Dummy Check Code Styling
     runs-on: ubuntu-latest
     steps:
       - run:
           echo "No files to be style checked."
 
   type-check:
-    name: Check Code Type Hinting
+    name: Dummy Check Code Type Hinting
     runs-on: ubuntu-latest
     steps:
       - run:
           echo "No files to be type checked."
 
   lint-check:
-    name: Check Code Lint
+    name: Dummy Check Code Lint
     runs-on: ubuntu-latest
     steps:
       - run:

--- a/.github/workflows/dont-test-suite.yml
+++ b/.github/workflows/dont-test-suite.yml
@@ -2,7 +2,7 @@
 # do-test-suite workflow aren't met.  This allows PRs to be merged when the
 # conditions aren't met for a protected branch.  See
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks
-name: Execute RAMSTK Test Suite with Coverage
+name: Dummy RAMSTK Test Suite with Coverage
 
 on:
   push:
@@ -20,7 +20,7 @@ on:
 
 jobs:
   test_suite:
-    name: Run Test Suite
+    name: Run Dummy Test Suite
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
           echo "Test suite not required for ${{ matrix.python }}."
 
   upload_coveralls:
-    name: Upload Results to Coveralls
+    name: Upload Dummy Results to Coveralls
     needs: test_suite
     runs-on: ubuntu-latest
     steps:

--- a/src/ramstk/views/gtk3/hazard_analysis/panel.py
+++ b/src/ramstk/views/gtk3/hazard_analysis/panel.py
@@ -7,7 +7,7 @@
 """GTK3 Hazard Analysis Panels."""
 
 # Standard Library Imports
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 # Third Party Imports
 from pubsub import pub
@@ -711,6 +711,9 @@ class HazardsTreePanel(RAMSTKTreePanel):
         }
 
         # Initialize public list instance attributes.
+        self.lst_hazards: List[str] = [""]
+        self.lst_severity: List[str] = [""]
+        self.lst_probability: List[str] = [""]
 
         # Initialize public scalar instance attributes.
 
@@ -742,44 +745,38 @@ class HazardsTreePanel(RAMSTKTreePanel):
         """
         return model[row][1] == self._parent_id
 
-    def do_load_severity(self, criticalities: Dict[int, Tuple[str, str, int]]) -> None:
-        """Load the Gtk.CellRendererCombo() containing severities.
+    def do_load_comboboxes(self) -> None:
+        """Load the Gtk.CellRendererCombo()s.
 
-        :param criticalities: the dict containing the hazard severity
-            categories and values.
         :return: None
         :rtype: None
         """
-        # See ISSUE 1006
-        for i in [6, 10, 14, 18]:
-            _model = self.tvwTreeView.get_cell_model(i)
-            for _key in criticalities:
-                _model.append((criticalities[_key][1],))
+        self.tvwTreeView.do_load_combo_cell(
+            self.tvwTreeView.position["potential_hazard"],
+            self.lst_hazards,
+        )
 
-    def do_load_hazards(self, hazards: Dict[Any, Any]) -> None:
-        """Load the Gtk.CellRendererCombos() containing hazards.
+        for _key in [
+            "assembly_probability",
+            "assembly_probability_f",
+            "system_probability",
+            "system_probability_f",
+        ]:
+            self.tvwTreeView.do_load_combo_cell(
+                self.tvwTreeView.position[_key],
+                self.lst_probability,
+            )
 
-        :param hazards: the dict containing the hazards and hazard types
-            to be considered.
-        :return: None
-        :rtype: None
-        """
-        _model = self.tvwTreeView.get_cell_model(3)
-        for _key in hazards:
-            _hazard = f"{hazards[_key][0]}, {hazards[_key][1]}"
-            _model.append((_hazard,))
-
-    def do_load_probability(self, probabilities: List[str]) -> None:
-        """Load the Gtk.CellRendererCombos() containing probabilities.
-
-        :param probabilities: the list of hazard probabilities.
-        :return: None
-        :rtype: None
-        """
-        for i in [7, 11, 15, 19]:
-            _model = self.tvwTreeView.get_cell_model(i)
-            for _probability in probabilities:
-                _model.append((_probability[0],))
+        for _key in [
+            "assembly_severity",
+            "assembly_severity_f",
+            "system_severity",
+            "system_severity_f",
+        ]:
+            self.tvwTreeView.do_load_combo_cell(
+                self.tvwTreeView.position[_key],
+                self.lst_severity,
+            )
 
     def do_refresh_functions(self, row: Gtk.TreeIter, function: List[str]) -> None:
         """Refresh the Similar Item functions in the RAMSTKTreeView().

--- a/src/ramstk/views/gtk3/hazard_analysis/view.py
+++ b/src/ramstk/views/gtk3/hazard_analysis/view.py
@@ -195,6 +195,26 @@ class HazardsWorkView(RAMSTKWorkView):
         self.dic_pkeys["revision_id"] = attributes["revision_id"]
         self.dic_pkeys["function_id"] = attributes["function_id"]
 
+    def __do_load_lists(self) -> None:
+        """Load the pick lists associated with Hazards.
+
+        :return: None
+        :rtype: None
+        """
+        for _key in self.RAMSTK_USER_CONFIGURATION.RAMSTK_HAZARDS:
+            _hazard = (
+                f"{self.RAMSTK_USER_CONFIGURATION.RAMSTK_HAZARDS[_key][0]}, "
+                f"{self.RAMSTK_USER_CONFIGURATION.RAMSTK_HAZARDS[_key][1]}"
+            )
+            self._pnlPanel.lst_hazards.append(_hazard)
+
+        for _key in self.RAMSTK_USER_CONFIGURATION.RAMSTK_SEVERITY:
+            _severity = self.RAMSTK_USER_CONFIGURATION.RAMSTK_SEVERITY[_key][1]
+            self._pnlPanel.lst_severity.append(_severity)
+
+        for _probability in self.RAMSTK_USER_CONFIGURATION.RAMSTK_FAILURE_PROBABILITY:
+            self._pnlPanel.lst_probability.append(_probability[0])
+
     def __make_ui(self) -> None:
         """Build the user interface for the Function Hazard Analysis tab.
 
@@ -204,10 +224,7 @@ class HazardsWorkView(RAMSTKWorkView):
         super().do_make_layout()
         super().do_embed_treeview_panel()
 
-        self._pnlPanel.do_load_severity(self.RAMSTK_USER_CONFIGURATION.RAMSTK_SEVERITY)
-        self._pnlPanel.do_load_hazards(self.RAMSTK_USER_CONFIGURATION.RAMSTK_HAZARDS)
-        self._pnlPanel.do_load_probability(
-            self.RAMSTK_USER_CONFIGURATION.RAMSTK_FAILURE_PROBABILITY
-        )
+        self.__do_load_lists()
+        self._pnlPanel.do_load_comboboxes()
 
         self.show_all()


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To load the Hazard Analysis tree Gtk.CellRendererCombos using panel lists like every other work stream module.

## Describe how this was implemented.
Created lists for hazards, probability, and severity in the Hazards Tree Panel.  Add method to load the CellRenderers to the Panel class.  Removed individual methods from the Panel class.  Added method to load all the lists to the Hazard View class.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #1006 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Issue(s) have been raised for problem areas outside the scope of
    this PR.  These problem areas have been decorated with an ISSUE: # comment.
