### PR TITLE
fix: raise dialog to inform user of issues encountered while running application

### DIFF
--- a/src/ramstk/models/dbrecords/programdb_design_electric_record.py
+++ b/src/ramstk/models/dbrecords/programdb_design_electric_record.py
@@ -408,7 +408,7 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):  # type: ignore
             )
         except ZeroDivisionError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"Failed to calculate current ratio for hardware ID "
@@ -430,7 +430,7 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):  # type: ignore
             )
         except ZeroDivisionError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"Failed to calculate power ratio for hardware ID "
@@ -453,7 +453,7 @@ class RAMSTKDesignElectricRecord(RAMSTK_BASE, RAMSTKBaseRecord):  # type: ignore
             )
         except ZeroDivisionError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"Failed to calculate voltage ratio for hardware ID "

--- a/src/ramstk/models/dbtables/basetable.py
+++ b/src/ramstk/models/dbtables/basetable.py
@@ -172,7 +172,7 @@ class RAMSTKBaseTable:
             )
         except (AttributeError, DataAccessError, NodeIDAbsentError):
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"Attempted to delete non-existent "
@@ -194,7 +194,7 @@ class RAMSTKBaseTable:
             )
         except AttributeError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"No attributes found for record ID {node_id} in {self._tag} table."
@@ -245,13 +245,13 @@ class RAMSTKBaseTable:
             )
         except DataAccessError as _error:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=str(_error.msg),
             )
         except NodeIDAbsentError as _error:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=str(_error),
             )
@@ -274,7 +274,7 @@ class RAMSTKBaseTable:
             TypeError,
         ):
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"No data package for node ID {node_id} in module {self._tag}."
@@ -341,7 +341,7 @@ class RAMSTKBaseTable:
             _attributes = self.do_select(node_id).get_attributes()
         except (AttributeError, KeyError):
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"No data package for node ID {node_id} in module {self._tag}."
@@ -405,7 +405,7 @@ class RAMSTKBaseTable:
             )
         except AttributeError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"Attempted to save non-existent {self._tag.replace('_', ' ')} "
@@ -414,7 +414,7 @@ class RAMSTKBaseTable:
             )
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"No data package found for {self._tag.replace('_', ' ')} ID "
@@ -430,7 +430,7 @@ class RAMSTKBaseTable:
             else:
                 _error_msg = _(f"Attempting to update the root node {node_id}.")
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_error_msg,
             )

--- a/src/ramstk/models/dbtables/programdb_similar_item_table.py
+++ b/src/ramstk/models/dbtables/programdb_similar_item_table.py
@@ -116,7 +116,7 @@ class RAMSTKSimilarItemTable(RAMSTKBaseTable):
             )
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"Failed to calculate similar item reliability for hardware ID "

--- a/src/ramstk/views/gtk3/assistants/project.py
+++ b/src/ramstk/views/gtk3/assistants/project.py
@@ -222,7 +222,7 @@ class OpenProject:
         )
         _dialog = RAMSTKMessageDialog(parent=self._parent)
         _dialog.do_set_message(_prompt)
-        _dialog.do_set_message_type("information")
+        _dialog.do_set_message_type("info")
 
         if _dialog.run() == Gtk.ResponseType.OK:
             _dialog.destroy()

--- a/src/ramstk/views/gtk3/books/modulebook.pyi
+++ b/src/ramstk/views/gtk3/books/modulebook.pyi
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Any
+from typing import Dict
 
 # Third Party Imports
 from treelib import Tree as Tree
@@ -13,8 +13,8 @@ from ramstk.views.gtk3.revision import RevisionModuleView as RevisionModuleView
 from ramstk.views.gtk3.widgets import RAMSTKBaseBook as RAMSTKBaseBook
 
 class RAMSTKModuleBook(RAMSTKBaseBook):
-    _dic_module_views: Any
-    icoStatus: Any
+    _dic_module_views: Dict[str, object]
+    icoStatus: Gtk.StatusIcon
     def __init__(
         self, configuration: RAMSTKUserConfiguration, logger: RAMSTKLogManager
     ) -> None: ...

--- a/src/ramstk/views/gtk3/hardware/view.py
+++ b/src/ramstk/views/gtk3/hardware/view.py
@@ -223,7 +223,7 @@ class HardwareModuleView(RAMSTKModuleView):
             )
             _dialog = super().do_raise_dialog(parent=_parent)
             _dialog.do_set_message(message=_message)
-            _dialog.do_set_message_type(message_type="information")
+            _dialog.do_set_message_type(message_type="info")
             _dialog.do_run()
             _dialog.do_destroy()
             return
@@ -273,7 +273,7 @@ class HardwareModuleView(RAMSTKModuleView):
             )
             _dialog = super().do_raise_dialog(parent=_parent)
             _dialog.do_set_message(message=_message)
-            _dialog.do_set_message_type(message_type="information")
+            _dialog.do_set_message_type(message_type="info")
             _dialog.do_run()
             _dialog.do_destroy()
             return
@@ -325,7 +325,7 @@ class HardwareModuleView(RAMSTKModuleView):
             )
             _dialog = super().do_raise_dialog(parent=_parent)
             _dialog.do_set_message(message=_message)
-            _dialog.do_set_message_type(message_type="information")
+            _dialog.do_set_message_type(message_type="info")
             _dialog.do_run()
             _dialog.do_destroy()
             return

--- a/src/ramstk/views/gtk3/widgets/dialog.py
+++ b/src/ramstk/views/gtk3/widgets/dialog.py
@@ -469,8 +469,9 @@ class RAMSTKMessageDialog(Gtk.MessageDialog):
         _dic_message_type = {
             "error": Gtk.MessageType.ERROR,
             "warning": Gtk.MessageType.WARNING,
-            "information": Gtk.MessageType.INFO,
+            "info": Gtk.MessageType.INFO,
             "question": Gtk.MessageType.QUESTION,
+            "debug": Gtk.MessageType.OTHER,
         }
 
         _prompt = self.get_property("text")
@@ -489,7 +490,7 @@ class RAMSTKMessageDialog(Gtk.MessageDialog):
         self.set_markup(_prompt)
         self.set_property("message-type", _dic_message_type[message_type])
 
-        if message_type in {"error", "warning", "information"}:
+        if message_type in {"error", "warning", "info", "debug"}:
             self.add_buttons("_OK", Gtk.ResponseType.OK)
         elif message_type == "question":
             self.add_buttons(

--- a/src/ramstk/views/gtk3/widgets/panel.py
+++ b/src/ramstk/views/gtk3/widgets/panel.py
@@ -353,7 +353,7 @@ class RAMSTKFixedPanel(RAMSTKPanel):
                 )
         except (KeyError, ValueError):
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while editing {self._tag} data for record ID "
@@ -485,7 +485,7 @@ class RAMSTKFixedPanel(RAMSTKPanel):
             _widget.do_update(_value, _signal)  # type: ignore
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while updating {self._tag} data for record ID "
@@ -495,7 +495,7 @@ class RAMSTKFixedPanel(RAMSTKPanel):
             )
         except TypeError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while updating {self._tag} data for record ID "
@@ -530,7 +530,7 @@ class RAMSTKFixedPanel(RAMSTKPanel):
             )
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while updating {self._tag} data for record ID "
@@ -562,7 +562,7 @@ class RAMSTKFixedPanel(RAMSTKPanel):
                 _new_text = str(entry.do_get_text())
         except (KeyError, ValueError):
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while reading {self._tag} data for record ID "
@@ -766,7 +766,7 @@ class RAMSTKTreePanel(RAMSTKPanel):
                 self.show_all()
         except TypeError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while loading {self._tag} data for Record ID "
@@ -776,7 +776,7 @@ class RAMSTKTreePanel(RAMSTKPanel):
             )
         except ValueError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while loading {self._tag} data for Record ID "
@@ -916,7 +916,7 @@ class RAMSTKTreePanel(RAMSTKPanel):
             _model.set_value(_row, _position, _value)
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while refreshing {self._tag} data for Record "
@@ -926,7 +926,7 @@ class RAMSTKTreePanel(RAMSTKPanel):
             )
         except TypeError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while refreshing {self._tag} data "
@@ -1068,7 +1068,7 @@ class RAMSTKTreePanel(RAMSTKPanel):
             )
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while editing {self._tag} data for record ID "
@@ -1110,7 +1110,7 @@ class RAMSTKTreePanel(RAMSTKPanel):
             )
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while editing {self._tag} data for record ID "
@@ -1144,7 +1144,7 @@ class RAMSTKTreePanel(RAMSTKPanel):
                 )
         except KeyError:
             pub.sendMessage(
-                "do_log_debug",
+                "do_log_debug_msg",
                 logger_name="DEBUG",
                 message=_(
                     f"An error occurred while editing {self._tag} data for record ID "

--- a/tests/views/gtk3/widgets/test_dialog.py
+++ b/tests/views/gtk3/widgets/test_dialog.py
@@ -89,10 +89,11 @@ class TestRAMSTKMessageDialog:
         assert DUT.get_property("text") == (
             "<b>Test Prompt  Check the error log for additional information "
             "(if any).  Please e-mail <span foreground='blue' "
-            "underline='single'><a href='mailto:bugs@reliaqual.com?subject=RAMSTK BUG REPORT: "
-            "<ADD SHORT PROBLEM DESCRIPTION>&amp;body=RAMSTK "
+            "underline='single'><a href='mailto:bugs@reliaqual.com?subject=RAMSTK BUG "
+            "REPORT: <ADD SHORT PROBLEM DESCRIPTION>&amp;body=RAMSTK "
             "MODULE:%0d%0a%0d%0aRAMSTK VERSION:%20%0d%0a%0d%0aYOUR "
-            "HARDWARE:%20%0d%0a%0d%0aYOUR OS:%20%0d%0a%0d%0aDETAILED PROBLEM DESCRIPTION:%20%0d%0a'>bugs@reliaqual.com</a></span> "
+            "HARDWARE:%20%0d%0a%0d%0aYOUR OS:%20%0d%0a%0d%0aDETAILED PROBLEM "
+            "DESCRIPTION:%20%0d%0a'>bugs@reliaqual.com</a></span> "
             "with a detailed description of the problem, the workflow you are "
             "using and the error log attached if the problem persists.</b>"
         )
@@ -116,7 +117,7 @@ class TestRAMSTKMessageDialog:
         """__init__() should create an info type RAMSTKMessageDialog."""
         DUT = RAMSTKMessageDialog()
         DUT.do_set_message("Test Info Prompt")
-        DUT.do_set_message_type("information")
+        DUT.do_set_message_type("info")
 
         assert isinstance(DUT, RAMSTKMessageDialog)
         assert DUT.get_destroy_with_parent()


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To raise a dialog whenever a message is sent that corresponds to the user's selected log level.  This dialog displays the same message that is being sent to the logger.  All messages will be sent to the status bar regardless of the user's selected log level.

## Describe how this was implemented.
Add method to RAMSTKDesktop to listen for do_log_XX messages and raise a dialog with the message if the log level is the same as the user's selected log level.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #1005 


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Issue(s) have been raised for problem areas outside the scope of
    this PR.  These problem areas have been decorated with an ISSUE: # comment.
