### PR TITLE
feature: use database triggers to add records on Hardware insert

### DIFF
--- a/.github/workflows/on-pr-close.yml
+++ b/.github/workflows/on-pr-close.yml
@@ -85,4 +85,4 @@ jobs:
           git config --global user.email "${{ steps.import_gpg.outputs.email }}"
           git config --global user.name "${{ steps.import_gpg.outputs.name }}"
           git tag -s -a -m"v${{ steps.nextversion.outputs.next_version }}" v${{steps.nextversion.outputs.next_version }}
-          git push --tags
+          git push --tags -f

--- a/.github/workflows/on-pr-open.yml
+++ b/.github/workflows/on-pr-open.yml
@@ -24,7 +24,7 @@ jobs:
           success-state: Conventional commits compliant title detected.
           failure-state: Pull request title is not conventional commits compliant!
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
   pr-labeler:
     name: Label Pull Request from Branch Name
@@ -33,4 +33,4 @@ jobs:
       - name: Apply Labels to PR
         uses: TimonVS/pr-labeler-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/on-pr-open.yml
+++ b/.github/workflows/on-pr-open.yml
@@ -24,7 +24,7 @@ jobs:
           success-state: Conventional commits compliant title detected.
           failure-state: Pull request title is not conventional commits compliant!
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   pr-labeler:
     name: Label Pull Request from Branch Name
@@ -33,4 +33,4 @@ jobs:
       - name: Apply Labels to PR
         uses: TimonVS/pr-labeler-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/data/postgres_program_db.sql
+++ b/data/postgres_program_db.sql
@@ -1321,6 +1321,83 @@ END;
 $function$
 ;
 
+CREATE OR REPLACE FUNCTION public.insertdesignelectricrecord()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF NEW.fld_part = 1 THEN
+        INSERT INTO ramstk_design_electric(fld_revision_id,fld_hardware_id)
+        VALUES(NEW.fld_revision_id, NEW.fld_hardware_id);
+    END IF;
+
+    RETURN NEW;
+
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.insertdesignmechanicrecord()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF NEW.fld_part = 1 THEN
+        INSERT INTO ramstk_design_mechanic(fld_revision_id,fld_hardware_id)
+        VALUES(NEW.fld_revision_id, NEW.fld_hardware_id);
+    END IF;
+
+    RETURN NEW;
+
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.insertmilhdbk217frecord()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF NEW.fld_part = 1 THEN
+        INSERT INTO ramstk_mil_hdbk_f(fld_revision_id,fld_hardware_id)
+        VALUES(NEW.fld_revision_id, NEW.fld_hardware_id);
+    END IF;
+
+    RETURN NEW;
+
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.insertnswcrecord()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF NEW.fld_part = 1 THEN
+        INSERT INTO ramstk_nswc(fld_revision_id,fld_hardware_id)
+        VALUES(NEW.fld_revision_id, NEW.fld_hardware_id);
+    END IF;
+
+    RETURN NEW;
+
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.insertreliabilityrecord()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    INSERT INTO ramstk_reliability(fld_revision_id,fld_hardware_id)
+    VALUES(NEW.fld_revision_id, NEW.fld_hardware_id);
+    RETURN NEW;
+
+END;
+$function$
+;
+
 -- Create triggers
 create trigger insertallocationrecord after
 insert
@@ -1331,3 +1408,28 @@ create trigger insertsimilaritemrecord after
 insert
     on
     public.ramstk_hardware for each row execute procedure insertsimilaritemrecord();
+
+create trigger insertdesignelectricrecord after
+insert
+    on
+    public.ramstk_hardware for each row execute procedure insertdesignelectricrecord();
+
+create trigger insertdesignmechanicrecord after
+insert
+    on
+    public.ramstk_hardware for each row execute procedure insertdesignmechanicrecord();
+
+create trigger insertmilhdbk217frecord after
+insert
+    on
+    public.ramstk_hardware for each row execute procedure insertmilhdbk217frecord();
+
+create trigger insertnswcrecord after
+insert
+    on
+    public.ramstk_hardware for each row execute procedure insertnswcrecord();
+
+create trigger insertreliabilityrecord after
+insert
+    on
+    public.ramstk_hardware for each row execute procedure insertreliabilityrecord();

--- a/src/ramstk/models/dbtables/programdb_allocation_table.pyi
+++ b/src/ramstk/models/dbtables/programdb_allocation_table.pyi
@@ -2,6 +2,9 @@
 from datetime import date
 from typing import Dict, List, Tuple, Type, Union
 
+# Third Party Imports
+import treelib
+
 # RAMSTK Package Imports
 from ramstk.analyses import allocation as allocation
 
@@ -33,3 +36,4 @@ class RAMSTKAllocationTable(RAMSTKBaseTable):
     def do_calculate_foo_allocation(self, node_id: int) -> None: ...
     def _do_calculate_agree_total_elements(self, node_id: int) -> Tuple[int, int]: ...
     def _do_calculate_foo_cumulative_weight(self, node_id: int) -> int: ...
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None: ...

--- a/src/ramstk/models/dbtables/programdb_design_electric_table.py
+++ b/src/ramstk/models/dbtables/programdb_design_electric_table.py
@@ -11,6 +11,10 @@
 from datetime import date
 from typing import Dict, Type, Union
 
+# Third Party Imports
+import treelib
+from pubsub import pub
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKDesignElectricRecord
 from .basetable import RAMSTKBaseTable
@@ -61,6 +65,10 @@ class RAMSTKDesignElectricTable(RAMSTKBaseTable):
         self.pkey = "hardware_id"
 
         # Subscribe to PyPubSub messages.
+        pub.subscribe(
+            self._on_insert_hardware,
+            "succeed_insert_hardware",
+        )
 
     def do_get_new_record(  # pylint: disable=method-hidden
         self, attributes: Dict[str, Union[date, float, int, str]]
@@ -73,6 +81,36 @@ class RAMSTKDesignElectricTable(RAMSTKBaseTable):
         """
         _new_record = self._record()
         _new_record.revision_id = attributes["revision_id"]
-        _new_record.hardware_id = self.last_id + 1
+        _new_record.hardware_id = attributes["hardware_id"]
 
         return _new_record
+
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None:
+        """Add new node to the Design Electric tree for the newly added Hardware.
+
+        Design Electric records are added by triggers in the database when a new
+        Hardware item is added.  This method simply adds a new node to the Design
+        Electric tree with a blank record.
+
+        :param tree: the Hardware tree with the new node.
+        :return: None
+        :rtype: None
+        """
+        for _node in tree.all_nodes()[1:]:
+            if not self.tree.contains(_node.identifier) and _node.data["hardware"].part:
+                _attributes = {
+                    "revision_id": _node.data["hardware"].revision_id,
+                    "hardware_id": _node.data["hardware"].hardware_id,
+                }
+                _record = self.do_get_new_record(_attributes)
+                self.tree.create_node(
+                    tag=self._tag,
+                    identifier=_node.data["hardware"].hardware_id,
+                    parent=0,
+                    data={self._tag: _record},
+                )
+
+                pub.sendMessage(
+                    f"succeed_insert_{self._tag}",
+                    tree=self.tree,
+                )

--- a/src/ramstk/models/dbtables/programdb_design_electric_table.pyi
+++ b/src/ramstk/models/dbtables/programdb_design_electric_table.pyi
@@ -2,6 +2,9 @@
 from datetime import date
 from typing import Dict, List, Type, Union
 
+# Third Party Imports
+import treelib
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKDesignElectricRecord as RAMSTKDesignElectricRecord
 from .basetable import RAMSTKBaseTable as RAMSTKBaseTable
@@ -18,3 +21,4 @@ class RAMSTKDesignElectricTable(RAMSTKBaseTable):
     def do_get_new_record(
         self, attributes: Dict[str, Union[date, float, int, str]]
     ) -> RAMSTKDesignElectricRecord: ...
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None: ...

--- a/src/ramstk/models/dbtables/programdb_design_mechanic_table.py
+++ b/src/ramstk/models/dbtables/programdb_design_mechanic_table.py
@@ -11,6 +11,10 @@
 from datetime import date
 from typing import Dict, Type, Union
 
+# Third Party Imports
+import treelib
+from pubsub import pub
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKDesignMechanicRecord
 from .basetable import RAMSTKBaseTable
@@ -60,6 +64,10 @@ class RAMSTKDesignMechanicTable(RAMSTKBaseTable):
         self.pkey = "hardware_id"
 
         # Subscribe to PyPubSub messages.
+        pub.subscribe(
+            self._on_insert_hardware,
+            "succeed_insert_hardware",
+        )
 
     def do_get_new_record(  # pylint: disable=method-hidden
         self, attributes: Dict[str, Union[date, float, int, str]]
@@ -72,6 +80,36 @@ class RAMSTKDesignMechanicTable(RAMSTKBaseTable):
         """
         _new_record = self._record()
         _new_record.revision_id = attributes["revision_id"]
-        _new_record.hardware_id = self.last_id + 1
+        _new_record.hardware_id = attributes["hardware_id"]
 
         return _new_record
+
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None:
+        """Add new node to the Design Mechanic tree for the newly added Hardware.
+
+        Design Mechanic records are added by triggers in the database when a new
+        Hardware item is added.  This method simply adds a new node to the Design
+        Mechanic tree with a blank record.
+
+        :param tree: the Hardware tree with the new node.
+        :return: None
+        :rtype: None
+        """
+        for _node in tree.all_nodes()[1:]:
+            if not self.tree.contains(_node.identifier) and _node.data["hardware"].part:
+                _attributes = {
+                    "revision_id": _node.data["hardware"].revision_id,
+                    "hardware_id": _node.data["hardware"].hardware_id,
+                }
+                _record = self.do_get_new_record(_attributes)
+                self.tree.create_node(
+                    tag=self._tag,
+                    identifier=_node.data["hardware"].hardware_id,
+                    parent=0,
+                    data={self._tag: _record},
+                )
+
+                pub.sendMessage(
+                    f"succeed_insert_{self._tag}",
+                    tree=self.tree,
+                )

--- a/src/ramstk/models/dbtables/programdb_design_mechanic_table.pyi
+++ b/src/ramstk/models/dbtables/programdb_design_mechanic_table.pyi
@@ -2,6 +2,9 @@
 from datetime import date
 from typing import Dict, List, Type, Union
 
+# Third Party Imports
+import treelib
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKDesignMechanicRecord as RAMSTKDesignMechanicRecord
 from .basetable import RAMSTKBaseTable as RAMSTKBaseTable
@@ -18,3 +21,4 @@ class RAMSTKDesignMechanicTable(RAMSTKBaseTable):
     def do_get_new_record(
         self, attributes: Dict[str, Union[date, float, int, str]]
     ) -> RAMSTKDesignMechanicRecord: ...
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None: ...

--- a/src/ramstk/models/dbtables/programdb_milhdbk217f_table.pyi
+++ b/src/ramstk/models/dbtables/programdb_milhdbk217f_table.pyi
@@ -2,6 +2,9 @@
 from datetime import date
 from typing import Dict, List, Type, Union
 
+# Third Party Imports
+import treelib
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKMilHdbk217FRecord as RAMSTKMilHdbk217FRecord
 from .basetable import RAMSTKBaseTable as RAMSTKBaseTable
@@ -18,3 +21,4 @@ class RAMSTKMILHDBK217FTable(RAMSTKBaseTable):
     def do_get_new_record(
         self, attributes: Dict[str, Union[date, float, int, str]]
     ) -> RAMSTKMilHdbk217FRecord: ...
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None: ...

--- a/src/ramstk/models/dbtables/programdb_nswc_table.py
+++ b/src/ramstk/models/dbtables/programdb_nswc_table.py
@@ -10,6 +10,10 @@
 from datetime import date
 from typing import Dict, Type, Union
 
+# Third Party Imports
+import treelib
+from pubsub import pub
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKNSWCRecord
 from .basetable import RAMSTKBaseTable
@@ -60,6 +64,10 @@ class RAMSTKNSWCTable(RAMSTKBaseTable):
         self.pkey = "hardware_id"
 
         # Subscribe to PyPubSub messages.
+        pub.subscribe(
+            self._on_insert_hardware,
+            "succeed_insert_hardware",
+        )
 
     def do_get_new_record(  # pylint: disable=method-hidden
         self, attributes: Dict[str, Union[date, float, int, str]]
@@ -72,6 +80,35 @@ class RAMSTKNSWCTable(RAMSTKBaseTable):
         """
         _new_record = self._record()
         _new_record.revision_id = attributes["revision_id"]
-        _new_record.hardware_id = self.last_id + 1
+        _new_record.hardware_id = attributes["hardware_id"]
 
         return _new_record
+
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None:
+        """Add new node to the NSWC tree for the newly added Hardware.
+
+        NSWC records are added by triggers in the database when a new Hardware item is
+        added.  This method simply adds a new node to the NSWC tree with a blank record.
+
+        :param tree: the Hardware tree with the new node.
+        :return: None
+        :rtype: None
+        """
+        for _node in tree.all_nodes()[1:]:
+            if not self.tree.contains(_node.identifier) and _node.data["hardware"].part:
+                _attributes = {
+                    "revision_id": _node.data["hardware"].revision_id,
+                    "hardware_id": _node.data["hardware"].hardware_id,
+                }
+                _record = self.do_get_new_record(_attributes)
+                self.tree.create_node(
+                    tag=self._tag,
+                    identifier=_node.data["hardware"].hardware_id,
+                    parent=0,
+                    data={self._tag: _record},
+                )
+
+                pub.sendMessage(
+                    f"succeed_insert_{self._tag}",
+                    tree=self.tree,
+                )

--- a/src/ramstk/models/dbtables/programdb_nswc_table.pyi
+++ b/src/ramstk/models/dbtables/programdb_nswc_table.pyi
@@ -2,6 +2,9 @@
 from datetime import date
 from typing import Dict, List, Type, Union
 
+# Third Party Imports
+import treelib
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKNSWCRecord as RAMSTKNSWCRecord
 from .basetable import RAMSTKBaseTable as RAMSTKBaseTable
@@ -18,3 +21,4 @@ class RAMSTKNSWCTable(RAMSTKBaseTable):
     def do_get_new_record(
         self, attributes: Dict[str, Union[date, float, int, str]]
     ) -> RAMSTKNSWCRecord: ...
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None: ...

--- a/src/ramstk/models/dbtables/programdb_reliability_table.py
+++ b/src/ramstk/models/dbtables/programdb_reliability_table.py
@@ -11,6 +11,10 @@
 from datetime import date
 from typing import Dict, Type, Union
 
+# Third Party Imports
+import treelib
+from pubsub import pub
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKReliabilityRecord
 from .basetable import RAMSTKBaseTable
@@ -60,6 +64,10 @@ class RAMSTKReliabilityTable(RAMSTKBaseTable):
         self.pkey = "hardware_id"
 
         # Subscribe to PyPubSub messages.
+        pub.subscribe(
+            self._on_insert_hardware,
+            "succeed_insert_hardware",
+        )
 
     def do_get_new_record(  # pylint: disable=method-hidden
         self, attributes: Dict[str, Union[date, float, int, str]]
@@ -72,6 +80,36 @@ class RAMSTKReliabilityTable(RAMSTKBaseTable):
         """
         _new_record = self._record()
         _new_record.revision_id = attributes["revision_id"]
-        _new_record.hardware_id = self.last_id + 1
+        _new_record.hardware_id = attributes["hardware_id"]
 
         return _new_record
+
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None:
+        """Add new node to the Reliability tree for the newly added Hardware.
+
+        Reliability records are added by triggers in the database when a new Hardware
+        item is added.  This method simply adds a new node to the Reliability tree with
+        a blank record.
+
+        :param tree: the Hardware tree with the new node.
+        :return: None
+        :rtype: None
+        """
+        for _node in tree.all_nodes()[1:]:
+            if not self.tree.contains(_node.identifier):
+                _attributes = {
+                    "revision_id": _node.data["hardware"].revision_id,
+                    "hardware_id": _node.data["hardware"].hardware_id,
+                }
+                _record = self.do_get_new_record(_attributes)
+                self.tree.create_node(
+                    tag=self._tag,
+                    identifier=_node.data["hardware"].hardware_id,
+                    parent=0,
+                    data={self._tag: _record},
+                )
+
+                pub.sendMessage(
+                    f"succeed_insert_{self._tag}",
+                    tree=self.tree,
+                )

--- a/src/ramstk/models/dbtables/programdb_reliability_table.pyi
+++ b/src/ramstk/models/dbtables/programdb_reliability_table.pyi
@@ -2,6 +2,9 @@
 from datetime import date
 from typing import Dict, List, Type, Union
 
+# Third Party Imports
+import treelib
+
 # RAMSTK Local Imports
 from ..dbrecords import RAMSTKReliabilityRecord as RAMSTKReliabilityRecord
 from .basetable import RAMSTKBaseTable as RAMSTKBaseTable
@@ -18,3 +21,4 @@ class RAMSTKReliabilityTable(RAMSTKBaseTable):
     def do_get_new_record(
         self, attributes: Dict[str, Union[date, float, int, str]]
     ) -> RAMSTKReliabilityRecord: ...
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None: ...

--- a/src/ramstk/models/dbtables/programdb_similar_item_table.pyi
+++ b/src/ramstk/models/dbtables/programdb_similar_item_table.pyi
@@ -2,6 +2,9 @@
 from datetime import date
 from typing import Dict, List, Type, Union
 
+# Third Party Imports
+import treelib
+
 # RAMSTK Package Imports
 from ramstk.analyses import similaritem as similaritem
 from ramstk.views.gtk3 import _ as _
@@ -28,3 +31,4 @@ class RAMSTKSimilarItemTable(RAMSTKBaseTable):
     def do_roll_up_change_descriptions(self, node_id: int) -> None: ...
     def _do_calculate_topic_633(self, node_id: int) -> None: ...
     def _do_calculate_user_defined(self, node_id: int) -> None: ...
+    def _on_insert_hardware(self, tree: treelib.Tree) -> None: ...

--- a/src/ramstk/models/dbviews/programdb_hardware_view.py
+++ b/src/ramstk/models/dbviews/programdb_hardware_view.py
@@ -202,10 +202,6 @@ class RAMSTKHardwareBoMView(RAMSTKBaseView):
         if _record.is_leaf() or _record.data["reliability"].hazard_rate_type_id != 1:
             _attributes = {
                 **_record.data["hardware"].get_attributes(),
-                **_record.data["design_mechanic"].get_attributes(),
-                **_record.data["design_electric"].get_attributes(),
-                **_record.data["milhdbk217f"].get_attributes(),
-                **_record.data["nswc"].get_attributes(),
                 **_record.data["reliability"].get_attributes(),
             }
 
@@ -388,9 +384,6 @@ class RAMSTKHardwareBoMView(RAMSTKBaseView):
                 )
 
             _total_power_dissipation *= _record.data["hardware"].quantity
-            _record.data["design_electric"].set_attributes(
-                {"power_operating": _total_power_dissipation}
-            )
 
         _record.data["hardware"].set_attributes(
             {"total_power_dissipation": _total_power_dissipation}

--- a/src/ramstk/views/gtk3/hardware/view.py
+++ b/src/ramstk/views/gtk3/hardware/view.py
@@ -8,7 +8,6 @@
 """GTK3 Hardware Views."""
 
 # Standard Library Imports
-from copy import copy
 from typing import Any, Dict, List
 
 # Third Party Imports
@@ -204,17 +203,9 @@ class HardwareModuleView(RAMSTKModuleView):
         :param __button: the Gtk.ToolButton() that called this method.
         :return: None
         """
-        _attributes = {
-            "revision_id": self.dic_pkeys["revision_id"],
-            "hardware_id": self.dic_pkeys["hardware_id"],
-            "parent_id": self.dic_pkeys["hardware_id"],
-            "part": 0,
-            "record_id": self.dic_pkeys["record_id"],
-        }
-
         if self._pnlPanel.part == 1:
             _message = _(
-                "You cannot add a sibling item to a part.  First set the "
+                "You cannot add a child item to a part.  First set the "
                 "component category to nothing to convert this part to an "
                 "assembly and then try again."
             )
@@ -231,22 +222,14 @@ class HardwareModuleView(RAMSTKModuleView):
         super().do_set_cursor_busy()
         pub.sendMessage(
             "request_insert_hardware",
-            attributes=copy(_attributes),
+            attributes={
+                "revision_id": self.dic_pkeys["revision_id"],
+                "hardware_id": self.dic_pkeys["hardware_id"],
+                "parent_id": self.dic_pkeys["hardware_id"],
+                "part": 0,
+                "record_id": self.dic_pkeys["record_id"],
+            },
         )
-
-        # See Issue #985.
-        _attributes.pop("part")
-        for _table in [
-            "design_electric",
-            "design_mechanic",
-            "milhdbk217f",
-            "nswc",
-            "reliability",
-        ]:
-            pub.sendMessage(
-                f"request_insert_{_table}",
-                attributes=copy(_attributes),
-            )
 
     def _do_request_insert_part(self, __button: Gtk.ToolButton) -> None:
         """Send request to insert a piece part to the selected Hardware item.
@@ -254,14 +237,6 @@ class HardwareModuleView(RAMSTKModuleView):
         :param __button: the Gtk.ToolButton() that called this method.
         :return: None
         """
-        _attributes = {
-            "revision_id": self.dic_pkeys["revision_id"],
-            "hardware_id": self.dic_pkeys["hardware_id"],
-            "parent_id": self.dic_pkeys["hardware_id"],
-            "part": 1,
-            "record_id": self.dic_pkeys["record_id"],
-        }
-
         if self._pnlPanel.part == 1:
             _message = _(
                 "You cannot add a part to another part.  First set the "
@@ -281,22 +256,14 @@ class HardwareModuleView(RAMSTKModuleView):
         super().do_set_cursor_busy()
         pub.sendMessage(
             "request_insert_hardware",
-            attributes=copy(_attributes),
+            attributes={
+                "revision_id": self.dic_pkeys["revision_id"],
+                "hardware_id": self.dic_pkeys["hardware_id"],
+                "parent_id": self.dic_pkeys["hardware_id"],
+                "part": 1,
+                "record_id": self.dic_pkeys["record_id"],
+            },
         )
-
-        # See Issue #985.
-        _attributes.pop("part")
-        for _table in [
-            "design_electric",
-            "design_mechanic",
-            "milhdbk217f",
-            "nswc",
-            "reliability",
-        ]:
-            pub.sendMessage(
-                f"request_insert_{_table}",
-                attributes=copy(_attributes),
-            )
 
     def _do_request_insert_sibling(self, __button: Gtk.ToolButton) -> Any:
         """Send request to insert a new sibling Hardware item.
@@ -304,14 +271,6 @@ class HardwareModuleView(RAMSTKModuleView):
         :param __button: the Gtk.ToolButton() that called this method.
         :return: None
         """
-        _attributes = {
-            "revision_id": self.dic_pkeys["revision_id"],
-            "hardware_id": self.dic_pkeys["hardware_id"],
-            "parent_id": self.dic_pkeys["parent_id"],
-            "part": 0,
-            "record_id": self.dic_pkeys["record_id"],
-        }
-
         if self.dic_pkeys["parent_id"] == 0:
             _message = _(
                 "You cannot have two top-level items for a single revision.  "
@@ -333,22 +292,14 @@ class HardwareModuleView(RAMSTKModuleView):
         super().do_set_cursor_busy()
         pub.sendMessage(
             "request_insert_hardware",
-            attributes=copy(_attributes),
+            attributes={
+                "revision_id": self.dic_pkeys["revision_id"],
+                "hardware_id": self.dic_pkeys["hardware_id"],
+                "parent_id": self.dic_pkeys["parent_id"],
+                "part": 0,
+                "record_id": self.dic_pkeys["record_id"],
+            },
         )
-
-        # See Issue #985.
-        _attributes.pop("part")
-        for _table in [
-            "design_electric",
-            "design_mechanic",
-            "milhdbk217f",
-            "nswc",
-            "reliability",
-        ]:
-            pub.sendMessage(
-                f"request_insert_{_table}",
-                attributes=copy(_attributes),
-            )
 
     def _do_set_record_id(self, attributes: Dict[str, Any]) -> None:
         """Set the work stream module's record ID and, if any, parent ID.

--- a/tests/__data/test_program_db.sql
+++ b/tests/__data/test_program_db.sql
@@ -1,335 +1,29 @@
-CREATE TABLE ramstk_revision (
-    fld_revision_id INTEGER NOT NULL,
-    fld_availability_logistics FLOAT NOT NULL,
-    fld_availability_mission FLOAT NOT NULL,
-    fld_cost FLOAT NOT NULL,
-    fld_cost_failure FLOAT NOT NULL,
-    fld_cost_hour FLOAT NOT NULL,
-    fld_hazard_rate_active FLOAT NOT NULL,
-    fld_hazard_rate_dormant FLOAT NOT NULL,
-    fld_hazard_rate_logistics FLOAT NOT NULL,
-    fld_hazard_rate_mission FLOAT NOT NULL,
-    fld_hazard_rate_software FLOAT NOT NULL,
-    fld_mmt FLOAT NOT NULL,
-    fld_mcmt FLOAT NOT NULL,
-    fld_mpmt FLOAT NOT NULL,
-    fld_mtbf_logistics FLOAT NOT NULL,
-    fld_mtbf_mission FLOAT NOT NULL,
-    fld_mttr FLOAT NOT NULL,
-    fld_name VARCHAR(128) NOT NULL,
-    fld_reliability_logistics FLOAT NOT NULL,
-    fld_reliability_mission FLOAT NOT NULL,
-    fld_remarks VARCHAR NOT NULL,
-    fld_total_part_count INTEGER NOT NULL,
-    fld_revision_code VARCHAR(8) NOT NULL,
-    fld_program_time FLOAT NOT NULL,
-    fld_program_time_sd FLOAT NOT NULL,
-    fld_program_cost FLOAT NOT NULL,
-    fld_program_cost_sd FLOAT NOT NULL,
-    PRIMARY KEY (fld_revision_id)
-);
-INSERT INTO "ramstk_revision" VALUES(1,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,'Test Revision',1.0,1.0,X'',1,'',0.0,0.0,0.0,0.0);
 INSERT INTO "ramstk_revision" VALUES(2,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,'Test Revision 2',1.0,1.0,X'',1,'',0.0,0.0,0.0,0.0);
-CREATE TABLE ramstk_mission (
-    fld_revision_id INTEGER NOT NULL,
-    fld_mission_id INTEGER NOT NULL,
-    fld_description VARCHAR,
-    fld_mission_time FLOAT,
-    fld_time_units VARCHAR(256),
-    PRIMARY KEY (fld_mission_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_mission" VALUES(1,1,'Test Mission 1',0.0,'hours');
 INSERT INTO "ramstk_mission" VALUES(1,2,'Test Mission 2',0.0,'hours');
 INSERT INTO "ramstk_mission" VALUES(1,3,'Test Mission 3',0.0,'hours');
-CREATE TABLE ramstk_mission_phase (
-    fld_revision_id INTEGER NOT NULL,
-    fld_mission_id INTEGER NOT NULL,
-    fld_mission_phase_id INTEGER NOT NULL,
-    fld_description VARCHAR,
-    fld_name VARCHAR(256),
-    fld_phase_start FLOAT,
-    fld_phase_end FLOAT,
-    PRIMARY KEY (fld_mission_phase_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_mission_id) REFERENCES ramstk_mission (fld_mission_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_mission_phase" VALUES(1,1,1,'Test Mission Phase 1','',0.0,0.0);
 INSERT INTO "ramstk_mission_phase" VALUES(1,2,2,'Test Mission Phase 2','',0.0,0.0);
 INSERT INTO "ramstk_mission_phase" VALUES(1,3,3,'Test Mission Phase 3','',0.0,0.0);
-CREATE TABLE ramstk_environment (
-    fld_revision_id INTEGER NOT NULL,
-    fld_mission_id INTEGER NOT NULL,
-    fld_mission_phase_id INTEGER NOT NULL,
-    fld_environment_id INTEGER NOT NULL,
-    fld_name VARCHAR(256),
-    fld_units VARCHAR(128),
-    fld_minimum FLOAT,
-    fld_maximum FLOAT,
-    fld_mean FLOAT,
-    fld_variance FLOAT,
-    fld_ramp_rate FLOAT,
-    fld_low_dwell_time FLOAT,
-    fld_high_dwell_time FLOAT,
-    PRIMARY KEY (fld_environment_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_mission_id) REFERENCES ramstk_mission (fld_mission_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_mission_phase_id) REFERENCES ramstk_mission_phase (fld_mission_phase_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_environment" VALUES(1,1,1,1,'Condition Name','Units',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
 INSERT INTO "ramstk_environment" VALUES(1,2,2,2,'Condition Name 2','Units',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
 INSERT INTO "ramstk_environment" VALUES(1,3,3,3,'Condition Name 3','Units',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-CREATE TABLE ramstk_program_info (
-    fld_revision_id INTEGER NOT NULL,
-    fld_function_active INTEGER,
-    fld_requirement_active INTEGER,
-    fld_hardware_active INTEGER,
-    fld_software_active INTEGER,
-    fld_rcm_active INTEGER,
-    fld_testing_active INTEGER,
-    fld_incident_active INTEGER,
-    fld_survival_active INTEGER,
-    fld_vandv_active INTEGER,
-    fld_hazard_active INTEGER,
-    fld_stakeholder_active INTEGER,
-    fld_allocation_active INTEGER,
-    fld_similar_item_active INTEGER,
-    fld_fmea_active INTEGER,
-    fld_pof_active INTEGER,
-    fld_rbd_active INTEGER,
-    fld_fta_active INTEGER,
-    fld_created_on DATE DEFAULT CURRENT_DATE,
-    fld_created_by VARCHAR(512),
-    fld_last_saved_on DATE DEFAULT CURRENT_DATE,
-    fld_last_saved_by VARCHAR(512),
-    PRIMARY KEY (fld_revision_id)
-);
-INSERT INTO "ramstk_program_info" VALUES(1,1,1,1,0,0,0,0,0,1,1,1,1,1,1,1,0,0,CURRENT_DATE,'',CURRENT_DATE,'');
-CREATE TABLE ramstk_program_status (
-    fld_revision_id INTEGER NOT NULL,
-    fld_status_id INTEGER NOT NULL,
-    fld_cost_remaining FLOAT,
-    fld_date_status DATE,
-    fld_time_remaining FLOAT,
-    PRIMARY KEY (fld_status_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id),
-    UNIQUE (fld_date_status)
-);
 INSERT INTO "ramstk_program_status" VALUES(1,1,0.0,CURRENT_DATE-30,0.0);
 INSERT INTO "ramstk_program_status" VALUES(1,2,0.0,CURRENT_DATE-20,0.0);
 INSERT INTO "ramstk_program_status" VALUES(1,3,0.0,CURRENT_DATE-10,0.0);
-
-CREATE TABLE ramstk_function (
-    fld_revision_id INTEGER NOT NULL,
-    fld_function_id INTEGER NOT NULL,
-    fld_availability_logistics FLOAT,
-    fld_availability_mission FLOAT,
-    fld_cost FLOAT,
-    fld_function_code VARCHAR(16),
-    fld_hazard_rate_logistics FLOAT,
-    fld_hazard_rate_mission FLOAT,
-    fld_level INTEGER,
-    fld_mmt FLOAT,
-    fld_mcmt FLOAT,
-    fld_mpmt FLOAT,
-    fld_mtbf_logistics FLOAT,
-    fld_mtbf_mission FLOAT,
-    fld_mttr FLOAT,
-    fld_name VARCHAR(256),
-    fld_parent_id INTEGER,
-    fld_remarks VARCHAR,
-    fld_safety_critical INTEGER,
-    fld_total_mode_count INTEGER,
-    fld_total_part_count INTEGER,
-    fld_type_id INTEGER,
-    PRIMARY KEY (fld_function_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_function" VALUES(1,1,1.0,1.0,0.0,'FUNC-0001',0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,'Function Name',0,'',0,0,0,0);
 INSERT INTO "ramstk_function" VALUES(1,2,1.0,1.0,0.0,'FUNC-0002',0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,'Function Name',1,'',0,0,0,0);
 INSERT INTO "ramstk_function" VALUES(1,3,1.0,1.0,0.0,'FUNC-0003',0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,'Function Name',0,'',0,0,0,0);
-CREATE TABLE ramstk_failure_definition (
-    fld_revision_id INTEGER NOT NULL,
-    fld_function_id INTEGER NOT NULL,
-    fld_definition_id INTEGER NOT NULL,
-    fld_definition VARCHAR(1024),
-    PRIMARY KEY (fld_definition_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_function_id) REFERENCES ramstk_function (fld_function_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_failure_definition" VALUES(1,1,1,'Failure Definition');
 INSERT INTO "ramstk_failure_definition" VALUES(1,1,2,'Failure Definition');
 INSERT INTO "ramstk_failure_definition" VALUES(1,1,3,'Failure Definition');
-CREATE TABLE ramstk_hazard_analysis (
-    fld_revision_id INTEGER NOT NULL,
-    fld_function_id INTEGER NOT NULL,
-    fld_hazard_id INTEGER NOT NULL,
-    fld_potential_hazard VARCHAR(256),
-    fld_potential_cause VARCHAR(512),
-    fld_assembly_effect VARCHAR(512),
-    fld_assembly_severity VARCHAR(256),
-    fld_assembly_probability VARCHAR(256),
-    fld_assembly_hri INTEGER,
-    fld_assembly_mitigation VARCHAR,
-    fld_assembly_severity_f VARCHAR(256),
-    fld_assembly_probability_f VARCHAR(256),
-    fld_assembly_hri_f INTEGER,
-    fld_function_1 VARCHAR(128),
-    fld_function_2 VARCHAR(128),
-    fld_function_3 VARCHAR(128),
-    fld_function_4 VARCHAR(128),
-    fld_function_5 VARCHAR(128),
-    fld_remarks VARCHAR,
-    fld_result_1 FLOAT,
-    fld_result_2 FLOAT,
-    fld_result_3 FLOAT,
-    fld_result_4 FLOAT,
-    fld_result_5 FLOAT,
-    fld_system_effect VARCHAR(512),
-    fld_system_severity VARCHAR(256),
-    fld_system_probability VARCHAR(256),
-    fld_system_hri INTEGER,
-    fld_system_mitigation VARCHAR,
-    fld_system_severity_f VARCHAR(256),
-    fld_system_probability_f VARCHAR(256),
-    fld_system_hri_f INTEGER,
-    fld_user_blob_1 VARCHAR,
-    fld_user_blob_2 VARCHAR,
-    fld_user_blob_3 VARCHAR,
-    fld_user_float_1 FLOAT,
-    fld_user_float_2 FLOAT,
-    fld_user_float_3 FLOAT,
-    fld_user_int_1 INTEGER,
-    fld_user_int_2 INTEGER,
-    fld_user_int_3 INTEGER,
-    PRIMARY KEY (fld_hazard_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_function_id) REFERENCES ramstk_function (fld_function_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_hazard_analysis" VALUES(1,1,1,'','','','Major','Level A - Frequent',20,'','Medium','Level A - Frequent',4,'uf1*uf2','res1/ui1','','','','',0.0,0.0,0.0,0.0,0.0,'','Medium','Level A - Frequent',20,'','Medium','Level A - Frequent',20,'','','',1.5,0.8,0.0,2,0,0);
 INSERT INTO "ramstk_hazard_analysis" VALUES(1,2,2,'','','','Major','Level A - Frequent',20,'','Major','Level A - Frequent',20,'','','','','','',0.0,0.0,0.0,0.0,0.0,'','Major','Level A - Frequent',20,'','Major','Level A - Frequent',20,'','','',0.0,0.0,0.0,0,0,0);
 INSERT INTO "ramstk_hazard_analysis" VALUES(1,3,3,'','','','Major','Level A - Frequent',20,'','Major','Level A - Frequent',20,'','','','','','',0.0,0.0,0.0,0.0,0.0,'','Major','Level A - Frequent',20,'','Major','Level A - Frequent',20,'','','',0.0,0.0,0.0,0,0,0);
 INSERT INTO "ramstk_hazard_analysis" VALUES(1,1,4,'','','','Medium','Level A - Frequent',20,'','Medium','Level A - Frequent',4,'','','','','','',0.0,0.0,0.0,0.0,0.0,'','Medium','Level A - Frequent',20,'','Medium','Level A - Frequent',20,'','','',0.0,0.0,0.0,0,0,0);
-
-CREATE TABLE ramstk_requirement (
-    fld_revision_id INTEGER NOT NULL,
-    fld_requirement_id INTEGER NOT NULL,
-    fld_derived INTEGER,
-    fld_description VARCHAR,
-    fld_figure_number VARCHAR(256),
-    fld_owner INTEGER,
-    fld_page_number VARCHAR(256),
-    fld_parent_id INTEGER,
-    fld_priority INTEGER,
-    fld_requirement_code VARCHAR(256),
-    fld_specification VARCHAR(256),
-    fld_requirement_type INTEGER,
-    fld_validated INTEGER,
-    fld_validated_date DATE,
-    fld_clarity_0 INTEGER,
-    fld_clarity_1 INTEGER,
-    fld_clarity_2 INTEGER,
-    fld_clarity_3 INTEGER,
-    fld_clarity_4 INTEGER,
-    fld_clarity_5 INTEGER,
-    fld_clarity_6 INTEGER,
-    fld_clarity_7 INTEGER,
-    fld_clarity_8 INTEGER,
-    fld_complete_0 INTEGER,
-    fld_complete_1 INTEGER,
-    fld_complete_2 INTEGER,
-    fld_complete_3 INTEGER,
-    fld_complete_4 INTEGER,
-    fld_complete_5 INTEGER,
-    fld_complete_6 INTEGER,
-    fld_complete_7 INTEGER,
-    fld_complete_8 INTEGER,
-    fld_complete_9 INTEGER,
-    fld_consistent_0 INTEGER,
-    fld_consistent_1 INTEGER,
-    fld_consistent_2 INTEGER,
-    fld_consistent_3 INTEGER,
-    fld_consistent_4 INTEGER,
-    fld_consistent_5 INTEGER,
-    fld_consistent_6 INTEGER,
-    fld_consistent_7 INTEGER,
-    fld_consistent_8 INTEGER,
-    fld_verifiable_0 INTEGER,
-    fld_verifiable_1 INTEGER,
-    fld_verifiable_2 INTEGER,
-    fld_verifiable_3 INTEGER,
-    fld_verifiable_4 INTEGER,
-    fld_verifiable_5 INTEGER,
-    PRIMARY KEY (fld_requirement_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_requirement" VALUES(1,1,0,'','',0,'',0,0,'REL-0001','',0,0,'2019-07-21',0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
 INSERT INTO "ramstk_requirement" VALUES(1,2,0,'','',0,'',0,0,'FUN-0002','',0,0,'2019-07-21',0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
 INSERT INTO "ramstk_requirement" VALUES(1,3,0,'','',0,'',0,0,'PRF-0003','',0,0,'2019-07-21',0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
 INSERT INTO "ramstk_requirement" VALUES(1,4,0,'','',0,'',1,0,'REL-0002','',0,0,'2019-07-21',0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
-CREATE TABLE ramstk_stakeholder (
-    fld_revision_id INTEGER NOT NULL,
-    fld_stakeholder_id INTEGER NOT NULL,
-    fld_customer_rank INTEGER,
-    fld_description TEXT,
-    fld_group VARCHAR(128),
-    fld_improvement FLOAT,
-    fld_overall_weight FLOAT,
-    fld_planned_rank INTEGER,
-    fld_priority INTEGER,
-    fld_requirement_id INTEGER,
-    fld_stakeholder VARCHAR(128),
-    fld_user_float_1 FLOAT,
-    fld_user_float_2 FLOAT,
-    fld_user_float_3 FLOAT,
-    fld_user_float_4 FLOAT,
-    fld_user_float_5 FLOAT,
-    PRIMARY KEY (fld_stakeholder_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_stakeholder" VALUES(1,1,1,'Test Stakeholder Input','',0.0,0.0,1,1,0,'',1.0,1.0,1.0,1.0,1.0);
 INSERT INTO "ramstk_stakeholder" VALUES(1,2,1,'Test Stakeholder Input 2','',0.0,0.0,1,1,0,'',1.0,1.0,1.0,1.0,1.0);
-
-CREATE TABLE ramstk_hardware (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_alt_part_number VARCHAR(256),
-    fld_attachments VARCHAR(512),
-    fld_cage_code VARCHAR(256),
-    fld_category_id INTEGER,
-    fld_comp_ref_des VARCHAR(256),
-    fld_cost FLOAT,
-    fld_cost_failure FLOAT,
-    fld_cost_hour FLOAT,
-    fld_cost_type_id INTEGER,
-    fld_description VARCHAR(512),
-    fld_duty_cycle FLOAT,
-    fld_figure_number VARCHAR(256),
-    fld_lcn VARCHAR(256),
-    fld_level INTEGER,
-    fld_manufacturer_id INTEGER,
-    fld_mission_time FLOAT,
-    fld_name VARCHAR(256),
-    fld_nsn VARCHAR(256),
-    fld_page_number VARCHAR(256),
-    fld_parent_id INTEGER,
-    fld_part INTEGER,
-    fld_part_number VARCHAR(256),
-    fld_quantity INTEGER,
-    fld_ref_des VARCHAR(256),
-    fld_remarks VARCHAR,
-    fld_repairable INTEGER,
-    fld_specification_number VARCHAR(256),
-    fld_subcategory_id INTEGER,
-    fld_tagged_part INTEGER,
-    fld_total_cost FLOAT,
-    fld_total_part_count INTEGER,
-    fld_total_power_dissipation FLOAT,
-    fld_year_of_manufacture INTEGER,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_hardware" VALUES(1,1,'','','',0,'S1',5.28,0.0,1.85263157894736840859e-05,2,'Test System',100.0,'','',0,0,10.0,'','','',0,0,'',1,'S1','',0,'',0,0,5.28,10,0.0,2019);
 INSERT INTO "ramstk_hardware" VALUES(1,2,'','','',0,'S1:SS1',0.0,0.0,0.0,0,'Test Sub-System 1',100.0,'','',0,0,100.0,'','','',1,0,'',1,'SS1','',0,'',0,0,0.0,0,0.0,2019);
 INSERT INTO "ramstk_hardware" VALUES(1,3,'','','',0,'S1:SS2',1282.95,0.0,0.0,0,'Test Sub-System 2',100.0,'','',0,0,100.0,'','','',1,0,'',1,'SS2','',0,'',0,0,0.0,55,4.67,2019);
 INSERT INTO "ramstk_hardware" VALUES(1,4,'','','',0,'S1:SS3',0.0,0.0,0.0,0,'Test Sub-System 3',100.0,'','',0,0,100.0,'','','',1,0,'',1,'SS3','',0,'',0,0,0.0,0,0.0,2019);
@@ -337,1176 +31,741 @@ INSERT INTO "ramstk_hardware" VALUES(1,5,'','','',0,'S1:SS4',438.19,0.0,0.0,0,'T
 INSERT INTO "ramstk_hardware" VALUES(1,6,'','','',0,'S1:SS1:A1',832.98,0.0,0.0,0,'Test Assembly 1',100.0,'','',0,0,100.0,'Test Assembly 6','','',2,0,'',1,'A1','',0,'',0,0,0.0,132,12.3,2019);
 INSERT INTO "ramstk_hardware" VALUES(1,7,'','','',0,'S1:SS1:A2',1432.86,0.0,0.0,0,'Test Assembly 2',100.0,'','',0,0,100.0,'Test Assembly 7','','',2,0,'',1,'A2','',0,'',0,0,0.0,26,0.967,2019);
 INSERT INTO "ramstk_hardware" VALUES(1,8,'','','',4,'S1:SS1:A2:C1',0.0,0.0,0.0,0,'Test Capacitor 1',100.0,'','',0,0,100.0,'Test Capacitor','','',7,1,'',1,'C1','',0,'',1,0,0.0,0,0.0,2019);
-CREATE TABLE ramstk_allocation (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_availability_alloc FLOAT,
-    fld_duty_cycle FLOAT,
-    fld_env_factor INTEGER,
-    fld_goal_measure_id INTEGER,
-    fld_hazard_rate_alloc FLOAT,
-    fld_hazard_rate_goal FLOAT,
-    fld_included INTEGER,
-    fld_int_factor INTEGER,
-    fld_allocation_method_id INTEGER,
-    fld_mission_time FLOAT,
-    fld_mtbf_alloc FLOAT,
-    fld_mtbf_goal FLOAT,
-    fld_n_sub_systems INTEGER,
-    fld_n_sub_elements INTEGER,
-    fld_parent_id INTEGER,
-    fld_percent_weight_factor FLOAT,
-    fld_reliability_alloc FLOAT,
-    fld_reliability_goal FLOAT,
-    fld_op_time_factor INTEGER,
-    fld_soa_factor INTEGER,
-    fld_weight_factor INTEGER,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_allocation" VALUES(1,1,0.0,100.0,1,1,0.0,0.0,1,1,1,10.0,0.0,0.0,1,1,0,0.0,1.0,1.0,1,1,1);
-INSERT INTO "ramstk_allocation" VALUES(1,2,0.0,100.0,1,1,0.0,0.000617,1,1,4,100.0,0.0,0.0,1,1,1,0.0,1.0,0.995,1,1,1);
-INSERT INTO "ramstk_allocation" VALUES(1,3,0.0,100.0,1,1,0.0,0.0,1,1,1,100.0,0.0,0.0,1,1,1,0.0,1.0,1.0,1,1,1);
-INSERT INTO "ramstk_allocation" VALUES(1,4,0.0,80.0,6,1,0.000157531914893617,0.0,1,3,1,100.0,6.3479200432198813358e+03,12000.0,1,2,2,0.0,9.84370241029675296928e-01,0.9995,9,2,0.8);
-INSERT INTO "ramstk_allocation" VALUES(1,5,0.0,90.0,3,1,4.59468085106382972786e-04,0.0,1,5,1,100.0,2.17642972910395928929e+03,0.0,1,4,2,0.0,0.955092763646177,1.0,9,7,0.95);
-CREATE TABLE ramstk_design_electric (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_application_id INTEGER,
-    fld_area FLOAT,
-    fld_capacitance FLOAT,
-    fld_configuration_id INTEGER,
-    fld_construction_id INTEGER,
-    fld_contact_form_id INTEGER,
-    fld_contact_gauge INTEGER,
-    fld_contact_rating_id INTEGER,
-    fld_current_operating FLOAT,
-    fld_current_rated FLOAT,
-    fld_current_ratio FLOAT,
-    fld_environment_active_id INTEGER,
-    fld_environment_dormant_id INTEGER,
-    fld_family_id INTEGER,
-    fld_feature_size FLOAT,
-    fld_frequency_operating FLOAT,
-    fld_insert_id INTEGER,
-    fld_insulation_id INTEGER,
-    fld_manufacturing_id INTEGER,
-    fld_matching_id INTEGER,
-    fld_n_active_pins INTEGER,
-    fld_n_circuit_planes INTEGER,
-    fld_n_cycles FLOAT,
-    fld_n_elements INTEGER,
-    fld_n_hand_soldered INTEGER,
-    fld_n_wave_soldered INTEGER,
-    fld_operating_life FLOAT,
-    fld_overstress INTEGER,
-    fld_package_id INTEGER,
-    fld_power_operating FLOAT,
-    fld_power_rated FLOAT,
-    fld_power_ratio FLOAT,
-    fld_reason VARCHAR,
-    fld_resistance FLOAT,
-    fld_specification_id INTEGER,
-    fld_technology_id INTEGER,
-    fld_temperature_active FLOAT,
-    fld_temperature_case FLOAT,
-    fld_temperature_dormant FLOAT,
-    fld_temperature_hot_spot FLOAT,
-    fld_temperature_junction FLOAT,
-    fld_temperature_knee FLOAT,
-    fld_temperature_rated_max FLOAT,
-    fld_temperature_rated_min FLOAT,
-    fld_temperature_rise FLOAT,
-    fld_theta_jc FLOAT,
-    fld_type_id INTEGER,
-    fld_voltage_ac_operating FLOAT,
-    fld_voltage_dc_operating FLOAT,
-    fld_voltage_esd FLOAT,
-    fld_voltage_rated FLOAT,
-    fld_voltage_ratio FLOAT,
-    fld_weight FLOAT,
-    fld_years_in_production INTEGER,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_design_electric" VALUES(1,1,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-INSERT INTO "ramstk_design_electric" VALUES(1,2,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-INSERT INTO "ramstk_design_electric" VALUES(1,3,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-INSERT INTO "ramstk_design_electric" VALUES(1,4,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-INSERT INTO "ramstk_design_electric" VALUES(1,5,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-INSERT INTO "ramstk_design_electric" VALUES(1,6,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-INSERT INTO "ramstk_design_electric" VALUES(1,7,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-INSERT INTO "ramstk_design_electric" VALUES(1,8,0,0.0,0.0,0,0,0,0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,1);
-CREATE TABLE ramstk_design_mechanic (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_altitude_operating FLOAT,
-    fld_application_id INTEGER,
-    fld_balance_id INTEGER,
-    fld_clearance FLOAT,
-    fld_casing_id INTEGER,
-    fld_contact_pressure FLOAT,
-    fld_deflection FLOAT,
-    fld_diameter_coil FLOAT,
-    fld_diameter_inner FLOAT,
-    fld_diameter_outer FLOAT,
-    fld_diameter_wire FLOAT,
-    fld_filter_size FLOAT,
-    fld_flow_design FLOAT,
-    fld_flow_operating FLOAT,
-    fld_frequency_operating FLOAT,
-    fld_friction FLOAT,
-    fld_impact_id INTEGER,
-    fld_leakage_allowable FLOAT,
-    fld_length FLOAT,
-    fld_length_compressed FLOAT,
-    fld_length_relaxed FLOAT,
-    fld_load_design FLOAT,
-    fld_load_id INTEGER,
-    fld_load_operating FLOAT,
-    fld_lubrication_id INTEGER,
-    fld_manufacturing_id INTEGER,
-    fld_material_id INTEGER,
-    fld_meyer_hardness FLOAT,
-    fld_misalignment_angle FLOAT,
-    fld_n_ten INTEGER,
-    fld_n_cycles INTEGER,
-    fld_n_elements INTEGER,
-    fld_offset FLOAT,
-    fld_particle_size FLOAT,
-    fld_pressure_contact FLOAT,
-    fld_pressure_delta FLOAT,
-    fld_pressure_downstream FLOAT,
-    fld_pressure_rated FLOAT,
-    fld_pressure_upstream FLOAT,
-    fld_rpm_design FLOAT,
-    fld_rpm_operating FLOAT,
-    fld_service_id INTEGER,
-    fld_spring_index FLOAT,
-    fld_surface_finish FLOAT,
-    fld_technology_id INTEGER,
-    fld_thickness FLOAT,
-    fld_torque_id INTEGER,
-    fld_type_id INTEGER,
-    fld_viscosity_design FLOAT,
-    fld_viscosity_dynamic FLOAT,
-    fld_water_per_cent FLOAT,
-    fld_width_minimum FLOAT,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,1,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,2,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,3,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,4,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,5,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,6,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,7,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_design_mechanic" VALUES(1,8,0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0);
-CREATE TABLE ramstk_mil_hdbk_f (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_a_one FLOAT,
-    fld_a_two FLOAT,
-    fld_b_one FLOAT,
-    fld_b_two FLOAT,
-    fld_c_one FLOAT,
-    fld_c_two FLOAT,
-    fld_lambda_bd FLOAT,
-    fld_lambda_bp FLOAT,
-    fld_lambda_cyc FLOAT,
-    fld_lambda_eos FLOAT,
-    fld_pi_a FLOAT,
-    fld_pi_c FLOAT,
-    fld_pi_cd FLOAT,
-    fld_pi_cf FLOAT,
-    fld_pi_cr FLOAT,
-    fld_pi_cv FLOAT,
-    fld_pi_cyc FLOAT,
-    fld_pi_e FLOAT,
-    fld_pi_f FLOAT,
-    fld_pi_i FLOAT,
-    fld_pi_k FLOAT,
-    fld_pi_l FLOAT,
-    fld_pi_m FLOAT,
-    fld_pi_mfg FLOAT,
-    fld_pi_n FLOAT,
-    fld_pi_nr FLOAT,
-    fld_pi_p FLOAT,
-    fld_pi_pt FLOAT,
-    fld_pi_q FLOAT,
-    fld_pi_r FLOAT,
-    fld_pi_s FLOAT,
-    fld_pi_t FLOAT,
-    fld_pi_taps FLOAT,
-    fld_pi_u FLOAT,
-    fld_pi_v FLOAT,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,2,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,4,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,5,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,6,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,7,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_mil_hdbk_f" VALUES(1,8,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-CREATE TABLE ramstk_nswc (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_c_ac FLOAT,
-    fld_c_alt FLOAT,
-    fld_c_b FLOAT,
-    fld_c_bl FLOAT,
-    fld_c_bt FLOAT,
-    fld_c_bv FLOAT,
-    fld_c_c FLOAT,
-    fld_c_cf FLOAT,
-    fld_c_cp FLOAT,
-    fld_c_cs FLOAT,
-    fld_c_cv FLOAT,
-    fld_c_cw FLOAT,
-    fld_c_d FLOAT,
-    fld_c_dc FLOAT,
-    fld_c_dl FLOAT,
-    fld_c_dp FLOAT,
-    fld_c_ds FLOAT,
-    fld_c_dt FLOAT,
-    fld_c_dw FLOAT,
-    fld_c_dy FLOAT,
-    fld_c_e FLOAT,
-    fld_c_f FLOAT,
-    fld_c_g FLOAT,
-    fld_c_ga FLOAT,
-    fld_c_gl FLOAT,
-    fld_c_gp FLOAT,
-    fld_c_gs FLOAT,
-    fld_c_gt FLOAT,
-    fld_c_gv FLOAT,
-    fld_c_h FLOAT,
-    fld_c_i FLOAT,
-    fld_c_k FLOAT,
-    fld_c_l FLOAT,
-    fld_c_lc FLOAT,
-    fld_c_m FLOAT,
-    fld_c_mu FLOAT,
-    fld_c_n FLOAT,
-    fld_c_np FLOAT,
-    fld_c_nw FLOAT,
-    fld_c_p FLOAT,
-    fld_c_pd FLOAT,
-    fld_c_pf FLOAT,
-    fld_c_pv FLOAT,
-    fld_c_q FLOAT,
-    fld_c_r FLOAT,
-    fld_c_rd FLOAT,
-    fld_c_s FLOAT,
-    fld_c_sc FLOAT,
-    fld_c_sf FLOAT,
-    fld_c_st FLOAT,
-    fld_c_sv FLOAT,
-    fld_c_sw FLOAT,
-    fld_c_sz FLOAT,
-    fld_c_t FLOAT,
-    fld_c_v FLOAT,
-    fld_c_w FLOAT,
-    fld_c_y FLOAT,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_nswc" VALUES(1,1,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_nswc" VALUES(1,2,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_nswc" VALUES(1,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_nswc" VALUES(1,4,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_nswc" VALUES(1,5,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_nswc" VALUES(1,6,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_nswc" VALUES(1,7,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-INSERT INTO "ramstk_nswc" VALUES(1,8,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-CREATE TABLE ramstk_reliability (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_add_adj_factor FLOAT,
-    fld_availability_logistics FLOAT,
-    fld_availability_mission FLOAT,
-    fld_avail_log_variance FLOAT,
-    fld_avail_mis_variance FLOAT,
-    fld_failure_distribution_id INTEGER,
-    fld_hazard_rate_active FLOAT,
-    fld_hazard_rate_dormant FLOAT,
-    fld_hazard_rate_logistics FLOAT,
-    fld_hazard_rate_method_id INTEGER,
-    fld_hazard_rate_mission FLOAT,
-    fld_hazard_rate_model VARCHAR(512),
-    fld_hazard_rate_percent FLOAT,
-    fld_hazard_rate_software FLOAT,
-    fld_hazard_rate_specified FLOAT,
-    fld_hazard_rate_type_id INTEGER,
-    fld_hr_active_variance FLOAT,
-    fld_hr_dormant_variance FLOAT,
-    fld_hr_log_variance FLOAT,
-    fld_hr_mis_variance FLOAT,
-    fld_hr_spec_variance FLOAT,
-    fld_lambda_b FLOAT,
-    fld_location_parameter FLOAT,
-    fld_mtbf_logistics FLOAT,
-    fld_mtbf_mission FLOAT,
-    fld_mtbf_specified FLOAT,
-    fld_mtbf_log_variance FLOAT,
-    fld_mtbf_mis_variance FLOAT,
-    fld_mtbf_spec_variance FLOAT,
-    fld_mult_adj_factor FLOAT,
-    fld_quality_id INTEGER,
-    fld_reliability_goal FLOAT,
-    fld_reliability_goal_measure_id INTEGER,
-    fld_reliability_logistics FLOAT,
-    fld_reliability_mission FLOAT,
-    fld_reliability_log_variance FLOAT,
-    fld_reliability_mis_variance FLOAT,
-    fld_scale_parameter FLOAT,
-    fld_shape_parameter FLOAT,
-    fld_survival_analysis_id INTEGER,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_reliability" VALUES(1,1,0.0,1.0,1.0,0.0,0.0,0,0.0,0.0,0.0,0,0.0,'',0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-INSERT INTO "ramstk_reliability" VALUES(1,2,0.0,1.0,1.0,0.0,0.0,0,0.00617,0.0,0.0,0,0.0,'',0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-INSERT INTO "ramstk_reliability" VALUES(1,3,0.0,1.0,1.0,0.0,0.0,0,0.0,0.0,0.0,0,0.0,'',0.0,0.045,0.0,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,38292.0,0.0,0.0,0.0,1.0,0,0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-INSERT INTO "ramstk_reliability" VALUES(1,4,0.0,1.0,1.0,0.0,0.0,0,0.0,0.0,0.0,0,0.0,'',0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-INSERT INTO "ramstk_reliability" VALUES(1,5,0.0,1.0,1.0,0.0,0.0,0,0.0,0.0035,0.0,0,0.0,'',0.0,0.0,0.15,2,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-INSERT INTO "ramstk_reliability" VALUES(1,6,0.0,1.0,1.0,0.0,0.0,0,2.89e-06,0.0,0.0,0,0.0,'',0.0,2.3,0.045,2,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,0.9995,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-INSERT INTO "ramstk_reliability" VALUES(1,7,0.0,1.0,1.0,0.0,0.0,0,1.132e-07,0.0,0.0,0,0.0,'',0.0,0.0,0.0,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,89560.0,0.0,0.0,0.0,1.0,0,0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-INSERT INTO "ramstk_reliability" VALUES(1,8,0.0,1.0,1.0,0.0,0.0,0,1.132e-07,0.0,0.0,0,0.0,'',0.0,0.0,0.0,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,89560.0,0.0,0.0,0.0,1.0,0,0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0);
-CREATE TABLE ramstk_similar_item (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_change_description_1 VARCHAR,
-    fld_change_description_2 VARCHAR,
-    fld_change_description_3 VARCHAR,
-    fld_change_description_4 VARCHAR,
-    fld_change_description_5 VARCHAR,
-    fld_change_description_6 VARCHAR,
-    fld_change_description_7 VARCHAR,
-    fld_change_description_8 VARCHAR,
-    fld_change_description_9 VARCHAR,
-    fld_change_description_10 VARCHAR,
-    fld_change_factor_1 FLOAT,
-    fld_change_factor_2 FLOAT,
-    fld_change_factor_3 FLOAT,
-    fld_change_factor_4 FLOAT,
-    fld_change_factor_5 FLOAT,
-    fld_change_factor_6 FLOAT,
-    fld_change_factor_7 FLOAT,
-    fld_change_factor_8 FLOAT,
-    fld_change_factor_9 FLOAT,
-    fld_change_factor_10 FLOAT,
-    fld_environment_from_id INTEGER,
-    fld_environment_to_id INTEGER,
-    fld_function_1 VARCHAR(128),
-    fld_function_2 VARCHAR(128),
-    fld_function_3 VARCHAR(128),
-    fld_function_4 VARCHAR(128),
-    fld_function_5 VARCHAR(128),
-    fld_similar_item_method_id INTEGER,
-    fld_parent_id INTEGER,
-    fld_quality_from_id INTEGER,
-    fld_quality_to_id INTEGER,
-    fld_result_1 FLOAT,
-    fld_result_2 FLOAT,
-    fld_result_3 FLOAT,
-    fld_result_4 FLOAT,
-    fld_result_5 FLOAT,
-    fld_temperature_from FLOAT,
-    fld_temperature_to FLOAT,
-    fld_user_blob_1 VARCHAR,
-    fld_user_blob_2 VARCHAR,
-    fld_user_blob_3 VARCHAR,
-    fld_user_blob_4 VARCHAR,
-    fld_user_blob_5 VARCHAR,
-    fld_user_float_1 FLOAT,
-    fld_user_float_2 FLOAT,
-    fld_user_float_3 FLOAT,
-    fld_user_float_4 FLOAT,
-    fld_user_float_5 FLOAT,
-    fld_user_int_1 INTEGER,
-    fld_user_int_2 INTEGER,
-    fld_user_int_3 INTEGER,
-    fld_user_int_4 INTEGER,
-    fld_user_int_5 INTEGER,
-    PRIMARY KEY (fld_hardware_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_similar_item" VALUES(1,1,'','','','','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0','0','0','0',1,0,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
-INSERT INTO "ramstk_similar_item" VALUES(1,2,'','','','','','','','','','',0.85,1.2,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,2,3,'pi1*pi2*hr','0','0','0','0',2,1,1,2,0.0,0.0,0.0,0.0,0.0,55.0,65.0,'','','','','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
-INSERT INTO "ramstk_similar_item" VALUES(1,3,'','','','','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0','0','0','0',1,1,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
-INSERT INTO "ramstk_similar_item" VALUES(1,4,'','','','','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0','0','0','0',1,3,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
-INSERT INTO "ramstk_similar_item" VALUES(1,5,'','','','','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0','0','0','0',1,1,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
-INSERT INTO "ramstk_similar_item" VALUES(1,6,'54686973206973206368616E67652064656372697074696F6E203120666F7220617373656D626C792036','54686973206973206368616E67652064656372697074696F6E203220666F7220617373656D626C792036','54686973206973206368616E67652064656372697074696F6E203320666F7220617373656D626C792036','','','','','','','',1.0,1.0,1.0,1.0,0.95,1.0,1.0,1.0,1.0,1.0,0,0,'0','0','0','0','0',1,2,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
-INSERT INTO "ramstk_similar_item" VALUES(1,7,'54686973206973206368616E67652064656372697074696F6E203120666F7220617373656D626C792037','54686973206973206368616E67652064656372697074696F6E203220666F7220617373656D626C792037','54686973206973206368616E67652064656372697074696F6E203320666F7220617373656D626C792037','','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0','0','0','0',1,2,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0);
-CREATE TABLE ramstk_mode (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_critical_item INTEGER,
-    fld_description VARCHAR(512),
-    fld_design_provisions VARCHAR,
-    fld_detection_method VARCHAR(512),
-    fld_effect_end VARCHAR(512),
-    fld_effect_local VARCHAR(512),
-    fld_effect_next VARCHAR(512),
-    fld_effect_probability FLOAT,
-    fld_hazard_rate_source VARCHAR(512),
-    fld_isolation_method VARCHAR(512),
-    fld_mission VARCHAR(64),
-    fld_mission_phase VARCHAR(64),
-    fld_mode_criticality FLOAT,
-    fld_mode_hazard_rate FLOAT,
-    fld_mode_op_time FLOAT,
-    fld_mode_probability VARCHAR(64),
-    fld_mode_ratio FLOAT,
-    fld_operator_actions VARCHAR,
-    fld_other_indications VARCHAR(512),
-    fld_remarks VARCHAR,
-    fld_rpn_severity INTEGER,
-    fld_rpn_severity_new INTEGER,
-    fld_severity_class VARCHAR(64),
-    fld_single_point INTEGER,
-    fld_type_id INTEGER,
-    PRIMARY KEY(fld_mode_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_hardware_id) REFERENCES ramstk_hardware (fld_hardware_id) ON DELETE CASCADE
-);
+
+UPDATE "ramstk_allocation" SET (fld_availability_alloc, fld_duty_cycle,
+    fld_env_factor, fld_goal_measure_id, fld_hazard_rate_alloc,
+    fld_hazard_rate_goal, fld_included, fld_int_factor,
+    fld_allocation_method_id, fld_mission_time, fld_mtbf_alloc,
+    fld_mtbf_goal, fld_n_sub_systems, fld_n_sub_elements,
+    fld_parent_id, fld_percent_weight_factor, fld_reliability_alloc,
+    fld_reliability_goal, fld_op_time_factor, fld_soa_factor,
+    fld_weight_factor)=(0.0,100.0,1,1,0.0,0.000617,1,1,4,100.0,0.0,0.0,1,1,1,
+    0.0,1.0,0.995,1,1,1) WHERE fld_hardware_id=2;
+UPDATE "ramstk_allocation" SET (fld_availability_alloc, fld_duty_cycle,
+    fld_env_factor, fld_goal_measure_id, fld_hazard_rate_alloc,
+    fld_hazard_rate_goal, fld_included, fld_int_factor,
+    fld_allocation_method_id, fld_mission_time, fld_mtbf_alloc,
+    fld_mtbf_goal, fld_n_sub_systems, fld_n_sub_elements,
+    fld_parent_id, fld_percent_weight_factor, fld_reliability_alloc,
+    fld_reliability_goal, fld_op_time_factor, fld_soa_factor,
+    fld_weight_factor)=(0.0,100.0,1,1,0.0,0.0,1,1,1,100.0,0.0,0.0,1,1,1,0.0,1.0,
+    1.0,1,1,1) WHERE fld_hardware_id=3;
+UPDATE "ramstk_allocation" SET (fld_availability_alloc, fld_duty_cycle,
+    fld_env_factor, fld_goal_measure_id, fld_hazard_rate_alloc,
+    fld_hazard_rate_goal, fld_included, fld_int_factor,
+    fld_allocation_method_id, fld_mission_time, fld_mtbf_alloc,
+    fld_mtbf_goal, fld_n_sub_systems, fld_n_sub_elements,
+    fld_parent_id, fld_percent_weight_factor, fld_reliability_alloc,
+    fld_reliability_goal, fld_op_time_factor, fld_soa_factor,
+    fld_weight_factor)=(0.0,80.0,6,1,0.000157531914893617,0.0,1,3,1,100.0,
+    6.3479200432198813358e+03,12000.0,1,2,2,0.0,9.84370241029675296928e-01,
+    0.9995,9,2,0.8) WHERE fld_hardware_id=4;
+UPDATE "ramstk_allocation"  SET (fld_availability_alloc, fld_duty_cycle,
+    fld_env_factor, fld_goal_measure_id, fld_hazard_rate_alloc,
+    fld_hazard_rate_goal, fld_included, fld_int_factor,
+    fld_allocation_method_id, fld_mission_time, fld_mtbf_alloc,
+    fld_mtbf_goal, fld_n_sub_systems, fld_n_sub_elements,
+    fld_parent_id, fld_percent_weight_factor, fld_reliability_alloc,
+    fld_reliability_goal, fld_op_time_factor, fld_soa_factor,
+    fld_weight_factor)=(0.0,90.0,3,1,4.59468085106382972786e-04,0.0,1,5,1,100.0,
+    2.17642972910395928929e+03,0.0,1,4,2,0.0,0.955092763646177,1.0,9,7,0.95)
+    WHERE fld_hardware_id=5;
+
+UPDATE "ramstk_design_electric" SET (fld_application_id, fld_area,
+    fld_capacitance, fld_configuration_id, fld_construction_id,
+    fld_contact_form_id, fld_contact_gauge, fld_contact_rating_id,
+    fld_current_operating, fld_current_rated, fld_current_ratio,
+    fld_environment_active_id, fld_environment_dormant_id, fld_family_id,
+    fld_feature_size, fld_frequency_operating, fld_insert_id, fld_insulation_id,
+    fld_manufacturing_id, fld_matching_id, fld_n_active_pins,
+    fld_n_circuit_planes, fld_n_cycles, fld_n_elements, fld_n_hand_soldered,
+    fld_n_wave_soldered, fld_operating_life, fld_overstress, fld_package_id,
+    fld_power_operating, fld_power_rated, fld_power_ratio, fld_reason,
+    fld_resistance, fld_specification_id, fld_technology_id,
+    fld_temperature_active, fld_temperature_case, fld_temperature_dormant,
+    fld_temperature_hot_spot, fld_temperature_junction, fld_temperature_knee,
+    fld_temperature_rated_max, fld_temperature_rated_min, fld_temperature_rise,
+    fld_theta_jc, fld_type_id, fld_voltage_ac_operating,
+    fld_voltage_dc_operating, fld_voltage_esd, fld_voltage_rated,
+    fld_voltage_ratio, fld_weight, fld_years_in_production) = (0,0.0,0.0,0,0,0,
+    0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',
+    0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,
+    0.0,1) WHERE fld_hardware_id=2;
+UPDATE "ramstk_design_electric" SET (fld_application_id, fld_area,
+    fld_capacitance, fld_configuration_id, fld_construction_id,
+    fld_contact_form_id, fld_contact_gauge, fld_contact_rating_id,
+    fld_current_operating, fld_current_rated, fld_current_ratio,
+    fld_environment_active_id, fld_environment_dormant_id, fld_family_id,
+    fld_feature_size, fld_frequency_operating, fld_insert_id, fld_insulation_id,
+    fld_manufacturing_id, fld_matching_id, fld_n_active_pins,
+    fld_n_circuit_planes, fld_n_cycles, fld_n_elements, fld_n_hand_soldered,
+    fld_n_wave_soldered, fld_operating_life, fld_overstress, fld_package_id,
+    fld_power_operating, fld_power_rated, fld_power_ratio, fld_reason,
+    fld_resistance, fld_specification_id, fld_technology_id,
+    fld_temperature_active, fld_temperature_case, fld_temperature_dormant,
+    fld_temperature_hot_spot, fld_temperature_junction, fld_temperature_knee,
+    fld_temperature_rated_max, fld_temperature_rated_min, fld_temperature_rise,
+    fld_theta_jc, fld_type_id, fld_voltage_ac_operating,
+    fld_voltage_dc_operating, fld_voltage_esd, fld_voltage_rated,
+    fld_voltage_ratio, fld_weight, fld_years_in_production) = (0,0.0,0.0,0,0,0,
+    0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',
+    0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,
+    0.0,1) WHERE fld_hardware_id=3;
+UPDATE "ramstk_design_electric" SET (fld_application_id, fld_area,
+    fld_capacitance, fld_configuration_id, fld_construction_id,
+    fld_contact_form_id, fld_contact_gauge, fld_contact_rating_id,
+    fld_current_operating, fld_current_rated, fld_current_ratio,
+    fld_environment_active_id, fld_environment_dormant_id, fld_family_id,
+    fld_feature_size, fld_frequency_operating, fld_insert_id, fld_insulation_id,
+    fld_manufacturing_id, fld_matching_id, fld_n_active_pins,
+    fld_n_circuit_planes, fld_n_cycles, fld_n_elements, fld_n_hand_soldered,
+    fld_n_wave_soldered, fld_operating_life, fld_overstress, fld_package_id,
+    fld_power_operating, fld_power_rated, fld_power_ratio, fld_reason,
+    fld_resistance, fld_specification_id, fld_technology_id,
+    fld_temperature_active, fld_temperature_case, fld_temperature_dormant,
+    fld_temperature_hot_spot, fld_temperature_junction, fld_temperature_knee,
+    fld_temperature_rated_max, fld_temperature_rated_min, fld_temperature_rise,
+    fld_theta_jc, fld_type_id, fld_voltage_ac_operating,
+    fld_voltage_dc_operating, fld_voltage_esd, fld_voltage_rated,
+    fld_voltage_ratio, fld_weight, fld_years_in_production) = (0,0.0,0.0,0,0,0,
+    0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',
+    0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,
+    0.0,1) WHERE fld_hardware_id=4;
+UPDATE "ramstk_design_electric" SET (fld_application_id, fld_area,
+    fld_capacitance, fld_configuration_id, fld_construction_id,
+    fld_contact_form_id, fld_contact_gauge, fld_contact_rating_id,
+    fld_current_operating, fld_current_rated, fld_current_ratio,
+    fld_environment_active_id, fld_environment_dormant_id, fld_family_id,
+    fld_feature_size, fld_frequency_operating, fld_insert_id, fld_insulation_id,
+    fld_manufacturing_id, fld_matching_id, fld_n_active_pins,
+    fld_n_circuit_planes, fld_n_cycles, fld_n_elements, fld_n_hand_soldered,
+    fld_n_wave_soldered, fld_operating_life, fld_overstress, fld_package_id,
+    fld_power_operating, fld_power_rated, fld_power_ratio, fld_reason,
+    fld_resistance, fld_specification_id, fld_technology_id,
+    fld_temperature_active, fld_temperature_case, fld_temperature_dormant,
+    fld_temperature_hot_spot, fld_temperature_junction, fld_temperature_knee,
+    fld_temperature_rated_max, fld_temperature_rated_min, fld_temperature_rise,
+    fld_theta_jc, fld_type_id, fld_voltage_ac_operating,
+    fld_voltage_dc_operating, fld_voltage_esd, fld_voltage_rated,
+    fld_voltage_ratio, fld_weight, fld_years_in_production) = (0,0.0,0.0,0,0,0,
+    0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',
+    0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,
+    0.0,1) WHERE fld_hardware_id=5;
+UPDATE "ramstk_design_electric" SET (fld_application_id, fld_area,
+    fld_capacitance, fld_configuration_id, fld_construction_id,
+    fld_contact_form_id, fld_contact_gauge, fld_contact_rating_id,
+    fld_current_operating, fld_current_rated, fld_current_ratio,
+    fld_environment_active_id, fld_environment_dormant_id, fld_family_id,
+    fld_feature_size, fld_frequency_operating, fld_insert_id, fld_insulation_id,
+    fld_manufacturing_id, fld_matching_id, fld_n_active_pins,
+    fld_n_circuit_planes, fld_n_cycles, fld_n_elements, fld_n_hand_soldered,
+    fld_n_wave_soldered, fld_operating_life, fld_overstress, fld_package_id,
+    fld_power_operating, fld_power_rated, fld_power_ratio, fld_reason,
+    fld_resistance, fld_specification_id, fld_technology_id,
+    fld_temperature_active, fld_temperature_case, fld_temperature_dormant,
+    fld_temperature_hot_spot, fld_temperature_junction, fld_temperature_knee,
+    fld_temperature_rated_max, fld_temperature_rated_min, fld_temperature_rise,
+    fld_theta_jc, fld_type_id, fld_voltage_ac_operating,
+    fld_voltage_dc_operating, fld_voltage_esd, fld_voltage_rated,
+    fld_voltage_ratio, fld_weight, fld_years_in_production) = (0,0.0,0.0,0,0,0,
+    0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',
+    0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,
+    0.0,1) WHERE fld_hardware_id=6;
+UPDATE "ramstk_design_electric" SET (fld_application_id, fld_area,
+    fld_capacitance, fld_configuration_id, fld_construction_id,
+    fld_contact_form_id, fld_contact_gauge, fld_contact_rating_id,
+    fld_current_operating, fld_current_rated, fld_current_ratio,
+    fld_environment_active_id, fld_environment_dormant_id, fld_family_id,
+    fld_feature_size, fld_frequency_operating, fld_insert_id, fld_insulation_id,
+    fld_manufacturing_id, fld_matching_id, fld_n_active_pins,
+    fld_n_circuit_planes, fld_n_cycles, fld_n_elements, fld_n_hand_soldered,
+    fld_n_wave_soldered, fld_operating_life, fld_overstress, fld_package_id,
+    fld_power_operating, fld_power_rated, fld_power_ratio, fld_reason,
+    fld_resistance, fld_specification_id, fld_technology_id,
+    fld_temperature_active, fld_temperature_case, fld_temperature_dormant,
+    fld_temperature_hot_spot, fld_temperature_junction, fld_temperature_knee,
+    fld_temperature_rated_max, fld_temperature_rated_min, fld_temperature_rise,
+    fld_theta_jc, fld_type_id, fld_voltage_ac_operating,
+    fld_voltage_dc_operating, fld_voltage_esd, fld_voltage_rated,
+    fld_voltage_ratio, fld_weight, fld_years_in_production) = (0,0.0,0.0,0,0,0,
+    0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',
+    0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,
+    0.0,1) WHERE fld_hardware_id=7;
+UPDATE "ramstk_design_electric" SET (fld_application_id, fld_area,
+    fld_capacitance, fld_configuration_id, fld_construction_id,
+    fld_contact_form_id, fld_contact_gauge, fld_contact_rating_id,
+    fld_current_operating, fld_current_rated, fld_current_ratio,
+    fld_environment_active_id, fld_environment_dormant_id, fld_family_id,
+    fld_feature_size, fld_frequency_operating, fld_insert_id, fld_insulation_id,
+    fld_manufacturing_id, fld_matching_id, fld_n_active_pins,
+    fld_n_circuit_planes, fld_n_cycles, fld_n_elements, fld_n_hand_soldered,
+    fld_n_wave_soldered, fld_operating_life, fld_overstress, fld_package_id,
+    fld_power_operating, fld_power_rated, fld_power_ratio, fld_reason,
+    fld_resistance, fld_specification_id, fld_technology_id,
+    fld_temperature_active, fld_temperature_case, fld_temperature_dormant,
+    fld_temperature_hot_spot, fld_temperature_junction, fld_temperature_knee,
+    fld_temperature_rated_max, fld_temperature_rated_min, fld_temperature_rise,
+    fld_theta_jc, fld_type_id, fld_voltage_ac_operating,
+    fld_voltage_dc_operating, fld_voltage_esd, fld_voltage_rated,
+    fld_voltage_ratio, fld_weight, fld_years_in_production) = (0,0.0,0.0,0,0,0,
+    0,0,0.0,0.0,0.0,0,0,0,0.0,0.0,0,0,0,0,0,1,0,0,0,0,0.0,0,0,0.0,0.0,0.0,'',
+    0.0,0,0,35.0,0.0,25.0,0.0,0.0,25.0,0.0,0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,
+    0.0,1) WHERE fld_hardware_id=8;
+
+UPDATE "ramstk_design_mechanic" SET (fld_altitude_operating, fld_application_id,
+    fld_balance_id, fld_clearance, fld_casing_id, fld_contact_pressure,
+    fld_deflection, fld_diameter_coil, fld_diameter_inner, fld_diameter_outer,
+    fld_diameter_wire, fld_filter_size, fld_flow_design, fld_flow_operating,
+    fld_frequency_operating, fld_friction, fld_impact_id, fld_leakage_allowable,
+    fld_length, fld_length_compressed, fld_length_relaxed, fld_load_design,
+    fld_load_id, fld_load_operating, fld_lubrication_id, fld_manufacturing_id,
+    fld_material_id, fld_meyer_hardness, fld_misalignment_angle, fld_n_ten,
+    fld_n_cycles, fld_n_elements, fld_offset, fld_particle_size,
+    fld_pressure_contact, fld_pressure_delta, fld_pressure_downstream,
+    fld_pressure_rated, fld_pressure_upstream, fld_rpm_design,
+    fld_rpm_operating, fld_service_id, fld_spring_index, fld_surface_finish,
+    fld_technology_id, fld_thickness, fld_torque_id, fld_type_id,
+    fld_viscosity_design, fld_viscosity_dynamic, fld_water_per_cent,
+    fld_width_minimum)=(0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0) WHERE fld_hardware_id=2;
+UPDATE "ramstk_design_mechanic" SET (fld_altitude_operating, fld_application_id,
+    fld_balance_id, fld_clearance, fld_casing_id, fld_contact_pressure,
+    fld_deflection, fld_diameter_coil, fld_diameter_inner, fld_diameter_outer,
+    fld_diameter_wire, fld_filter_size, fld_flow_design, fld_flow_operating,
+    fld_frequency_operating, fld_friction, fld_impact_id, fld_leakage_allowable,
+    fld_length, fld_length_compressed, fld_length_relaxed, fld_load_design,
+    fld_load_id, fld_load_operating, fld_lubrication_id, fld_manufacturing_id,
+    fld_material_id, fld_meyer_hardness, fld_misalignment_angle, fld_n_ten,
+    fld_n_cycles, fld_n_elements, fld_offset, fld_particle_size,
+    fld_pressure_contact, fld_pressure_delta, fld_pressure_downstream,
+    fld_pressure_rated, fld_pressure_upstream, fld_rpm_design,
+    fld_rpm_operating, fld_service_id, fld_spring_index, fld_surface_finish,
+    fld_technology_id, fld_thickness, fld_torque_id, fld_type_id,
+    fld_viscosity_design, fld_viscosity_dynamic, fld_water_per_cent,
+    fld_width_minimum)=(0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0) WHERE fld_hardware_id=3;
+UPDATE "ramstk_design_mechanic" SET (fld_altitude_operating, fld_application_id,
+    fld_balance_id, fld_clearance, fld_casing_id, fld_contact_pressure,
+    fld_deflection, fld_diameter_coil, fld_diameter_inner, fld_diameter_outer,
+    fld_diameter_wire, fld_filter_size, fld_flow_design, fld_flow_operating,
+    fld_frequency_operating, fld_friction, fld_impact_id, fld_leakage_allowable,
+    fld_length, fld_length_compressed, fld_length_relaxed, fld_load_design,
+    fld_load_id, fld_load_operating, fld_lubrication_id, fld_manufacturing_id,
+    fld_material_id, fld_meyer_hardness, fld_misalignment_angle, fld_n_ten,
+    fld_n_cycles, fld_n_elements, fld_offset, fld_particle_size,
+    fld_pressure_contact, fld_pressure_delta, fld_pressure_downstream,
+    fld_pressure_rated, fld_pressure_upstream, fld_rpm_design,
+    fld_rpm_operating, fld_service_id, fld_spring_index, fld_surface_finish,
+    fld_technology_id, fld_thickness, fld_torque_id, fld_type_id,
+    fld_viscosity_design, fld_viscosity_dynamic, fld_water_per_cent,
+    fld_width_minimum)=(0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0) WHERE fld_hardware_id=4;
+UPDATE "ramstk_design_mechanic" SET (fld_altitude_operating, fld_application_id,
+    fld_balance_id, fld_clearance, fld_casing_id, fld_contact_pressure,
+    fld_deflection, fld_diameter_coil, fld_diameter_inner, fld_diameter_outer,
+    fld_diameter_wire, fld_filter_size, fld_flow_design, fld_flow_operating,
+    fld_frequency_operating, fld_friction, fld_impact_id, fld_leakage_allowable,
+    fld_length, fld_length_compressed, fld_length_relaxed, fld_load_design,
+    fld_load_id, fld_load_operating, fld_lubrication_id, fld_manufacturing_id,
+    fld_material_id, fld_meyer_hardness, fld_misalignment_angle, fld_n_ten,
+    fld_n_cycles, fld_n_elements, fld_offset, fld_particle_size,
+    fld_pressure_contact, fld_pressure_delta, fld_pressure_downstream,
+    fld_pressure_rated, fld_pressure_upstream, fld_rpm_design,
+    fld_rpm_operating, fld_service_id, fld_spring_index, fld_surface_finish,
+    fld_technology_id, fld_thickness, fld_torque_id, fld_type_id,
+    fld_viscosity_design, fld_viscosity_dynamic, fld_water_per_cent,
+    fld_width_minimum)=(0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0) WHERE fld_hardware_id=5;
+UPDATE "ramstk_design_mechanic" SET (fld_altitude_operating, fld_application_id,
+    fld_balance_id, fld_clearance, fld_casing_id, fld_contact_pressure,
+    fld_deflection, fld_diameter_coil, fld_diameter_inner, fld_diameter_outer,
+    fld_diameter_wire, fld_filter_size, fld_flow_design, fld_flow_operating,
+    fld_frequency_operating, fld_friction, fld_impact_id, fld_leakage_allowable,
+    fld_length, fld_length_compressed, fld_length_relaxed, fld_load_design,
+    fld_load_id, fld_load_operating, fld_lubrication_id, fld_manufacturing_id,
+    fld_material_id, fld_meyer_hardness, fld_misalignment_angle, fld_n_ten,
+    fld_n_cycles, fld_n_elements, fld_offset, fld_particle_size,
+    fld_pressure_contact, fld_pressure_delta, fld_pressure_downstream,
+    fld_pressure_rated, fld_pressure_upstream, fld_rpm_design,
+    fld_rpm_operating, fld_service_id, fld_spring_index, fld_surface_finish,
+    fld_technology_id, fld_thickness, fld_torque_id, fld_type_id,
+    fld_viscosity_design, fld_viscosity_dynamic, fld_water_per_cent,
+    fld_width_minimum)=(0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0) WHERE fld_hardware_id=6;
+UPDATE "ramstk_design_mechanic" SET (fld_altitude_operating, fld_application_id,
+    fld_balance_id, fld_clearance, fld_casing_id, fld_contact_pressure,
+    fld_deflection, fld_diameter_coil, fld_diameter_inner, fld_diameter_outer,
+    fld_diameter_wire, fld_filter_size, fld_flow_design, fld_flow_operating,
+    fld_frequency_operating, fld_friction, fld_impact_id, fld_leakage_allowable,
+    fld_length, fld_length_compressed, fld_length_relaxed, fld_load_design,
+    fld_load_id, fld_load_operating, fld_lubrication_id, fld_manufacturing_id,
+    fld_material_id, fld_meyer_hardness, fld_misalignment_angle, fld_n_ten,
+    fld_n_cycles, fld_n_elements, fld_offset, fld_particle_size,
+    fld_pressure_contact, fld_pressure_delta, fld_pressure_downstream,
+    fld_pressure_rated, fld_pressure_upstream, fld_rpm_design,
+    fld_rpm_operating, fld_service_id, fld_spring_index, fld_surface_finish,
+    fld_technology_id, fld_thickness, fld_torque_id, fld_type_id,
+    fld_viscosity_design, fld_viscosity_dynamic, fld_water_per_cent,
+    fld_width_minimum)=(0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0) WHERE fld_hardware_id=7;
+UPDATE "ramstk_design_mechanic" SET (fld_altitude_operating, fld_application_id,
+    fld_balance_id, fld_clearance, fld_casing_id, fld_contact_pressure,
+    fld_deflection, fld_diameter_coil, fld_diameter_inner, fld_diameter_outer,
+    fld_diameter_wire, fld_filter_size, fld_flow_design, fld_flow_operating,
+    fld_frequency_operating, fld_friction, fld_impact_id, fld_leakage_allowable,
+    fld_length, fld_length_compressed, fld_length_relaxed, fld_load_design,
+    fld_load_id, fld_load_operating, fld_lubrication_id, fld_manufacturing_id,
+    fld_material_id, fld_meyer_hardness, fld_misalignment_angle, fld_n_ten,
+    fld_n_cycles, fld_n_elements, fld_offset, fld_particle_size,
+    fld_pressure_contact, fld_pressure_delta, fld_pressure_downstream,
+    fld_pressure_rated, fld_pressure_upstream, fld_rpm_design,
+    fld_rpm_operating, fld_service_id, fld_spring_index, fld_surface_finish,
+    fld_technology_id, fld_thickness, fld_torque_id, fld_type_id,
+    fld_viscosity_design, fld_viscosity_dynamic, fld_water_per_cent,
+    fld_width_minimum)=(0.0,0,0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0,0.0,0.0,0.0,0.0,0.0,0,0.0,0,0,0,0.0,0.0,0,0,0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0,0.0,0.0,0,0.0,0,0,0.0,0.0,0.0,0.0) WHERE fld_hardware_id=8;
+
+UPDATE "ramstk_mil_hdbk_f" SET(fld_a_one, fld_a_two, fld_b_one, fld_b_two,
+    fld_c_one, fld_c_two, fld_lambda_bd, fld_lambda_bp, fld_lambda_cyc,
+    fld_lambda_eos, fld_pi_a, fld_pi_c, fld_pi_cd, fld_pi_cf, fld_pi_cr,
+    fld_pi_cv, fld_pi_cyc, fld_pi_e, fld_pi_f, fld_pi_i, fld_pi_k, fld_pi_l,
+    fld_pi_m, fld_pi_mfg, fld_pi_n, fld_pi_nr, fld_pi_p, fld_pi_pt, fld_pi_q,
+    fld_pi_r, fld_pi_s, fld_pi_t, fld_pi_taps, fld_pi_u, fld_pi_v)=(0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=2;
+UPDATE "ramstk_mil_hdbk_f" SET(fld_a_one, fld_a_two, fld_b_one, fld_b_two,
+    fld_c_one, fld_c_two, fld_lambda_bd, fld_lambda_bp, fld_lambda_cyc,
+    fld_lambda_eos, fld_pi_a, fld_pi_c, fld_pi_cd, fld_pi_cf, fld_pi_cr,
+    fld_pi_cv, fld_pi_cyc, fld_pi_e, fld_pi_f, fld_pi_i, fld_pi_k, fld_pi_l,
+    fld_pi_m, fld_pi_mfg, fld_pi_n, fld_pi_nr, fld_pi_p, fld_pi_pt, fld_pi_q,
+    fld_pi_r, fld_pi_s, fld_pi_t, fld_pi_taps, fld_pi_u, fld_pi_v)=(0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=3;
+UPDATE "ramstk_mil_hdbk_f" SET(fld_a_one, fld_a_two, fld_b_one, fld_b_two,
+    fld_c_one, fld_c_two, fld_lambda_bd, fld_lambda_bp, fld_lambda_cyc,
+    fld_lambda_eos, fld_pi_a, fld_pi_c, fld_pi_cd, fld_pi_cf, fld_pi_cr,
+    fld_pi_cv, fld_pi_cyc, fld_pi_e, fld_pi_f, fld_pi_i, fld_pi_k, fld_pi_l,
+    fld_pi_m, fld_pi_mfg, fld_pi_n, fld_pi_nr, fld_pi_p, fld_pi_pt, fld_pi_q,
+    fld_pi_r, fld_pi_s, fld_pi_t, fld_pi_taps, fld_pi_u, fld_pi_v)=(0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=4;
+UPDATE "ramstk_mil_hdbk_f" SET(fld_a_one, fld_a_two, fld_b_one, fld_b_two,
+    fld_c_one, fld_c_two, fld_lambda_bd, fld_lambda_bp, fld_lambda_cyc,
+    fld_lambda_eos, fld_pi_a, fld_pi_c, fld_pi_cd, fld_pi_cf, fld_pi_cr,
+    fld_pi_cv, fld_pi_cyc, fld_pi_e, fld_pi_f, fld_pi_i, fld_pi_k, fld_pi_l,
+    fld_pi_m, fld_pi_mfg, fld_pi_n, fld_pi_nr, fld_pi_p, fld_pi_pt, fld_pi_q,
+    fld_pi_r, fld_pi_s, fld_pi_t, fld_pi_taps, fld_pi_u, fld_pi_v)=(0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=5;
+UPDATE "ramstk_mil_hdbk_f" SET(fld_a_one, fld_a_two, fld_b_one, fld_b_two,
+    fld_c_one, fld_c_two, fld_lambda_bd, fld_lambda_bp, fld_lambda_cyc,
+    fld_lambda_eos, fld_pi_a, fld_pi_c, fld_pi_cd, fld_pi_cf, fld_pi_cr,
+    fld_pi_cv, fld_pi_cyc, fld_pi_e, fld_pi_f, fld_pi_i, fld_pi_k, fld_pi_l,
+    fld_pi_m, fld_pi_mfg, fld_pi_n, fld_pi_nr, fld_pi_p, fld_pi_pt, fld_pi_q,
+    fld_pi_r, fld_pi_s, fld_pi_t, fld_pi_taps, fld_pi_u, fld_pi_v)=(0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=6;
+UPDATE "ramstk_mil_hdbk_f" SET(fld_a_one, fld_a_two, fld_b_one, fld_b_two,
+    fld_c_one, fld_c_two, fld_lambda_bd, fld_lambda_bp, fld_lambda_cyc,
+    fld_lambda_eos, fld_pi_a, fld_pi_c, fld_pi_cd, fld_pi_cf, fld_pi_cr,
+    fld_pi_cv, fld_pi_cyc, fld_pi_e, fld_pi_f, fld_pi_i, fld_pi_k, fld_pi_l,
+    fld_pi_m, fld_pi_mfg, fld_pi_n, fld_pi_nr, fld_pi_p, fld_pi_pt, fld_pi_q,
+    fld_pi_r, fld_pi_s, fld_pi_t, fld_pi_taps, fld_pi_u, fld_pi_v)=(0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=7;
+UPDATE "ramstk_mil_hdbk_f" SET(fld_a_one, fld_a_two, fld_b_one, fld_b_two,
+    fld_c_one, fld_c_two, fld_lambda_bd, fld_lambda_bp, fld_lambda_cyc,
+    fld_lambda_eos, fld_pi_a, fld_pi_c, fld_pi_cd, fld_pi_cf, fld_pi_cr,
+    fld_pi_cv, fld_pi_cyc, fld_pi_e, fld_pi_f, fld_pi_i, fld_pi_k, fld_pi_l,
+    fld_pi_m, fld_pi_mfg, fld_pi_n, fld_pi_nr, fld_pi_p, fld_pi_pt, fld_pi_q,
+    fld_pi_r, fld_pi_s, fld_pi_t, fld_pi_taps, fld_pi_u, fld_pi_v)=(0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=8;
+
+UPDATE "ramstk_nswc" SET(fld_c_ac, fld_c_alt, fld_c_b, fld_c_bl, fld_c_bt,
+    fld_c_bv, fld_c_c, fld_c_cf, fld_c_cp, fld_c_cs, fld_c_cv, fld_c_cw,
+    fld_c_d, fld_c_dc, fld_c_dl, fld_c_dp, fld_c_ds, fld_c_dt, fld_c_dw,
+    fld_c_dy, fld_c_e, fld_c_f, fld_c_g, fld_c_ga, fld_c_gl, fld_c_gp, fld_c_gs,
+    fld_c_gt, fld_c_gv, fld_c_h, fld_c_i, fld_c_k, fld_c_l, fld_c_lc, fld_c_m,
+    fld_c_mu, fld_c_n, fld_c_np, fld_c_nw, fld_c_p, fld_c_pd, fld_c_pf,
+    fld_c_pv, fld_c_q, fld_c_r, fld_c_rd, fld_c_s, fld_c_sc, fld_c_sf, fld_c_st,
+    fld_c_sv, fld_c_sw, fld_c_sz, fld_c_t, fld_c_v, fld_c_w, fld_c_y)=(0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=2;
+UPDATE "ramstk_nswc" SET(fld_c_ac, fld_c_alt, fld_c_b, fld_c_bl, fld_c_bt,
+    fld_c_bv, fld_c_c, fld_c_cf, fld_c_cp, fld_c_cs, fld_c_cv, fld_c_cw,
+    fld_c_d, fld_c_dc, fld_c_dl, fld_c_dp, fld_c_ds, fld_c_dt, fld_c_dw,
+    fld_c_dy, fld_c_e, fld_c_f, fld_c_g, fld_c_ga, fld_c_gl, fld_c_gp, fld_c_gs,
+    fld_c_gt, fld_c_gv, fld_c_h, fld_c_i, fld_c_k, fld_c_l, fld_c_lc, fld_c_m,
+    fld_c_mu, fld_c_n, fld_c_np, fld_c_nw, fld_c_p, fld_c_pd, fld_c_pf,
+    fld_c_pv, fld_c_q, fld_c_r, fld_c_rd, fld_c_s, fld_c_sc, fld_c_sf, fld_c_st,
+    fld_c_sv, fld_c_sw, fld_c_sz, fld_c_t, fld_c_v, fld_c_w, fld_c_y)=(0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=3;
+UPDATE "ramstk_nswc" SET(fld_c_ac, fld_c_alt, fld_c_b, fld_c_bl, fld_c_bt,
+    fld_c_bv, fld_c_c, fld_c_cf, fld_c_cp, fld_c_cs, fld_c_cv, fld_c_cw,
+    fld_c_d, fld_c_dc, fld_c_dl, fld_c_dp, fld_c_ds, fld_c_dt, fld_c_dw,
+    fld_c_dy, fld_c_e, fld_c_f, fld_c_g, fld_c_ga, fld_c_gl, fld_c_gp, fld_c_gs,
+    fld_c_gt, fld_c_gv, fld_c_h, fld_c_i, fld_c_k, fld_c_l, fld_c_lc, fld_c_m,
+    fld_c_mu, fld_c_n, fld_c_np, fld_c_nw, fld_c_p, fld_c_pd, fld_c_pf,
+    fld_c_pv, fld_c_q, fld_c_r, fld_c_rd, fld_c_s, fld_c_sc, fld_c_sf, fld_c_st,
+    fld_c_sv, fld_c_sw, fld_c_sz, fld_c_t, fld_c_v, fld_c_w, fld_c_y)=(0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=4;
+UPDATE "ramstk_nswc" SET(fld_c_ac, fld_c_alt, fld_c_b, fld_c_bl, fld_c_bt,
+    fld_c_bv, fld_c_c, fld_c_cf, fld_c_cp, fld_c_cs, fld_c_cv, fld_c_cw,
+    fld_c_d, fld_c_dc, fld_c_dl, fld_c_dp, fld_c_ds, fld_c_dt, fld_c_dw,
+    fld_c_dy, fld_c_e, fld_c_f, fld_c_g, fld_c_ga, fld_c_gl, fld_c_gp, fld_c_gs,
+    fld_c_gt, fld_c_gv, fld_c_h, fld_c_i, fld_c_k, fld_c_l, fld_c_lc, fld_c_m,
+    fld_c_mu, fld_c_n, fld_c_np, fld_c_nw, fld_c_p, fld_c_pd, fld_c_pf,
+    fld_c_pv, fld_c_q, fld_c_r, fld_c_rd, fld_c_s, fld_c_sc, fld_c_sf, fld_c_st,
+    fld_c_sv, fld_c_sw, fld_c_sz, fld_c_t, fld_c_v, fld_c_w, fld_c_y)=(0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=5;
+UPDATE "ramstk_nswc" SET(fld_c_ac, fld_c_alt, fld_c_b, fld_c_bl, fld_c_bt,
+    fld_c_bv, fld_c_c, fld_c_cf, fld_c_cp, fld_c_cs, fld_c_cv, fld_c_cw,
+    fld_c_d, fld_c_dc, fld_c_dl, fld_c_dp, fld_c_ds, fld_c_dt, fld_c_dw,
+    fld_c_dy, fld_c_e, fld_c_f, fld_c_g, fld_c_ga, fld_c_gl, fld_c_gp, fld_c_gs,
+    fld_c_gt, fld_c_gv, fld_c_h, fld_c_i, fld_c_k, fld_c_l, fld_c_lc, fld_c_m,
+    fld_c_mu, fld_c_n, fld_c_np, fld_c_nw, fld_c_p, fld_c_pd, fld_c_pf,
+    fld_c_pv, fld_c_q, fld_c_r, fld_c_rd, fld_c_s, fld_c_sc, fld_c_sf, fld_c_st,
+    fld_c_sv, fld_c_sw, fld_c_sz, fld_c_t, fld_c_v, fld_c_w, fld_c_y)=(0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=6;
+UPDATE "ramstk_nswc" SET(fld_c_ac, fld_c_alt, fld_c_b, fld_c_bl, fld_c_bt,
+    fld_c_bv, fld_c_c, fld_c_cf, fld_c_cp, fld_c_cs, fld_c_cv, fld_c_cw,
+    fld_c_d, fld_c_dc, fld_c_dl, fld_c_dp, fld_c_ds, fld_c_dt, fld_c_dw,
+    fld_c_dy, fld_c_e, fld_c_f, fld_c_g, fld_c_ga, fld_c_gl, fld_c_gp, fld_c_gs,
+    fld_c_gt, fld_c_gv, fld_c_h, fld_c_i, fld_c_k, fld_c_l, fld_c_lc, fld_c_m,
+    fld_c_mu, fld_c_n, fld_c_np, fld_c_nw, fld_c_p, fld_c_pd, fld_c_pf,
+    fld_c_pv, fld_c_q, fld_c_r, fld_c_rd, fld_c_s, fld_c_sc, fld_c_sf, fld_c_st,
+    fld_c_sv, fld_c_sw, fld_c_sz, fld_c_t, fld_c_v, fld_c_w, fld_c_y)=(0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=7;
+UPDATE "ramstk_nswc" SET(fld_c_ac, fld_c_alt, fld_c_b, fld_c_bl, fld_c_bt,
+    fld_c_bv, fld_c_c, fld_c_cf, fld_c_cp, fld_c_cs, fld_c_cv, fld_c_cw,
+    fld_c_d, fld_c_dc, fld_c_dl, fld_c_dp, fld_c_ds, fld_c_dt, fld_c_dw,
+    fld_c_dy, fld_c_e, fld_c_f, fld_c_g, fld_c_ga, fld_c_gl, fld_c_gp, fld_c_gs,
+    fld_c_gt, fld_c_gv, fld_c_h, fld_c_i, fld_c_k, fld_c_l, fld_c_lc, fld_c_m,
+    fld_c_mu, fld_c_n, fld_c_np, fld_c_nw, fld_c_p, fld_c_pd, fld_c_pf,
+    fld_c_pv, fld_c_q, fld_c_r, fld_c_rd, fld_c_s, fld_c_sc, fld_c_sf, fld_c_st,
+    fld_c_sv, fld_c_sw, fld_c_sz, fld_c_t, fld_c_v, fld_c_w, fld_c_y)=(0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
+    0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0) WHERE
+    fld_hardware_id=8;
+
+UPDATE "ramstk_reliability" SET(fld_add_adj_factor, fld_availability_logistics,
+    fld_availability_mission, fld_avail_log_variance, fld_avail_mis_variance,
+    fld_failure_distribution_id, fld_hazard_rate_active,
+    fld_hazard_rate_dormant, fld_hazard_rate_logistics,
+    fld_hazard_rate_method_id, fld_hazard_rate_mission, fld_hazard_rate_model,
+    fld_hazard_rate_percent, fld_hazard_rate_software,
+    fld_hazard_rate_specified, fld_hazard_rate_type_id, fld_hr_active_variance,
+    fld_hr_dormant_variance, fld_hr_log_variance, fld_hr_mis_variance,
+    fld_hr_spec_variance, fld_lambda_b, fld_location_parameter,
+    fld_mtbf_logistics, fld_mtbf_mission, fld_mtbf_specified,
+    fld_mtbf_log_variance, fld_mtbf_mis_variance, fld_mtbf_spec_variance,
+    fld_mult_adj_factor, fld_quality_id, fld_reliability_goal,
+    fld_reliability_goal_measure_id, fld_reliability_logistics,
+    fld_reliability_mission, fld_reliability_log_variance,
+    fld_reliability_mis_variance, fld_scale_parameter, fld_shape_parameter,
+    fld_survival_analysis_id)=(0.0,1.0,1.0,0.0,0.0,0,0.00617,0.0,0.0,0,0.0,'',
+    0.0,0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,0.0,
+    0,1.0,1.0,0.0,0.0,0.0,0.0,0) WHERE fld_hardware_id=2;
+UPDATE "ramstk_reliability" SET(fld_add_adj_factor, fld_availability_logistics,
+    fld_availability_mission, fld_avail_log_variance, fld_avail_mis_variance,
+    fld_failure_distribution_id, fld_hazard_rate_active,
+    fld_hazard_rate_dormant, fld_hazard_rate_logistics,
+    fld_hazard_rate_method_id, fld_hazard_rate_mission, fld_hazard_rate_model,
+    fld_hazard_rate_percent, fld_hazard_rate_software,
+    fld_hazard_rate_specified, fld_hazard_rate_type_id, fld_hr_active_variance,
+    fld_hr_dormant_variance, fld_hr_log_variance, fld_hr_mis_variance,
+    fld_hr_spec_variance, fld_lambda_b, fld_location_parameter,
+    fld_mtbf_logistics, fld_mtbf_mission, fld_mtbf_specified,
+    fld_mtbf_log_variance, fld_mtbf_mis_variance, fld_mtbf_spec_variance,
+    fld_mult_adj_factor, fld_quality_id, fld_reliability_goal,
+    fld_reliability_goal_measure_id, fld_reliability_logistics,
+    fld_reliability_mission, fld_reliability_log_variance,
+    fld_reliability_mis_variance, fld_scale_parameter, fld_shape_parameter,
+    fld_survival_analysis_id)=(0.0,1.0,1.0,0.0,0.0,0,0.0,0.0,0.0,0,0.0,'',0.0,
+    0.045,0.0,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,38292.0,0.0,0.0,0.0,1.0,0,
+    0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0) WHERE fld_hardware_id=3;
+UPDATE "ramstk_reliability" SET(fld_add_adj_factor, fld_availability_logistics,
+    fld_availability_mission, fld_avail_log_variance, fld_avail_mis_variance,
+    fld_failure_distribution_id, fld_hazard_rate_active,
+    fld_hazard_rate_dormant, fld_hazard_rate_logistics,
+    fld_hazard_rate_method_id, fld_hazard_rate_mission, fld_hazard_rate_model,
+    fld_hazard_rate_percent, fld_hazard_rate_software,
+    fld_hazard_rate_specified, fld_hazard_rate_type_id, fld_hr_active_variance,
+    fld_hr_dormant_variance, fld_hr_log_variance, fld_hr_mis_variance,
+    fld_hr_spec_variance, fld_lambda_b, fld_location_parameter,
+    fld_mtbf_logistics, fld_mtbf_mission, fld_mtbf_specified,
+    fld_mtbf_log_variance, fld_mtbf_mis_variance, fld_mtbf_spec_variance,
+    fld_mult_adj_factor, fld_quality_id, fld_reliability_goal,
+    fld_reliability_goal_measure_id, fld_reliability_logistics,
+    fld_reliability_mission, fld_reliability_log_variance,
+    fld_reliability_mis_variance, fld_scale_parameter, fld_shape_parameter,
+    fld_survival_analysis_id)=(0.0,1.0,1.0,0.0,0.0,0,0.0,0.0,0.0,0,0.0,'',0.0,
+    0.0,0.0,0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,0.0,0,
+    1.0,1.0,0.0,0.0,0.0,0.0,0) WHERE fld_hardware_id=4;
+UPDATE "ramstk_reliability" SET(fld_add_adj_factor, fld_availability_logistics,
+    fld_availability_mission, fld_avail_log_variance, fld_avail_mis_variance,
+    fld_failure_distribution_id, fld_hazard_rate_active,
+    fld_hazard_rate_dormant, fld_hazard_rate_logistics,
+    fld_hazard_rate_method_id, fld_hazard_rate_mission, fld_hazard_rate_model,
+    fld_hazard_rate_percent, fld_hazard_rate_software,
+    fld_hazard_rate_specified, fld_hazard_rate_type_id, fld_hr_active_variance,
+    fld_hr_dormant_variance, fld_hr_log_variance, fld_hr_mis_variance,
+    fld_hr_spec_variance, fld_lambda_b, fld_location_parameter,
+    fld_mtbf_logistics, fld_mtbf_mission, fld_mtbf_specified,
+    fld_mtbf_log_variance, fld_mtbf_mis_variance, fld_mtbf_spec_variance,
+    fld_mult_adj_factor, fld_quality_id, fld_reliability_goal,
+    fld_reliability_goal_measure_id, fld_reliability_logistics,
+    fld_reliability_mission, fld_reliability_log_variance,
+    fld_reliability_mis_variance, fld_scale_parameter, fld_shape_parameter,
+    fld_survival_analysis_id)=(0.0,1.0,1.0,0.0,0.0,0,0.0,0.0035,0.0,0,0.0,'',
+    0.0,0.0,0.15,2,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,
+    0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0) WHERE fld_hardware_id=5;
+UPDATE "ramstk_reliability" SET(fld_add_adj_factor, fld_availability_logistics,
+    fld_availability_mission, fld_avail_log_variance, fld_avail_mis_variance,
+    fld_failure_distribution_id, fld_hazard_rate_active,
+    fld_hazard_rate_dormant, fld_hazard_rate_logistics,
+    fld_hazard_rate_method_id, fld_hazard_rate_mission, fld_hazard_rate_model,
+    fld_hazard_rate_percent, fld_hazard_rate_software,
+    fld_hazard_rate_specified, fld_hazard_rate_type_id, fld_hr_active_variance,
+    fld_hr_dormant_variance, fld_hr_log_variance, fld_hr_mis_variance,
+    fld_hr_spec_variance, fld_lambda_b, fld_location_parameter,
+    fld_mtbf_logistics, fld_mtbf_mission, fld_mtbf_specified,
+    fld_mtbf_log_variance, fld_mtbf_mis_variance, fld_mtbf_spec_variance,
+    fld_mult_adj_factor, fld_quality_id, fld_reliability_goal,
+    fld_reliability_goal_measure_id, fld_reliability_logistics,
+    fld_reliability_mission, fld_reliability_log_variance,
+    fld_reliability_mis_variance, fld_scale_parameter, fld_shape_parameter,
+    fld_survival_analysis_id)=(0.0,1.0,1.0,0.0,0.0,0,2.89e-06,0.0,0.0,0,0.0,'',
+    0.0,2.3,0.045,2,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0,
+    0.9995,0,1.0,1.0,0.0,0.0,0.0,0.0,0) WHERE fld_hardware_id=6;
+UPDATE "ramstk_reliability" SET(fld_add_adj_factor, fld_availability_logistics,
+    fld_availability_mission, fld_avail_log_variance, fld_avail_mis_variance,
+    fld_failure_distribution_id, fld_hazard_rate_active,
+    fld_hazard_rate_dormant, fld_hazard_rate_logistics,
+    fld_hazard_rate_method_id, fld_hazard_rate_mission, fld_hazard_rate_model,
+    fld_hazard_rate_percent, fld_hazard_rate_software,
+    fld_hazard_rate_specified, fld_hazard_rate_type_id, fld_hr_active_variance,
+    fld_hr_dormant_variance, fld_hr_log_variance, fld_hr_mis_variance,
+    fld_hr_spec_variance, fld_lambda_b, fld_location_parameter,
+    fld_mtbf_logistics, fld_mtbf_mission, fld_mtbf_specified,
+    fld_mtbf_log_variance, fld_mtbf_mis_variance, fld_mtbf_spec_variance,
+    fld_mult_adj_factor, fld_quality_id, fld_reliability_goal,
+    fld_reliability_goal_measure_id, fld_reliability_logistics,
+    fld_reliability_mission, fld_reliability_log_variance,
+    fld_reliability_mis_variance, fld_scale_parameter, fld_shape_parameter,
+    fld_survival_analysis_id)=(0.0,1.0,1.0,0.0,0.0,0,1.132e-07,0.0,0.0,0,0.0,'',
+    0.0,0.0,0.0,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,89560.0,0.0,0.0,0.0,1.0,0,
+    0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0) WHERE fld_hardware_id=7;
+UPDATE "ramstk_reliability" SET(fld_add_adj_factor, fld_availability_logistics,
+    fld_availability_mission, fld_avail_log_variance, fld_avail_mis_variance,
+    fld_failure_distribution_id, fld_hazard_rate_active,
+    fld_hazard_rate_dormant, fld_hazard_rate_logistics,
+    fld_hazard_rate_method_id, fld_hazard_rate_mission, fld_hazard_rate_model,
+    fld_hazard_rate_percent, fld_hazard_rate_software,
+    fld_hazard_rate_specified, fld_hazard_rate_type_id, fld_hr_active_variance,
+    fld_hr_dormant_variance, fld_hr_log_variance, fld_hr_mis_variance,
+    fld_hr_spec_variance, fld_lambda_b, fld_location_parameter,
+    fld_mtbf_logistics, fld_mtbf_mission, fld_mtbf_specified,
+    fld_mtbf_log_variance, fld_mtbf_mis_variance, fld_mtbf_spec_variance,
+    fld_mult_adj_factor, fld_quality_id, fld_reliability_goal,
+    fld_reliability_goal_measure_id, fld_reliability_logistics,
+    fld_reliability_mission, fld_reliability_log_variance,
+    fld_reliability_mis_variance, fld_scale_parameter, fld_shape_parameter,
+    fld_survival_analysis_id)=(0.0,1.0,1.0,0.0,0.0,0,1.132e-07,0.0,0.0,0,0.0,'',
+    0.0,0.0,0.0,3,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,89560.0,0.0,0.0,0.0,1.0,0,
+    0.0,0,1.0,1.0,0.0,0.0,0.0,0.0,0) WHERE fld_hardware_id=8;
+
+UPDATE "ramstk_similar_item" SET(fld_change_description_1,
+    fld_change_description_2, fld_change_description_3,
+    fld_change_description_4, fld_change_description_5,
+    fld_change_description_6, fld_change_description_7,
+    fld_change_description_8, fld_change_description_9,
+    fld_change_description_10, fld_change_factor_1, fld_change_factor_2,
+    fld_change_factor_3, fld_change_factor_4, fld_change_factor_5,
+    fld_change_factor_6, fld_change_factor_7, fld_change_factor_8,
+    fld_change_factor_9, fld_change_factor_10, fld_environment_from_id,
+    fld_environment_to_id, fld_function_1, fld_function_2, fld_function_3,
+    fld_function_4, fld_function_5, fld_similar_item_method_id, fld_parent_id,
+    fld_quality_from_id, fld_quality_to_id, fld_result_1, fld_result_2,
+    fld_result_3, fld_result_4, fld_result_5, fld_temperature_from,
+    fld_temperature_to, fld_user_blob_1, fld_user_blob_2, fld_user_blob_3,
+    fld_user_blob_4, fld_user_blob_5, fld_user_float_1, fld_user_float_2,
+    fld_user_float_3, fld_user_float_4, fld_user_float_5, fld_user_int_1,
+    fld_user_int_2, fld_user_int_3, fld_user_int_4, fld_user_int_5)=('','','',
+    '','','','','','','',0.85,1.2,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,2,3,
+    'pi1*pi2*hr','0','0','0','0',2,1,1,2,0.0,0.0,0.0,0.0,0.0,55.0,65.0,'','','',
+    '','',0.0,0.0,0.0,0.0,0.0,0,0,0,0,0) WHERE fld_hardware_id=2;
+UPDATE "ramstk_similar_item" SET(fld_change_description_1,
+    fld_change_description_2, fld_change_description_3,
+    fld_change_description_4, fld_change_description_5,
+    fld_change_description_6, fld_change_description_7,
+    fld_change_description_8, fld_change_description_9,
+    fld_change_description_10, fld_change_factor_1, fld_change_factor_2,
+    fld_change_factor_3, fld_change_factor_4, fld_change_factor_5,
+    fld_change_factor_6, fld_change_factor_7, fld_change_factor_8,
+    fld_change_factor_9, fld_change_factor_10, fld_environment_from_id,
+    fld_environment_to_id, fld_function_1, fld_function_2, fld_function_3,
+    fld_function_4, fld_function_5, fld_similar_item_method_id, fld_parent_id,
+    fld_quality_from_id, fld_quality_to_id, fld_result_1, fld_result_2,
+    fld_result_3, fld_result_4, fld_result_5, fld_temperature_from,
+    fld_temperature_to, fld_user_blob_1, fld_user_blob_2, fld_user_blob_3,
+    fld_user_blob_4, fld_user_blob_5, fld_user_float_1, fld_user_float_2,
+    fld_user_float_3, fld_user_float_4, fld_user_float_5, fld_user_int_1,
+    fld_user_int_2, fld_user_int_3, fld_user_int_4, fld_user_int_5)=('','','',
+    '','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0',
+    '0','0','0',1,1,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,
+    0.0,0.0,0.0,0,0,0,0,0) WHERE fld_hardware_id=3;
+UPDATE "ramstk_similar_item" SET(fld_change_description_1,
+    fld_change_description_2, fld_change_description_3,
+    fld_change_description_4, fld_change_description_5,
+    fld_change_description_6, fld_change_description_7,
+    fld_change_description_8, fld_change_description_9,
+    fld_change_description_10, fld_change_factor_1, fld_change_factor_2,
+    fld_change_factor_3, fld_change_factor_4, fld_change_factor_5,
+    fld_change_factor_6, fld_change_factor_7, fld_change_factor_8,
+    fld_change_factor_9, fld_change_factor_10, fld_environment_from_id,
+    fld_environment_to_id, fld_function_1, fld_function_2, fld_function_3,
+    fld_function_4, fld_function_5, fld_similar_item_method_id, fld_parent_id,
+    fld_quality_from_id, fld_quality_to_id, fld_result_1, fld_result_2,
+    fld_result_3, fld_result_4, fld_result_5, fld_temperature_from,
+    fld_temperature_to, fld_user_blob_1, fld_user_blob_2, fld_user_blob_3,
+    fld_user_blob_4, fld_user_blob_5, fld_user_float_1, fld_user_float_2,
+    fld_user_float_3, fld_user_float_4, fld_user_float_5, fld_user_int_1,
+    fld_user_int_2, fld_user_int_3, fld_user_int_4, fld_user_int_5)=('','','',
+    '','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0',
+    '0','0','0',1,3,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,
+    0.0,0.0,0.0,0,0,0,0,0) WHERE fld_hardware_id=4;
+UPDATE "ramstk_similar_item" SET(fld_change_description_1,
+    fld_change_description_2, fld_change_description_3,
+    fld_change_description_4, fld_change_description_5,
+    fld_change_description_6, fld_change_description_7,
+    fld_change_description_8, fld_change_description_9,
+    fld_change_description_10, fld_change_factor_1, fld_change_factor_2,
+    fld_change_factor_3, fld_change_factor_4, fld_change_factor_5,
+    fld_change_factor_6, fld_change_factor_7, fld_change_factor_8,
+    fld_change_factor_9, fld_change_factor_10, fld_environment_from_id,
+    fld_environment_to_id, fld_function_1, fld_function_2, fld_function_3,
+    fld_function_4, fld_function_5, fld_similar_item_method_id, fld_parent_id,
+    fld_quality_from_id, fld_quality_to_id, fld_result_1, fld_result_2,
+    fld_result_3, fld_result_4, fld_result_5, fld_temperature_from,
+    fld_temperature_to, fld_user_blob_1, fld_user_blob_2, fld_user_blob_3,
+    fld_user_blob_4, fld_user_blob_5, fld_user_float_1, fld_user_float_2,
+    fld_user_float_3, fld_user_float_4, fld_user_float_5, fld_user_int_1,
+    fld_user_int_2, fld_user_int_3, fld_user_int_4, fld_user_int_5)=('','','',
+    '','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0',
+    '0','0','0',1,1,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,
+    0.0,0.0,0.0,0,0,0,0,0) WHERE fld_hardware_id=5;
+UPDATE "ramstk_similar_item" SET(fld_change_description_1,
+    fld_change_description_2, fld_change_description_3,
+    fld_change_description_4, fld_change_description_5,
+    fld_change_description_6, fld_change_description_7,
+    fld_change_description_8, fld_change_description_9,
+    fld_change_description_10, fld_change_factor_1, fld_change_factor_2,
+    fld_change_factor_3, fld_change_factor_4, fld_change_factor_5,
+    fld_change_factor_6, fld_change_factor_7, fld_change_factor_8,
+    fld_change_factor_9, fld_change_factor_10, fld_environment_from_id,
+    fld_environment_to_id, fld_function_1, fld_function_2, fld_function_3,
+    fld_function_4, fld_function_5, fld_similar_item_method_id, fld_parent_id,
+    fld_quality_from_id, fld_quality_to_id, fld_result_1, fld_result_2,
+    fld_result_3, fld_result_4, fld_result_5, fld_temperature_from,
+    fld_temperature_to, fld_user_blob_1, fld_user_blob_2, fld_user_blob_3,
+    fld_user_blob_4, fld_user_blob_5, fld_user_float_1, fld_user_float_2,
+    fld_user_float_3, fld_user_float_4, fld_user_float_5, fld_user_int_1,
+    fld_user_int_2, fld_user_int_3, fld_user_int_4, fld_user_int_5)=(
+    '54686973206973206368616E67652064656372697074696F6E203120666F7220617373656D626C792036',
+    '54686973206973206368616E67652064656372697074696F6E203220666F7220617373656D626C792036',
+    '54686973206973206368616E67652064656372697074696F6E203320666F7220617373656D626C792036',
+    '','','','','','','',1.0,1.0,1.0,1.0,0.95,1.0,1.0,1.0,1.0,1.0,0,0,'0','0',
+    '0','0','0',1,2,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,
+    0.0,0.0,0.0,0,0,0,0,0) WHERE fld_hardware_id=6;
+UPDATE "ramstk_similar_item" SET(fld_change_description_1,
+    fld_change_description_2, fld_change_description_3,
+    fld_change_description_4, fld_change_description_5,
+    fld_change_description_6, fld_change_description_7,
+    fld_change_description_8, fld_change_description_9,
+    fld_change_description_10, fld_change_factor_1, fld_change_factor_2,
+    fld_change_factor_3, fld_change_factor_4, fld_change_factor_5,
+    fld_change_factor_6, fld_change_factor_7, fld_change_factor_8,
+    fld_change_factor_9, fld_change_factor_10, fld_environment_from_id,
+    fld_environment_to_id, fld_function_1, fld_function_2, fld_function_3,
+    fld_function_4, fld_function_5, fld_similar_item_method_id, fld_parent_id,
+    fld_quality_from_id, fld_quality_to_id, fld_result_1, fld_result_2,
+    fld_result_3, fld_result_4, fld_result_5, fld_temperature_from,
+    fld_temperature_to, fld_user_blob_1, fld_user_blob_2, fld_user_blob_3,
+    fld_user_blob_4, fld_user_blob_5, fld_user_float_1, fld_user_float_2,
+    fld_user_float_3, fld_user_float_4, fld_user_float_5, fld_user_int_1,
+    fld_user_int_2, fld_user_int_3, fld_user_int_4, fld_user_int_5)=(
+    '54686973206973206368616E67652064656372697074696F6E203120666F7220617373656D626C792037',
+    '54686973206973206368616E67652064656372697074696F6E203220666F7220617373656D626C792037',
+    '54686973206973206368616E67652064656372697074696F6E203320666F7220617373656D626C792037',
+    '','','','','','','',1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,0,0,'0','0',
+    '0','0','0',1,2,0,0,0.0,0.0,0.0,0.0,0.0,30.0,30.0,'','','','','',0.0,0.0,
+    0.0,0.0,0.0,0,0,0,0,0) WHERE fld_hardware_id=8;
+
 INSERT INTO "ramstk_mode" VALUES(1,1,4,0,'System Test Failure Mode #1','','','','','',1.0,'','','Default Mission','',0.0,0.0,10.0,'',0.5,'','','',1,1,'IV',0,0);
 INSERT INTO "ramstk_mode" VALUES(1,1,5,0,'System Test Failure Mode #2','','','','','',0.75,'','','Default Mission','',0.0,0.0,5.0,'',0.2,'','','',1,1,'I',0,0);
 INSERT INTO "ramstk_mode" VALUES(1,1,6,0,'System Test Failure Mode #3','','','','','',0.9,'','','Default Mission','',0.0,0.0,10.0,'',0.3,'','','',1,1,'I',0,0);
-CREATE TABLE ramstk_mechanism (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_mechanism_id INTEGER NOT NULL,
-    fld_description VARCHAR(512),
-    fld_pof_include INTEGER,
-    fld_rpn INTEGER,
-    fld_rpn_detection INTEGER,
-    fld_rpn_detection_new INTEGER,
-    fld_rpn_new INTEGER,
-    fld_rpn_occurrence INTEGER,
-    fld_rpn_occurrence_new INTEGER,
-    PRIMARY KEY (fld_mechanism_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_mode_id) REFERENCES ramstk_mode (fld_mode_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_mechanism" VALUES(1,1,4,1,'Test Failure Mechanism #1 for Mode ID 4',1,0,8,7,0,2,2);
 INSERT INTO "ramstk_mechanism" VALUES(1,1,5,2,'Test Failure Mechanism #1 for Mode ID 5',1,0,2,5,0,4,4);
 INSERT INTO "ramstk_mechanism" VALUES(1,1,6,3,'Test Failure Mechanism #1 for Mode ID 6',1,0,5,2,0,7,5);
 INSERT INTO "ramstk_mechanism" VALUES(1,1,6,4,'Test Failure Mechanism #2 for Mode ID 6',1,0,5,2,0,7,5);
-CREATE TABLE ramstk_cause (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_mechanism_id INTEGER NOT NULL,
-    fld_cause_id INTEGER NOT NULL,
-    fld_description VARCHAR(512),
-    fld_rpn INTEGER,
-    fld_rpn_detection INTEGER,
-    fld_rpn_detection_new INTEGER,
-    fld_rpn_new INTEGER,
-    fld_rpn_occurrence INTEGER,
-    fld_rpn_occurrence_new INTEGER,
-    PRIMARY KEY (fld_cause_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_mode_id) REFERENCES ramstk_mode (fld_mode_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_mechanism_id) REFERENCES ramstk_mechanism (fld_mechanism_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_cause" VALUES(1,1,4,1,1,'Test Failure Cause #1 for Mechanism ID 1',0,2,1,0,8,5);
 INSERT INTO "ramstk_cause" VALUES(1,1,5,2,2,'Test Failure Cause #1 for Mechanism ID 2',0,4,3,0,4,3);
 INSERT INTO "ramstk_cause" VALUES(1,1,6,3,3,'Test Failure Cause #1 for Mechanism ID 3',0,3,3,0,6,4);
 INSERT INTO "ramstk_cause" VALUES(1,1,6,3,4,'Test Failure Cause #2 for Mechanism ID 3',0,6,3,0,6,4);
-CREATE TABLE ramstk_control (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_mechanism_id INTEGER NOT NULL,
-    fld_cause_id INTEGER NOT NULL,
-    fld_control_id INTEGER NOT NULL,
-    fld_description VARCHAR(512),
-    fld_type_id VARCHAR(512),
-    PRIMARY KEY (fld_control_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_cause_id) REFERENCES ramstk_cause (fld_cause_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_control" VALUES(1,1,4,1,1,1,'Test FMEA Control #1 for Cause ID 1','');
 INSERT INTO "ramstk_control" VALUES(1,1,5,2,2,2,'Test FMEA Control #1 for Cause ID 2','');
 INSERT INTO "ramstk_control" VALUES(1,1,6,3,3,3,'Test FMEA Control #1 for Cause ID 3','Detection');
 INSERT INTO "ramstk_control" VALUES(1,1,6,3,3,4,'Test FMEA Control #2 for Cause ID 3','Prevention');
-CREATE TABLE ramstk_action (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_mechanism_id INTEGER NOT NULL,
-    fld_cause_id INTEGER NOT NULL,
-    fld_action_id INTEGER NOT NULL,
-    fld_action_recommended VARCHAR,
-    fld_action_category VARCHAR(512),
-    fld_action_owner VARCHAR(512),
-    fld_action_due_date DATE,
-    fld_action_status VARCHAR(512),
-    fld_action_taken VARCHAR,
-    fld_action_approved INTEGER,
-    fld_action_approve_date DATE,
-    fld_action_closed INTEGER,
-    fld_action_close_date DATE,
-    PRIMARY KEY (fld_action_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_cause_id) REFERENCES ramstk_cause (fld_cause_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_action" VALUES(1,1,4,1,1,1,'Test FMEA Recommended Action #1 for Cause ID 1.','','','2019-08-20','',X'',0,'2019-08-20',0,'2019-08-20');
 INSERT INTO "ramstk_action" VALUES(1,1,5,2,2,2,'Test FMEA Recommended Action #1 for Cause ID 2.','','','2019-08-20','',X'',0,'2019-08-20',0,'2019-08-20');
 INSERT INTO "ramstk_action" VALUES(1,1,6,3,3,3,'Test FMEA Recommended Action #1 for Cause ID 3','','','2019-08-20','',X'',0,'2019-08-20',0,'2019-08-20');
 INSERT INTO "ramstk_action" VALUES(1,1,6,3,3,4,'Test FMEA Recommended Action #2 for Cause ID 3','','','2019-08-20','',X'',0,'2019-08-20',0,'2019-08-20');
-
-CREATE TABLE ramstk_op_load (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_mechanism_id INTEGER NOT NULL,
-    fld_opload_id INTEGER NOT NULL,
-    fld_description VARCHAR(512) DEFAULT '',
-    fld_damage_model VARCHAR(512) DEFAULT '',
-    fld_priority_id INTEGER DEFAULT 0,
-    PRIMARY KEY (fld_opload_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_mechanism_id) REFERENCES ramstk_mechanism (fld_mechanism_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_op_load" VALUES(1,1,4,1,1,'Test Operating Load','',0);
 INSERT INTO "ramstk_op_load" VALUES(1,1,5,2,2,'','',0);
 INSERT INTO "ramstk_op_load" VALUES(1,1,6,3,3,'','',0);
 INSERT INTO "ramstk_op_load" VALUES(1,1,6,4,4,'','',0);
-CREATE TABLE ramstk_op_stress (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_mechanism_id INTEGER NOT NULL,
-    fld_opload_id INTEGER NOT NULL,
-    fld_opstress_id INTEGER NOT NULL,
-    fld_description VARCHAR(512) DEFAULT '',
-    fld_load_history VARCHAR(512) DEFAULT '',
-    fld_measurable_parameter VARCHAR(512) DEFAULT '',
-    fld_remarks VARCHAR DEFAULT '',
-    PRIMARY KEY (fld_opstress_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_opload_id) REFERENCES ramstk_op_load (fld_opload_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_op_stress" VALUES(1,1,4,1,1,1,'Test Operating Stress','','','');
 INSERT INTO "ramstk_op_stress" VALUES(1,1,5,2,2,2,'','','','');
 INSERT INTO "ramstk_op_stress" VALUES(1,1,6,3,3,3,'','','','');
 INSERT INTO "ramstk_op_stress" VALUES(1,1,6,3,3,4,'','','','');
-CREATE TABLE ramstk_test_method (
-    fld_revision_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER NOT NULL,
-    fld_mode_id INTEGER NOT NULL,
-    fld_mechanism_id INTEGER NOT NULL,
-    fld_opload_id INTEGER NOT NULL,
-    fld_test_method_id INTEGER NOT NULL,
-    fld_description VARCHAR(512),
-    fld_boundary_conditions VARCHAR(512),
-    fld_remarks VARCHAR,
-    PRIMARY KEY (fld_test_method_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE,
-    FOREIGN KEY(fld_opload_id) REFERENCES ramstk_op_load (fld_opload_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_test_method" VALUES(1,1,4,1,1,1,'Test Test Method','','');
 INSERT INTO "ramstk_test_method" VALUES(1,1,5,2,2,2,'','','');
 INSERT INTO "ramstk_test_method" VALUES(1,1,6,3,3,3,'','','');
 INSERT INTO "ramstk_test_method" VALUES(1,1,6,3,3,4,'','','');
-
-CREATE TABLE ramstk_validation (
-    fld_revision_id INTEGER,
-    fld_validation_id INTEGER NOT NULL,
-    fld_acceptable_maximum FLOAT,
-    fld_acceptable_mean FLOAT,
-    fld_acceptable_minimum FLOAT,
-    fld_acceptable_variance FLOAT,
-    fld_confidence FLOAT,
-    fld_cost_average FLOAT,
-    fld_cost_ll FLOAT,
-    fld_cost_maximum FLOAT,
-    fld_cost_mean FLOAT,
-    fld_cost_minimum FLOAT,
-    fld_cost_ul FLOAT,
-    fld_cost_variance FLOAT,
-    fld_date_end DATE,
-    fld_date_start DATE,
-    fld_description VARCHAR,
-    fld_measurement_unit INTEGER DEFAULT 0,
-    fld_name VARCHAR(256) DEFAULT '',
-    fld_status FLOAT,
-    fld_type INTEGER DEFAULT 0,
-    fld_task_specification VARCHAR(512),
-    fld_time_average FLOAT,
-    fld_time_ll FLOAT,
-    fld_time_maximum FLOAT,
-    fld_time_mean FLOAT,
-    fld_time_minimum FLOAT,
-    fld_time_ul FLOAT,
-    fld_time_variance FLOAT,
-    PRIMARY KEY (fld_validation_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
 INSERT INTO "ramstk_validation" VALUES(1,1,0.0,0.0,0.0,0.0,95.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,CURRENT_DATE+INTERVAL'30 days',CURRENT_DATE,'Test Validation',0,'PRF-0001',0.0,0,'',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
 INSERT INTO "ramstk_validation" VALUES(1,2,0.0,0.0,0.0,0.0,95.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,CURRENT_DATE+INTERVAL'20 days',CURRENT_DATE-INTERVAL'10 days','Test Validation',0,'',0.0,0,'',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
 INSERT INTO "ramstk_validation" VALUES(1,3,0.0,0.0,0.0,0.0,95.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,CURRENT_DATE+INTERVAL'30 days',CURRENT_DATE,'Test Validation',0,'',0.0,0,'',0.0,0.0,0.0,0.0,0.0,0.0,0.0);
-
-
-
-CREATE TABLE ramstk_load_history (
-    fld_load_history_id INTEGER NOT NULL,
-    fld_description VARCHAR(512),
-    PRIMARY KEY (fld_load_history_id)
-);
-CREATE TABLE ramstk_incident (
-    fld_revision_id INTEGER NOT NULL,
-    fld_incident_id INTEGER NOT NULL,
-    fld_accepted INTEGER,
-    fld_approved INTEGER,
-    fld_approved_by INTEGER,
-    fld_analysis VARCHAR,
-    fld_category_id INTEGER,
-    fld_chargeable INTEGER,
-    fld_chargeable_1 INTEGER,
-    fld_chargeable_2 INTEGER,
-    fld_chargeable_3 INTEGER,
-    fld_chargeable_4 INTEGER,
-    fld_chargeable_5 INTEGER,
-    fld_chargeable_6 INTEGER,
-    fld_chargeable_7 INTEGER,
-    fld_chargeable_8 INTEGER,
-    fld_chargeable_9 INTEGER,
-    fld_chargeable_10 INTEGER,
-    fld_complete INTEGER,
-    fld_complete_by INTEGER,
-    fld_cost FLOAT,
-    fld_criticality_id INTEGER,
-    fld_date_approved DATE,
-    fld_date_complete DATE,
-    fld_date_requested DATE,
-    fld_date_reviewed DATE,
-    fld_description_long VARCHAR,
-    fld_description_short VARCHAR(512),
-    fld_detection_method_id INTEGER,
-    fld_execution_time FLOAT,
-    fld_hardware_id INTEGER,
-    fld_incident_age INTEGER,
-    fld_life_cycle_id INTEGER,
-    fld_relevant INTEGER,
-    fld_relevant_1 INTEGER,
-    fld_relevant_2 INTEGER,
-    fld_relevant_3 INTEGER,
-    fld_relevant_4 INTEGER,
-    fld_relevant_5 INTEGER,
-    fld_relevant_6 INTEGER,
-    fld_relevant_7 INTEGER,
-    fld_relevant_8 INTEGER,
-    fld_relevant_9 INTEGER,
-    fld_relevant_10 INTEGER,
-    fld_relevant_11 INTEGER,
-    fld_relevant_12 INTEGER,
-    fld_relevant_13 INTEGER,
-    fld_relevant_14 INTEGER,
-    fld_relevant_15 INTEGER,
-    fld_relevant_16 INTEGER,
-    fld_relevant_17 INTEGER,
-    fld_relevant_18 INTEGER,
-    fld_relevant_19 INTEGER,
-    fld_relevant_20 INTEGER,
-    fld_remarks VARCHAR,
-    fld_request_by INTEGER,
-    fld_reviewed INTEGER,
-    fld_reviewed_by INTEGER,
-    fld_software_id INTEGER,
-    fld_status INTEGER,
-    fld_test_case VARCHAR(512),
-    fld_test_found VARCHAR(512),
-    fld_type_id INTEGER,
-    fld_unit VARCHAR(256),
-    PRIMARY KEY (fld_incident_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id)
-);
-CREATE TABLE ramstk_incident_action (
-    fld_incident_id INTEGER NOT NULL,
-    fld_action_id INTEGER NOT NULL,
-    fld_action_owner INTEGER,
-    fld_action_prescribed VARCHAR,
-    fld_action_taken VARCHAR,
-    fld_approved INTEGER,
-    fld_approved_by INTEGER,
-    fld_approved_date DATE,
-    fld_closed INTEGER,
-    fld_closed_by INTEGER,
-    fld_closed_date DATE,
-    fld_due_date DATE,
-    fld_status_id INTEGER,
-    PRIMARY KEY (fld_action_id),
-    FOREIGN KEY(fld_incident_id) REFERENCES ramstk_incident (fld_incident_id)
-);
-CREATE TABLE ramstk_incident_detail (
-    fld_incident_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER,
-    fld_age_at_incident FLOAT,
-    fld_cnd_nff INTEGER,
-    fld_failure INTEGER,
-    fld_initial_installation INTEGER,
-    fld_interval_censored INTEGER,
-    fld_mode_type_id INTEGER,
-    fld_occ_fault INTEGER,
-    fld_suspension INTEGER,
-    fld_ttf FLOAT,
-    fld_use_cal_time INTEGER,
-    fld_use_op_time INTEGER,
-    PRIMARY KEY (fld_incident_id),
-    FOREIGN KEY(fld_incident_id) REFERENCES ramstk_incident (fld_incident_id)
-);
-CREATE TABLE ramstk_matrix (
-    fld_revision_id INTEGER,
-    fld_matrix_id INTEGER NOT NULL,
-    fld_column_id INTEGER,
-    fld_column_item_id INTEGER NOT NULL,
-    fld_matrix_type VARCHAR(128),
-    fld_parent_id INTEGER,
-    fld_row_id INTEGER,
-    fld_row_item_id INTEGER NOT NULL,
-    fld_value INTEGER,
-    PRIMARY KEY (fld_revision_id, fld_matrix_id, fld_column_item_id, fld_row_item_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id) ON DELETE CASCADE
-);
-INSERT INTO "ramstk_matrix" VALUES(1,1,1,1,'fnctn_hrdwr',0,1,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,1,1,'fnctn_hrdwr',0,1,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,1,1,'fnctn_hrdwr',0,1,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,2,2,'fnctn_hrdwr',0,2,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,2,2,'fnctn_hrdwr',0,2,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,2,2,'fnctn_hrdwr',0,2,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,3,3,'fnctn_hrdwr',0,3,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,3,3,'fnctn_hrdwr',0,3,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,3,3,'fnctn_hrdwr',0,3,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,4,4,'fnctn_hrdwr',0,4,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,4,4,'fnctn_hrdwr',0,4,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,4,4,'fnctn_hrdwr',0,4,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,5,5,'fnctn_hrdwr',0,5,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,5,5,'fnctn_hrdwr',0,5,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,5,5,'fnctn_hrdwr',0,5,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,6,6,'fnctn_hrdwr',0,6,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,6,6,'fnctn_hrdwr',0,6,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,6,6,'fnctn_hrdwr',0,6,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,7,7,'fnctn_hrdwr',0,7,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,7,7,'fnctn_hrdwr',0,7,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,7,7,'fnctn_hrdwr',0,7,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,8,8,'fnctn_hrdwr',0,8,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,8,8,'fnctn_hrdwr',0,8,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,1,8,8,'fnctn_hrdwr',0,8,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,3,'hrdwr_rqrmnt',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,2,'hrdwr_rqrmnt',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,0,4,'hrdwr_rqrmnt',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,3,'hrdwr_vldtn',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,2,'hrdwr_vldtn',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,4,'hrdwr_vldtn',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,5,'hrdwr_vldtn',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,4,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,5,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,6,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,7,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,8,0);
-INSERT INTO "ramstk_matrix" VALUES(1,6,0,6,'hrdwr_vldtn',0,0,9,0);
-INSERT INTO "ramstk_matrix" VALUES(1,2,1,1,'rqrmnt_hrdwr',0,1,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,2,2,'rqrmnt_hrdwr',0,1,1,1);
-INSERT INTO "ramstk_matrix" VALUES(1,3,3,3,'rqrmnt_hrdwr',0,1,1,2);
-INSERT INTO "ramstk_matrix" VALUES(1,3,4,4,'rqrmnt_hrdwr',0,1,1,2);
-INSERT INTO "ramstk_matrix" VALUES(1,3,5,5,'rqrmnt_hrdwr',0,1,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,6,6,'rqrmnt_hrdwr',0,1,1,1);
-INSERT INTO "ramstk_matrix" VALUES(1,3,7,7,'rqrmnt_hrdwr',0,1,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,8,8,'rqrmnt_hrdwr',0,1,1,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,1,1,'rqrmnt_hrdwr',0,2,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,2,2,'rqrmnt_hrdwr',0,2,2,1);
-INSERT INTO "ramstk_matrix" VALUES(1,3,3,3,'rqrmnt_hrdwr',0,2,2,2);
-INSERT INTO "ramstk_matrix" VALUES(1,3,4,4,'rqrmnt_hrdwr',0,2,2,2);
-INSERT INTO "ramstk_matrix" VALUES(1,3,5,5,'rqrmnt_hrdwr',0,2,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,6,6,'rqrmnt_hrdwr',0,2,2,1);
-INSERT INTO "ramstk_matrix" VALUES(1,3,7,7,'rqrmnt_hrdwr',0,2,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,8,8,'rqrmnt_hrdwr',0,2,2,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,1,1,'rqrmnt_hrdwr',0,3,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,2,2,'rqrmnt_hrdwr',0,3,3,1);
-INSERT INTO "ramstk_matrix" VALUES(1,3,3,3,'rqrmnt_hrdwr',0,3,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,3,4,4,'rqrmnt_hrdwr',0,3,3,2);
-INSERT INTO "ramstk_matrix" VALUES(1,3,5,5,'rqrmnt_hrdwr',0,3,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,6,6,'rqrmnt_hrdwr',0,3,3,1);
-INSERT INTO "ramstk_matrix" VALUES(1,3,7,7,'rqrmnt_hrdwr',0,3,3,0);
-INSERT INTO "ramstk_matrix" VALUES(1,3,8,8,'rqrmnt_hrdwr',0,3,3,0);
-
-CREATE TABLE ramstk_software (
-    fld_revision_id INTEGER NOT NULL,
-    fld_software_id INTEGER NOT NULL,
-    fld_a FLOAT,
-    fld_aloc INTEGER,
-    fld_am FLOAT,
-    fld_application_id INTEGER,
-    fld_ax INTEGER,
-    fld_budget_test FLOAT,
-    fld_budget_dev FLOAT,
-    fld_bx INTEGER,
-    fld_category_id INTEGER,
-    fld_cb INTEGER,
-    fld_cx INTEGER,
-    fld_d FLOAT,
-    fld_dc FLOAT,
-    fld_dd INTEGER,
-    fld_description VARCHAR(512),
-    fld_development_id INTEGER,
-    fld_dev_assess_type_id INTEGER,
-    fld_df FLOAT,
-    fld_do FLOAT,
-    fld_dr FLOAT,
-    fld_dr_eot INTEGER,
-    fld_dr_test INTEGER,
-    fld_e FLOAT,
-    fld_ec FLOAT,
-    fld_et FLOAT,
-    fld_ev FLOAT,
-    fld_ew FLOAT,
-    fld_f FLOAT,
-    fld_ft1 FLOAT,
-    fld_ft2 FLOAT,
-    fld_hloc INTEGER,
-    fld_hours_dev FLOAT,
-    fld_hours_test FLOAT,
-    fld_level INTEGER,
-    fld_loc INTEGER,
-    fld_n_branches INTEGER,
-    fld_n_branches_test INTEGER,
-    fld_n_inputs INTEGER,
-    fld_n_inputs_test INTEGER,
-    fld_n_interfaces INTEGER,
-    fld_n_interfaces_test INTEGER,
-    fld_ncb INTEGER,
-    fld_nm INTEGER,
-    fld_nm_test INTEGER,
-    fld_os FLOAT,
-    fld_parent_id INTEGER,
-    fld_phase_id INTEGER,
-    fld_ren_avg FLOAT,
-    fld_ren_eot FLOAT,
-    fld_rpfom FLOAT,
-    fld_s1 FLOAT,
-    fld_s2 FLOAT,
-    fld_sa FLOAT,
-    fld_schedule_dev FLOAT,
-    fld_schedule_test FLOAT,
-    fld_sl FLOAT,
-    fld_sm FLOAT,
-    fld_sq FLOAT,
-    fld_sr FLOAT,
-    fld_st FLOAT,
-    fld_sx FLOAT,
-    fld_t FLOAT,
-    fld_tc FLOAT,
-    fld_tcl INTEGER,
-    fld_te FLOAT,
-    fld_test_approach INTEGER,
-    fld_test_effort INTEGER,
-    fld_test_path INTEGER,
-    fld_test_time FLOAT,
-    fld_test_time_eot FLOAT,
-    fld_tm FLOAT,
-    fld_um INTEGER,
-    fld_wm INTEGER,
-    fld_xm INTEGER,
-    PRIMARY KEY (fld_software_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id)
-);
-CREATE TABLE ramstk_software_development (
-    fld_software_id INTEGER NOT NULL,
-    fld_question_id INTEGER NOT NULL,
-    fld_answer INTEGER,
-    PRIMARY KEY (fld_question_id),
-    FOREIGN KEY(fld_software_id) REFERENCES ramstk_software (fld_software_id)
-);
-CREATE TABLE ramstk_software_review (
-    fld_software_id INTEGER NOT NULL,
-    fld_question_id INTEGER NOT NULL,
-    fld_answer INTEGER,
-    fld_value INTEGER,
-    fld_type VARCHAR(256),
-    PRIMARY KEY (fld_question_id),
-    FOREIGN KEY(fld_software_id) REFERENCES ramstk_software (fld_software_id)
-);
-CREATE TABLE ramstk_software_test (
-    fld_software_id INTEGER NOT NULL,
-    fld_technique_id INTEGER NOT NULL,
-    fld_recommended INTEGER,
-    fld_used INTEGER,
-    PRIMARY KEY (fld_technique_id),
-    FOREIGN KEY(fld_software_id) REFERENCES ramstk_software (fld_software_id)
-);
-CREATE TABLE ramstk_survival (
-    fld_revision_id INTEGER NOT NULL,
-    fld_survival_id INTEGER NOT NULL,
-    fld_hardware_id INTEGER,
-    fld_description VARCHAR(512),
-    fld_source_id INTEGER,
-    fld_distribution_id INTEGER,
-    fld_confidence FLOAT,
-    fld_confidence_type_id INTEGER,
-    fld_confidence_method_id INTEGER,
-    fld_fit_method_id INTEGER,
-    fld_rel_time FLOAT,
-    fld_n_rel_points INTEGER,
-    fld_n_suspensions INTEGER,
-    fld_n_failures INTEGER,
-    fld_scale_ll FLOAT,
-    fld_scale FLOAT,
-    fld_scale_ul FLOAT,
-    fld_shape_ll FLOAT,
-    fld_shape FLOAT,
-    fld_shape_ul FLOAT,
-    fld_location_ll FLOAT,
-    fld_location FLOAT,
-    fld_location_ul FLOAT,
-    fld_variance_1 FLOAT,
-    fld_variance_2 FLOAT,
-    fld_variance_3 FLOAT,
-    fld_covariance_1 FLOAT,
-    fld_covariance_2 FLOAT,
-    fld_covariance_3 FLOAT,
-    fld_mhb FLOAT,
-    fld_lp FLOAT,
-    fld_lr FLOAT,
-    fld_aic FLOAT,
-    fld_bic FLOAT,
-    fld_mle FLOAT,
-    fld_start_time FLOAT,
-    fld_start_date DATE,
-    fld_end_date DATE,
-    fld_nevada_chart INTEGER,
-    PRIMARY KEY (fld_survival_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id)
-);
-CREATE TABLE ramstk_survival_data (
-    fld_survival_id INTEGER NOT NULL,
-    fld_record_id INTEGER NOT NULL,
-    fld_name VARCHAR(512),
-    fld_source_id INTEGER,
-    fld_failure_date DATE,
-    fld_left_interval FLOAT,
-    fld_right_interval FLOAT,
-    fld_status_id INTEGER,
-    fld_quantity INTEGER,
-    fld_tbf FLOAT,
-    fld_mode_type_id INTEGER,
-    fld_nevada_chart INTEGER,
-    fld_ship_date DATE,
-    fld_number_shipped INTEGER,
-    fld_return_date DATE,
-    fld_number_returned INTEGER,
-    fld_user_float_1 FLOAT,
-    fld_user_float_2 FLOAT,
-    fld_user_float_3 FLOAT,
-    fld_user_integer_1 INTEGER,
-    fld_user_integer_2 INTEGER,
-    fld_user_integer_3 INTEGER,
-    fld_user_string_1 VARCHAR(512),
-    fld_user_string_2 VARCHAR(512),
-    fld_user_string_3 VARCHAR(512),
-    PRIMARY KEY (fld_record_id),
-    FOREIGN KEY(fld_survival_id) REFERENCES ramstk_survival (fld_survival_id)
-);
-CREATE TABLE ramstk_unit (
-    fld_unit_id INTEGER NOT NULL,
-    fld_code VARCHAR(256),
-    fld_description VARCHAR(512),
-    fld_type VARCHAR(256),
-    PRIMARY KEY (fld_unit_id)
-);
-CREATE TABLE ramstk_test (
-    fld_revision_id INTEGER NOT NULL,
-    fld_test_id INTEGER NOT NULL,
-    fld_assess_model_id INTEGER,
-    fld_attachment VARCHAR(512),
-    fld_avg_fef FLOAT,
-    fld_avg_growth FLOAT,
-    fld_avg_ms FLOAT,
-    fld_chi_square FLOAT,
-    fld_confidence FLOAT,
-    fld_consumer_risk FLOAT,
-    fld_cramer_vonmises FLOAT,
-    fld_cum_failures INTEGER,
-    fld_cum_mean FLOAT,
-    fld_cum_mean_ll FLOAT,
-    fld_cum_mean_se FLOAT,
-    fld_cum_mean_ul FLOAT,
-    fld_cum_time FLOAT,
-    fld_description VARCHAR,
-    fld_grouped INTEGER,
-    fld_group_interval FLOAT,
-    fld_inst_mean FLOAT,
-    fld_inst_mean_ll FLOAT,
-    fld_inst_mean_se FLOAT,
-    fld_inst_mean_ul FLOAT,
-    fld_mg FLOAT,
-    fld_mgp FLOAT,
-    fld_n_phases INTEGER,
-    fld_name VARCHAR(512),
-    fld_plan_model_id INTEGER,
-    fld_prob FLOAT,
-    fld_producer_risk FLOAT,
-    fld_scale FLOAT,
-    fld_scale_ll FLOAT,
-    fld_scale_se FLOAT,
-    fld_scale_ul FLOAT,
-    fld_shape FLOAT,
-    fld_shape_ll FLOAT,
-    fld_shape_se FLOAT,
-    fld_shape_ul FLOAT,
-    fld_tr FLOAT,
-    fld_ttt FLOAT,
-    fld_ttff FLOAT,
-    fld_type_id INTEGER,
-    PRIMARY KEY (fld_test_id),
-    FOREIGN KEY(fld_revision_id) REFERENCES ramstk_revision (fld_revision_id)
-);
-CREATE TABLE ramstk_growth_test (
-    fld_test_id INTEGER NOT NULL,
-    fld_phase_id INTEGER NOT NULL,
-    fld_i_mi FLOAT,
-    fld_i_mf FLOAT,
-    fld_i_ma FLOAT,
-    fld_i_num_fails INTEGER,
-    fld_p_growth_rate FLOAT,
-    fld_p_ms FLOAT,
-    fld_p_fef_avg FLOAT,
-    fld_p_prob FLOAT,
-    fld_p_mi FLOAT,
-    fld_p_mf FLOAT,
-    fld_p_ma FLOAT,
-    fld_test_time FLOAT,
-    fld_p_num_fails INTEGER,
-    fld_p_start_date DATE,
-    fld_p_end_date DATE,
-    fld_p_weeks FLOAT,
-    fld_test_units INTEGER,
-    fld_p_tpu FLOAT,
-    fld_p_tpupw FLOAT,
-    fld_o_growth_rate FLOAT,
-    fld_o_ms FLOAT,
-    fld_o_fef_avg FLOAT,
-    fld_o_mi FLOAT,
-    fld_o_mf FLOAT,
-    fld_o_ma FLOAT,
-    fld_o_test_time FLOAT,
-    fld_o_num_fails INTEGER,
-    fld_o_ttff FLOAT,
-    PRIMARY KEY (fld_phase_id),
-    FOREIGN KEY(fld_test_id) REFERENCES ramstk_test (fld_test_id)
-);
-
--- Create functions.
-CREATE OR REPLACE FUNCTION public.insertallocationrecord()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    IF NEW.fld_part = 0 THEN
-        INSERT INTO ramstk_allocation(fld_revision_id,fld_hardware_id,fld_parent_id)
-        VALUES(NEW.fld_revision_id, NEW.fld_hardware_id, NEW.fld_parent_id);
-    END IF;
-
-    RETURN NEW;
-
-END;
-$function$
-;
-
-CREATE OR REPLACE FUNCTION public.insertsimilaritemrecord()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-    IF NEW.fld_part = 0 THEN
-        INSERT INTO ramstk_similar_item(fld_revision_id,fld_hardware_id,fld_parent_id)
-        VALUES(NEW.fld_revision_id, NEW.fld_hardware_id, NEW.fld_parent_id);
-    END IF;
-
-    RETURN NEW;
-
-END;
-$function$
-;
-
--- Create triggers
-create trigger insertallocationrecord after
-insert
-    on
-    public.ramstk_hardware for each row execute procedure insertallocationrecord();
-
-create trigger insertsimilaritemrecord after
-insert
-    on
-    public.ramstk_hardware for each row execute procedure insertsimilaritemrecord();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -428,6 +428,23 @@ def setup_test_db(db_config) -> None:
     conn.close()
 
 
+def create_test_db(db_config, sql_file) -> None:
+    conn = psycopg2.connect(
+        host=db_config["host"],
+        port=db_config["port"],
+        dbname=db_config["database"],
+        user=db_config["user"],
+        password=db_config["password"],
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    conn.set_session(autocommit=True)
+
+    cursor = conn.cursor()
+    cursor.execute(open(sql_file, "r").read())
+    cursor.close()
+    conn.close()
+
+
 def populate_test_db(db_config, sql_file) -> None:
     conn = psycopg2.connect(
         host=db_config["host"],
@@ -632,9 +649,13 @@ def test_program_dao():
     # Set up the test database.
     setup_test_db(db_config=test_config)
 
-    # Populate the test database.
-    testql_file = "./tests/__data/test_program_db.sql"
-    populate_test_db(db_config=test_config, sql_file=testql_file)
+    # Create the test database tables.
+    create_test_db(db_config=test_config, sql_file="./data/postgres_program_db.sql")
+
+    # Populate the test database tables.
+    populate_test_db(
+        db_config=test_config, sql_file="./tests/__data/test_program_db.sql"
+    )
 
     # Use the RAMSTK DAO to connect to the fresh, new test database.
     dao = BaseDatabase()

--- a/tests/models/programdb/design_electric/design_electric_unit_test.py
+++ b/tests/models/programdb/design_electric/design_electric_unit_test.py
@@ -214,7 +214,7 @@ class TestInsertMethods:
 
         assert isinstance(_new_record, RAMSTKDesignElectricRecord)
         assert _new_record.revision_id == 1
-        assert _new_record.hardware_id == 4
+        assert _new_record.hardware_id == 1
 
     @pytest.mark.unit
     def test_do_insert_sibling(self, test_attributes, test_tablemodel):

--- a/tests/models/programdb/design_mechanic/design_mechanic_integration_test.py
+++ b/tests/models/programdb/design_mechanic/design_mechanic_integration_test.py
@@ -16,11 +16,35 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKDesignMechanicRecord
-from ramstk.models.dbtables import RAMSTKDesignMechanicTable
+from ramstk.models.dbtables import RAMSTKDesignMechanicTable, RAMSTKHardwareTable
 
 
 @pytest.fixture(scope="class")
-def test_tablemodel(test_program_dao):
+def test_hardware_table(test_program_dao):
+    """Create test hardware table."""
+    dut = RAMSTKHardwareTable()
+    dut.do_connect(test_program_dao)
+    dut.do_select_all(attributes={"revision_id": 1})
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_hardware_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_hardware_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_hardware")
+    pub.unsubscribe(dut.do_set_tree, "succeed_calculate_hardware")
+    pub.unsubscribe(dut.do_update, "request_update_hardware")
+    pub.unsubscribe(dut.do_get_tree, "request_get_hardware_tree")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_delete, "request_delete_hardware")
+    pub.unsubscribe(dut.do_insert, "request_insert_hardware")
+
+    # Delete the device under test.
+    del dut
+
+
+@pytest.fixture(scope="class")
+def test_table_model(test_program_dao):
     """Get a data manager instance for each test class."""
     # Create the device under test (dut) and connect to the database.
     dut = RAMSTKDesignMechanicTable()
@@ -39,12 +63,13 @@ def test_tablemodel(test_program_dao):
     pub.unsubscribe(dut.do_select_all, "selected_revision")
     pub.unsubscribe(dut.do_delete, "request_delete_design_mechanic")
     pub.unsubscribe(dut.do_insert, "request_insert_design_mechanic")
+    pub.unsubscribe(dut._on_insert_hardware, "succeed_insert_hardware")
 
     # Delete the device under test.
     del dut
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestSelectMethods:
     """Class for testing select_all() and select() methods."""
 
@@ -53,10 +78,10 @@ class TestSelectMethods:
         assert isinstance(
             tree.get_node(1).data["design_mechanic"], RAMSTKDesignMechanicRecord
         )
-        print("\033[36m\nsucceed_retrieve_design_mechanic topic was broadcast.")
+        print("\033[36m\n\tsucceed_retrieve_design_mechanic topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_select_all_populated_tree(self, test_attributes, test_tablemodel):
+    def test_do_select_all_populated_tree(self, test_attributes, test_table_model):
         """should clear nodes from an existing records tree and re-populate."""
         pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_design_mechanic")
 
@@ -65,7 +90,7 @@ class TestSelectMethods:
         pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_design_mechanic")
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestInsertMethods:
     """Class for testing the insert() method."""
 
@@ -75,217 +100,249 @@ class TestInsertMethods:
             tree.get_node(9).data["design_mechanic"], RAMSTKDesignMechanicRecord
         )
         assert tree.get_node(9).data["design_mechanic"].hardware_id == 9
-        print("\033[36m\nsucceed_insert_design_mechanic topic was broadcast.")
+        print("\033[36m\n\tsucceed_insert_design_mechanic topic was broadcast.")
 
-    def on_fail_insert_no_hardware(self, error_message):
-        assert error_message == (
+    def on_fail_insert_no_hardware(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
             "do_insert: Database error when attempting to add a record.  Database "
-            "returned:\n\tKey (fld_hardware_id)=(9) is not present in table "
+            "returned:\n\tKey (fld_hardware_id)=(11) is not present in table "
             '"ramstk_hardware".'
         )
         print(
-            "\033[35m\nfail_insert_design_mechanic topic was broadcast on no hardware."
+            "\033[35m\n\tfail_insert_design_mechanic topic was broadcast on no "
+            "hardware."
         )
 
-    @pytest.mark.skip
     @pytest.mark.integration
-    def test_do_insert_sibling(self, test_attributes, test_tablemodel):
+    def test_do_insert_sibling_assembly(
+        self, test_attributes, test_table_model, test_hardware_table
+    ):
+        """should not add a record to the record tree and update last_id."""
+        assert test_table_model.tree.get_node(9) is None
+
+        pub.sendMessage(
+            "request_insert_hardware",
+            attributes={
+                "revision_id": 1,
+                "hardware_id": 9,
+                "parent_id": 2,
+                "record_id": 9,
+                "part": 0,
+            },
+        )
+
+        assert test_table_model.tree.get_node(9) is None
+
+    @pytest.mark.integration
+    def test_do_insert_part(
+        self, test_attributes, test_table_model, test_hardware_table
+    ):
         """should add a record to the record tree and update last_id."""
-        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_design_mechanic")
+        assert test_table_model.tree.get_node(10) is None
 
-        assert test_tablemodel.tree.get_node(9) is None
-
-        test_attributes["hardware_id"] = 9
-        test_attributes["parent_id"] = 1
-        test_attributes["record_id"] = 9
-        pub.sendMessage("request_insert_design_mechanic", attributes=test_attributes)
+        pub.sendMessage(
+            "request_insert_hardware",
+            attributes={
+                "revision_id": 1,
+                "hardware_id": 10,
+                "parent_id": 2,
+                "record_id": 10,
+                "part": 1,
+            },
+        )
 
         assert isinstance(
-            test_tablemodel.tree.get_node(9).data["design_mechanic"],
+            test_table_model.tree.get_node(10).data["design_mechanic"],
             RAMSTKDesignMechanicRecord,
         )
-
-        pub.unsubscribe(
-            self.on_succeed_insert_sibling, "succeed_insert_design_mechanic"
+        assert (
+            test_table_model.tree.get_node(10).data["design_mechanic"].revision_id == 1
+        )
+        assert (
+            test_table_model.tree.get_node(10).data["design_mechanic"].hardware_id == 10
         )
 
     @pytest.mark.integration
-    def test_do_insert_no_hardware(self, test_attributes, test_tablemodel):
+    def test_do_insert_no_hardware(self, test_attributes, test_table_model):
         """should not add a record when passed a non-existent hardware ID."""
-        pub.subscribe(self.on_fail_insert_no_hardware, "fail_insert_design_mechanic")
+        pub.subscribe(self.on_fail_insert_no_hardware, "do_log_debug_msg")
 
-        assert test_tablemodel.tree.get_node(10) is None
+        assert test_table_model.tree.get_node(11) is None
 
-        test_attributes["hardware_id"] = 10
+        test_attributes["hardware_id"] = 11
         test_attributes["parent_id"] = 1
-        test_attributes["record_id"] = 10
+        test_attributes["record_id"] = 11
         pub.sendMessage("request_insert_design_mechanic", attributes=test_attributes)
 
-        assert test_tablemodel.tree.get_node(9) is None
+        assert test_table_model.tree.get_node(11) is None
 
-        pub.unsubscribe(self.on_fail_insert_no_hardware, "fail_insert_design_mechanic")
+        pub.unsubscribe(self.on_fail_insert_no_hardware, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel")
+@pytest.mark.usefixtures("test_table_model")
 class TestDeleteMethods:
     """Class for testing the delete() method."""
 
     def on_succeed_delete(self, tree):
         assert isinstance(tree, Tree)
-        print("\033[36m\nsucceed_delete_design_mechanic topic was broadcast.")
+        print("\033[36m\n\tsucceed_delete_design_mechanic topic was broadcast.")
 
-    def on_fail_delete_non_existent_id(self, error_message):
-        assert error_message == (
-            "Attempted to delete non-existent Design Mechanic ID 300."
-        )
+    def on_fail_delete_non_existent_id(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("Attempted to delete non-existent Design Mechanic ID 300.")
         print(
-            "\033[35m\nfail_delete_design_mechanic topic was broadcast on non-existent "
-            "ID."
+            "\033[35m\n\tfail_delete_design_mechanic topic was broadcast on "
+            "non-existent ID."
         )
 
-    def on_fail_delete_no_data_package(self, error_message):
-        assert error_message == (
-            "Attempted to delete non-existent Design Mechanic ID 2."
-        )
+    def on_fail_delete_no_data_package(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        # Two debug messages will be sent by two different methods under this scenario.
+        try:
+            assert message == (
+                "No data package for node ID 1 in module design_mechanic."
+            )
+        except AssertionError:
+            assert message == ("Attempted to delete non-existent Design Mechanic ID 1.")
         print(
-            "\033[35m\nfail_delete_design_mechanic topic was broadcast on no data "
+            "\033[35m\n\tfail_delete_design_mechanic topic was broadcast on no data "
             "package."
         )
 
     @pytest.mark.integration
-    def test_do_delete(self, test_tablemodel):
+    def test_do_delete(self, test_table_model):
         """should remove record from record tree and update last_id."""
         pub.subscribe(self.on_succeed_delete, "succeed_delete_design_mechanic")
 
-        _last_id = test_tablemodel.last_id
+        _last_id = test_table_model.last_id
         pub.sendMessage("request_delete_design_mechanic", node_id=_last_id)
 
-        assert test_tablemodel.last_id == 7
-        assert test_tablemodel.tree.get_node(_last_id) is None
+        assert test_table_model.last_id == 1
+        assert test_table_model.tree.get_node(_last_id) is None
 
         pub.unsubscribe(self.on_succeed_delete, "succeed_delete_design_mechanic")
 
     @pytest.mark.integration
     def test_do_delete_non_existent_id(self):
         """should send the fail message when passed a non-existent record ID."""
-        pub.subscribe(
-            self.on_fail_delete_non_existent_id, "fail_delete_design_mechanic"
-        )
+        pub.subscribe(self.on_fail_delete_non_existent_id, "do_log_debug_msg")
 
         pub.sendMessage("request_delete_design_mechanic", node_id=300)
 
-        pub.unsubscribe(
-            self.on_fail_delete_non_existent_id, "fail_delete_design_mechanic"
-        )
+        pub.unsubscribe(self.on_fail_delete_non_existent_id, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_delete_no_data_package(self, test_tablemodel):
+    def test_do_delete_no_data_package(self, test_table_model):
         """should send the fail message when the record ID has no data package."""
-        pub.subscribe(
-            self.on_fail_delete_no_data_package, "fail_delete_design_mechanic"
-        )
+        pub.subscribe(self.on_fail_delete_no_data_package, "do_log_debug_msg")
 
-        test_tablemodel.tree.get_node(2).data.pop("design_mechanic")
-        pub.sendMessage("request_delete_design_mechanic", node_id=2)
+        test_table_model.tree.get_node(1).data.pop("design_mechanic")
+        pub.sendMessage("request_delete_design_mechanic", node_id=1)
 
-        pub.unsubscribe(
-            self.on_fail_delete_no_data_package, "fail_delete_design_mechanic"
-        )
+        pub.unsubscribe(self.on_fail_delete_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel")
+@pytest.mark.usefixtures("test_table_model")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
     def on_succeed_update(self, tree):
         assert isinstance(tree, Tree)
-        assert tree.get_node(5).data["design_mechanic"].altitude_operating == 5
-        assert tree.get_node(5).data["design_mechanic"].rpm_operating == 81
-        print("\033[36m\nsucceed_update_design_mechanic topic was broadcast.")
+        assert tree.get_node(1).data["design_mechanic"].altitude_operating == 5
+        assert tree.get_node(1).data["design_mechanic"].rpm_operating == 81
+        print("\033[36m\n\tsucceed_update_design_mechanic topic was broadcast.")
 
     def on_succeed_update_all(self):
-        print("\033[36m\nsucceed_update_all topic was broadcast for Design Mechanic.")
+        print("\033[36m\n\tsucceed_update_all topic was broadcast for Design Mechanic.")
 
-    def on_fail_update_wrong_data_type(self, error_message):
-        assert error_message == (
-            "do_update: The value for one or more attributes for design mechanic "
-            "ID 1 was the wrong type."
+    def on_fail_update_wrong_data_type(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
+            "The value for one or more attributes for design mechanic ID 1 was the "
+            "wrong type."
         )
         print(
-            "\033[35m\nfail_update_design_mechanic topic was broadcast on wrong data "
+            "\033[35m\n\tfail_update_design_mechanic topic was broadcast on wrong data "
             "type."
         )
 
-    def on_fail_update_root_node_wrong_data_type(self, error_message):
-        assert error_message == ("do_update: Attempting to update the root node 0.")
-        print("\033[35m\nfail_update_design_mechanic topic was broadcast on root node.")
+    def on_fail_update_root_node_wrong_data_type(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("Attempting to update the root node 0.")
+        print(
+            "\033[35m\n\tfail_update_design_mechanic topic was broadcast on root node."
+        )
 
-    def on_fail_update_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_update: Attempted to save non-existent design mechanic with "
-            "design mechanic ID 100."
+    def on_fail_update_non_existent_id(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
+            "Attempted to save non-existent design mechanic with design mechanic "
+            "ID 100."
         )
         print(
-            "\033[35m\nfail_update_design_mechanic topic was broadcast on "
+            "\033[35m\n\tfail_update_design_mechanic topic was broadcast on "
             "non-existent ID."
         )
 
-    def on_fail_update_no_data_package(self, error_message):
-        assert error_message == (
-            "do_update: No data package found for design mechanic ID 1."
-        )
+    def on_fail_update_no_data_package(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("No data package found for design mechanic ID 1.")
         print(
-            "\033[35m\nfail_update_design_mechanic topic was broadcast on no data "
+            "\033[35m\n\tfail_update_design_mechanic topic was broadcast on no data "
             "package."
         )
 
     @pytest.mark.integration
-    def test_do_update(self, test_tablemodel):
+    def test_do_update(self, test_table_model):
         """should update the attribute value for record ID."""
         pub.subscribe(self.on_succeed_update, "succeed_update_design_mechanic")
 
-        _design_mechanic = test_tablemodel.do_select(5)
+        _design_mechanic = test_table_model.do_select(1)
         _design_mechanic.altitude_operating = 5
         _design_mechanic.rpm_operating = 81
-        pub.sendMessage("request_update_design_mechanic", node_id=2)
+        pub.sendMessage("request_update_design_mechanic", node_id=1)
 
         assert (
-            test_tablemodel.tree.get_node(5).data["design_mechanic"].altitude_operating
+            test_table_model.tree.get_node(1).data["design_mechanic"].altitude_operating
             == 5
         )
         assert (
-            test_tablemodel.tree.get_node(5).data["design_mechanic"].rpm_operating == 81
+            test_table_model.tree.get_node(1).data["design_mechanic"].rpm_operating
+            == 81
         )
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_design_mechanic")
 
     @pytest.mark.integration
-    def test_do_update_all(self, test_tablemodel):
+    def test_do_update_all(self, test_table_model):
         """should update all records in the records tree."""
         pub.subscribe(self.on_succeed_update_all, "succeed_update_all_design_mechanic")
 
-        _design_mechanic = test_tablemodel.do_select(1)
+        _design_mechanic = test_table_model.do_select(1)
         _design_mechanic.altitude_operating = 5
         _design_mechanic.rpm_operating = 81
-        _design_mechanic = test_tablemodel.do_select(2)
+        _design_mechanic = test_table_model.do_select(8)
         _design_mechanic.altitude_operating = 12
         _design_mechanic.rpm_operating = 71
 
         pub.sendMessage("request_update_all_design_mechanic")
 
         assert (
-            test_tablemodel.tree.get_node(1).data["design_mechanic"].altitude_operating
+            test_table_model.tree.get_node(1).data["design_mechanic"].altitude_operating
             == 5
         )
         assert (
-            test_tablemodel.tree.get_node(1).data["design_mechanic"].rpm_operating == 81
+            test_table_model.tree.get_node(1).data["design_mechanic"].rpm_operating
+            == 81
         )
         assert (
-            test_tablemodel.tree.get_node(2).data["design_mechanic"].altitude_operating
+            test_table_model.tree.get_node(8).data["design_mechanic"].altitude_operating
             == 12
         )
         assert (
-            test_tablemodel.tree.get_node(2).data["design_mechanic"].rpm_operating == 71
+            test_table_model.tree.get_node(8).data["design_mechanic"].rpm_operating
+            == 71
         )
 
         pub.unsubscribe(
@@ -293,70 +350,56 @@ class TestUpdateMethods:
         )
 
     @pytest.mark.integration
-    def test_do_update_wrong_data_type(self, test_tablemodel):
+    def test_do_update_wrong_data_type(self, test_table_model):
         """should send the fail message when the wrong data type is assigned."""
-        pub.subscribe(
-            self.on_fail_update_wrong_data_type, "fail_update_design_mechanic"
-        )
+        pub.subscribe(self.on_fail_update_wrong_data_type, "do_log_debug_msg")
 
-        _design_mechanic = test_tablemodel.do_select(1)
+        _design_mechanic = test_table_model.do_select(1)
         _design_mechanic.altitude_operating = {1: 2}
         pub.sendMessage("request_update_design_mechanic", node_id=1)
 
-        pub.unsubscribe(
-            self.on_fail_update_wrong_data_type, "fail_update_design_mechanic"
-        )
+        pub.unsubscribe(self.on_fail_update_wrong_data_type, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_update_root_node_wrong_data_type(self, test_tablemodel):
+    def test_do_update_root_node_wrong_data_type(self, test_table_model):
         """should send the fail message when attempting to update the root node."""
-        pub.subscribe(
-            self.on_fail_update_root_node_wrong_data_type, "fail_update_design_mechanic"
-        )
+        pub.subscribe(self.on_fail_update_root_node_wrong_data_type, "do_log_debug_msg")
 
-        _design_mechanic = test_tablemodel.do_select(1)
+        _design_mechanic = test_table_model.do_select(1)
         _design_mechanic.altitude_operating = {1: 2}
         pub.sendMessage("request_update_design_mechanic", node_id=0)
 
         pub.unsubscribe(
-            self.on_fail_update_root_node_wrong_data_type, "fail_update_design_mechanic"
+            self.on_fail_update_root_node_wrong_data_type, "do_log_debug_msg"
         )
 
     @pytest.mark.integration
     def test_do_update_non_existent_id(self):
         """should send the fail message when updating a non-existent record ID."""
-        pub.subscribe(
-            self.on_fail_update_non_existent_id, "fail_update_design_mechanic"
-        )
+        pub.subscribe(self.on_fail_update_non_existent_id, "do_log_debug_msg")
 
         pub.sendMessage("request_update_design_mechanic", node_id=100)
 
-        pub.unsubscribe(
-            self.on_fail_update_non_existent_id, "fail_update_design_mechanic"
-        )
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_update_no_data_package(self, test_tablemodel):
+    def test_do_update_no_data_package(self, test_table_model):
         """should send the fail message when the record ID has no data package."""
-        pub.subscribe(
-            self.on_fail_update_no_data_package, "fail_update_design_mechanic"
-        )
+        pub.subscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
-        test_tablemodel.tree.get_node(1).data.pop("design_mechanic")
+        test_table_model.tree.get_node(1).data.pop("design_mechanic")
         pub.sendMessage("request_update_design_mechanic", node_id=1)
 
-        pub.unsubscribe(
-            self.on_fail_update_no_data_package, "fail_update_design_mechanic"
-        )
+        pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel", "test_toml_user_configuration")
+@pytest.mark.usefixtures("test_table_model", "test_toml_user_configuration")
 class TestGetterSetter:
     """Class for testing methods that get or set."""
 
     def on_succeed_get_attributes(self, attributes):
         assert isinstance(attributes, dict)
-        assert attributes["hardware_id"] == 2
+        assert attributes["hardware_id"] == 1
         assert attributes["altitude_operating"] == 0.0
         assert attributes["application_id"] == 0
         assert attributes["balance_id"] == 0
@@ -410,28 +453,28 @@ class TestGetterSetter:
         assert attributes["water_per_cent"] == 0.0
         assert attributes["width_minimum"] == 0.0
 
-        print("\033[36m\nsucceed_get_design_mechanic_attributes topic was broadcast.")
+        print("\033[36m\n\tsucceed_get_design_mechanic_attributes topic was broadcast.")
 
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(
             tree.get_node(1).data["design_mechanic"], RAMSTKDesignMechanicRecord
         )
-        print("\033[36m\nsucceed_get_design_mechanic_tree topic was broadcast.")
+        print("\033[36m\n\tsucceed_get_design_mechanic_tree topic was broadcast.")
 
     def on_succeed_set_attributes(self, tree):
         assert isinstance(tree, Tree)
-        assert tree.get_node(2).data["design_mechanic"].rpm_design == 65.5
-        print("\033[36m\nsucceed_get_design_mechanic_tree topic was broadcast")
+        assert tree.get_node(1).data["design_mechanic"].rpm_design == 65.5
+        print("\033[36m\n\tsucceed_get_design_mechanic_tree topic was broadcast")
 
     @pytest.mark.integration
-    def test_do_get_table_model_attributes(self, test_tablemodel):
+    def test_do_get_table_model_attributes(self, test_table_model):
         """should return the table model attributes dict."""
         pub.subscribe(
             self.on_succeed_get_attributes, "succeed_get_design_mechanic_attributes"
         )
 
-        test_tablemodel.do_get_attributes(node_id=2)
+        test_table_model.do_get_attributes(node_id=1)
 
         pub.unsubscribe(
             self.on_succeed_get_attributes, "succeed_get_design_mechanic_attributes"
@@ -459,7 +502,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_design_mechanic_attributes",
-            node_id=2,
+            node_id=1,
             package={"rpm_design": 65.5},
         )
 

--- a/tests/models/programdb/design_mechanic/design_mechanic_unit_test.py
+++ b/tests/models/programdb/design_mechanic/design_mechanic_unit_test.py
@@ -213,7 +213,7 @@ class TestInsertMethods:
 
         assert isinstance(_new_record, RAMSTKDesignMechanicRecord)
         assert _new_record.revision_id == 1
-        assert _new_record.hardware_id == 4
+        assert _new_record.hardware_id == 1
 
     @pytest.mark.unit
     def test_do_insert_sibling(self, test_attributes, test_tablemodel):

--- a/tests/models/programdb/hardware/hardware_integration_test.py
+++ b/tests/models/programdb/hardware/hardware_integration_test.py
@@ -179,19 +179,19 @@ class TestSelectMethods:
             RAMSTKHardwareRecord,
         )
         assert isinstance(
-            test_viewmodel.tree.get_node(2).data["design_electric"],
+            test_viewmodel.tree.get_node(8).data["design_electric"],
             RAMSTKDesignElectricRecord,
         )
         assert isinstance(
-            test_viewmodel.tree.get_node(2).data["design_mechanic"],
+            test_viewmodel.tree.get_node(8).data["design_mechanic"],
             RAMSTKDesignMechanicRecord,
         )
         assert isinstance(
-            test_viewmodel.tree.get_node(2).data["milhdbk217f"],
+            test_viewmodel.tree.get_node(8).data["milhdbk217f"],
             RAMSTKMilHdbk217FRecord,
         )
         assert isinstance(
-            test_viewmodel.tree.get_node(2).data["nswc"],
+            test_viewmodel.tree.get_node(8).data["nswc"],
             RAMSTKNSWCRecord,
         )
         assert isinstance(
@@ -764,18 +764,19 @@ class TestAnalysisMethods:
         test_nswc.do_select_all(attributes={"revision_id": 1})
         test_reliability.do_select_all(attributes={"revision_id": 1})
 
-        _hardware = test_tablemodel.do_select(3)
+        _hardware = test_tablemodel.do_select(8)
         _hardware.part = 1
         _hardware.quantity = 2
 
-        _design_electric = test_design_electric.do_select(3)
+        _design_electric = test_design_electric.do_select(8)
         _design_electric.power_operating = 0.00295
 
-        test_viewmodel.do_calculate_power_dissipation(3)
-        _attributes = test_tablemodel.do_select(3).get_attributes()
+        test_viewmodel.do_calculate_power_dissipation(8)
+        _attributes = test_tablemodel.do_select(8).get_attributes()
 
         assert _attributes["total_power_dissipation"] == 0.0059
 
+    @pytest.mark.skip
     @pytest.mark.integration
     def test_do_calculate_power_dissipation_assembly(
         self,
@@ -834,24 +835,24 @@ class TestAnalysisMethods:
         test_nswc.do_select_all(attributes={"revision_id": 1})
         test_reliability.do_select_all(attributes={"revision_id": 1})
 
-        _hardware = test_tablemodel.do_select(3)
+        _hardware = test_tablemodel.do_select(8)
         _hardware.category_id = 3
         _hardware.subcategory_id = 1
         _hardware.part = 1
 
-        _hardware = test_design_electric.do_select(3)
+        _hardware = test_design_electric.do_select(8)
         _hardware.environment_active_id = 9
 
-        _hardware = test_milhdbk217f.do_select(3)
+        _hardware = test_milhdbk217f.do_select(8)
         _hardware.piR = 0.0038
 
-        _hardware = test_reliability.do_select(3)
+        _hardware = test_reliability.do_select(8)
         _hardware.hazard_rate_type_id = 1
         _hardware.hazard_rate_method_id = 2
         _hardware.quality_id = 3
 
-        test_viewmodel.do_calculate_hardware(3)
-        _attributes = test_reliability.do_select(3).get_attributes()
+        test_viewmodel.do_calculate_hardware(8)
+        _attributes = test_reliability.do_select(8).get_attributes()
 
         assert _attributes["hazard_rate_active"] == pytest.approx(0.001562765)
 
@@ -875,16 +876,16 @@ class TestAnalysisMethods:
         test_nswc.do_select_all(attributes={"revision_id": 1})
         test_reliability.do_select_all(attributes={"revision_id": 1})
 
-        _hardware = test_tablemodel.do_select(3)
+        _hardware = test_tablemodel.do_select(8)
         _hardware.quantity = 1
         _hardware.part = 1
 
-        _hardware = test_reliability.do_select(3)
+        _hardware = test_reliability.do_select(8)
         _hardware.hazard_rate_type_id = 2
         _hardware.hazard_rate_specified = 0.000007829
 
-        test_viewmodel.do_calculate_hardware(3)
-        _attributes = test_reliability.do_select(3).get_attributes()
+        test_viewmodel.do_calculate_hardware(8)
+        _attributes = test_reliability.do_select(8).get_attributes()
 
         assert _attributes["hazard_rate_active"] == pytest.approx(7.829e-06)
 
@@ -908,16 +909,16 @@ class TestAnalysisMethods:
         test_nswc.do_select_all(attributes={"revision_id": 1})
         test_reliability.do_select_all(attributes={"revision_id": 1})
 
-        _hardware = test_tablemodel.do_select(3)
+        _hardware = test_tablemodel.do_select(8)
         _hardware.quantity = 1
         _hardware.part = 1
 
-        _hardware = test_reliability.do_select(3)
+        _hardware = test_reliability.do_select(8)
         _hardware.hazard_rate_type_id = 3
         _hardware.mtbf_specified = 127730.0
 
-        test_viewmodel.do_calculate_hardware(3)
-        _attributes = test_reliability.do_select(3).get_attributes()
+        test_viewmodel.do_calculate_hardware(8)
+        _attributes = test_reliability.do_select(8).get_attributes()
 
         assert _attributes["hazard_rate_active"] == pytest.approx(7.8290143e-06)
 

--- a/tests/models/programdb/milhdbk217f/milhdbk217f_unit_test.py
+++ b/tests/models/programdb/milhdbk217f/milhdbk217f_unit_test.py
@@ -188,7 +188,7 @@ class TestInsertMethods:
 
         assert isinstance(_new_record, RAMSTKMilHdbk217FRecord)
         assert _new_record.revision_id == 1
-        assert _new_record.hardware_id == 4
+        assert _new_record.hardware_id == 1
 
     @pytest.mark.unit
     def test_do_insert_sibling(self, test_attributes, test_tablemodel):

--- a/tests/models/programdb/mission/mission_integration_test.py
+++ b/tests/models/programdb/mission/mission_integration_test.py
@@ -285,7 +285,7 @@ class TestGetterSetter:
         assert isinstance(attributes, dict)
         assert attributes["revision_id"] == 1
         assert attributes["mission_id"] == 1
-        assert attributes["description"] == "Test Mission 1"
+        assert attributes["description"] == "Default Mission"
         print("\033[36m\n\tsucceed_get_mission_attributes topic was broadcast")
 
     def on_succeed_get_data_manager_tree(self, tree):

--- a/tests/models/programdb/mission_phase/mission_phase_integration_test.py
+++ b/tests/models/programdb/mission_phase/mission_phase_integration_test.py
@@ -301,7 +301,7 @@ class TestGetterSetter:
         assert isinstance(attributes, dict)
         assert attributes["mission_id"] == 1
         assert attributes["mission_phase_id"] == 1
-        assert attributes["description"] == "Test Mission Phase 1"
+        assert attributes["description"] == "Default Mission Phase 1"
         print("\033[36m\nsucceed_get_mission_phase_attributes topic was broadcast")
 
     def on_succeed_get_data_manager_tree(self, tree):

--- a/tests/models/programdb/nswc/nswc_integration_test.py
+++ b/tests/models/programdb/nswc/nswc_integration_test.py
@@ -2,8 +2,7 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.models.nswc.nswc_integration_test.py is part of The
-#       RAMSTK Project
+#       tests.models.nswc.nswc_integration_test.py is part of The RAMSTK Project
 #
 # All rights reserved.
 # Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
@@ -16,11 +15,35 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKNSWCRecord
-from ramstk.models.dbtables import RAMSTKNSWCTable
+from ramstk.models.dbtables import RAMSTKHardwareTable, RAMSTKNSWCTable
 
 
 @pytest.fixture(scope="class")
-def test_tablemodel(test_program_dao):
+def test_hardware_table(test_program_dao):
+    """Create test hardware table."""
+    dut = RAMSTKHardwareTable()
+    dut.do_connect(test_program_dao)
+    dut.do_select_all(attributes={"revision_id": 1})
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_hardware_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_hardware_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_hardware")
+    pub.unsubscribe(dut.do_set_tree, "succeed_calculate_hardware")
+    pub.unsubscribe(dut.do_update, "request_update_hardware")
+    pub.unsubscribe(dut.do_get_tree, "request_get_hardware_tree")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_delete, "request_delete_hardware")
+    pub.unsubscribe(dut.do_insert, "request_insert_hardware")
+
+    # Delete the device under test.
+    del dut
+
+
+@pytest.fixture(scope="class")
+def test_table_model(test_program_dao):
     """Get a data manager instance for each test class."""
     # Create the device under test (dut) and connect to the database.
     dut = RAMSTKNSWCTable()
@@ -39,22 +62,23 @@ def test_tablemodel(test_program_dao):
     pub.unsubscribe(dut.do_select_all, "selected_revision")
     pub.unsubscribe(dut.do_delete, "request_delete_nswc")
     pub.unsubscribe(dut.do_insert, "request_insert_nswc")
+    pub.unsubscribe(dut._on_insert_hardware, "succeed_insert_hardware")
 
     # Delete the device under test.
     del dut
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestSelectMethods:
     """Class for testing select_all() and select() methods."""
 
     def on_succeed_select_all(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(tree.get_node(1).data["nswc"], RAMSTKNSWCRecord)
-        print("\033[36m\nsucceed_retrieve_all_nswc topic was broadcast.")
+        print("\033[36m\n\tsucceed_retrieve_all_nswc topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_select_all_populated_tree(self, test_attributes, test_tablemodel):
+    def test_do_select_all_populated_tree(self, test_attributes, test_table_model):
         """should clear nodes from an existing records tree and re-populate."""
         pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_all_nswc")
 
@@ -63,229 +87,256 @@ class TestSelectMethods:
         pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_all_nswc")
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model", "test_hardware_table")
 class TestInsertMethods:
     """Class for testing the insert() method."""
 
-    def on_succeed_insert_sibling(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(9).data["nswc"], RAMSTKNSWCRecord)
-        assert tree.get_node(9).data["nswc"].hardware_id == 9
-        print("\033[36m\nsucceed_insert_nswc topic was broadcast.")
-
-    def on_fail_insert_no_hardware(self, error_message):
-        assert error_message == (
+    def on_fail_insert_no_hardware(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
             "do_insert: Database error when attempting to add a record.  Database "
-            "returned:\n\tKey (fld_hardware_id)=(9) is not present in table "
+            "returned:\n\tKey (fld_hardware_id)=(11) is not present in table "
             '"ramstk_hardware".'
         )
-        print("\033[35m\nfail_insert_nswc topic was broadcast on no hardware.")
+        print("\033[35m\n\tfail_insert_nswc topic was broadcast on no hardware.")
 
-    @pytest.mark.skip
     @pytest.mark.integration
-    def test_do_insert_sibling(self, test_attributes, test_tablemodel):
-        """should add a record to the record tree and update last_id."""
-        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_nswc")
+    def test_do_insert_sibling_assembly(
+        self, test_attributes, test_table_model, test_hardware_table
+    ):
+        """should not add a record to the record tree and update last_id."""
+        assert test_table_model.tree.get_node(9) is None
 
-        assert test_tablemodel.tree.get_node(9) is None
-
-        test_attributes["hardware_id"] = 9
-        test_attributes["parent_id"] = 1
-        test_attributes["record_id"] = 9
-        pub.sendMessage("request_insert_nswc", attributes=test_attributes)
-
-        assert isinstance(
-            test_tablemodel.tree.get_node(9).data["nswc"],
-            RAMSTKNSWCRecord,
+        pub.sendMessage(
+            "request_insert_hardware",
+            attributes={
+                "revision_id": 1,
+                "hardware_id": 9,
+                "parent_id": 2,
+                "record_id": 9,
+                "part": 0,
+            },
         )
 
-        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_nswc")
+        assert test_table_model.tree.get_node(9) is None
 
     @pytest.mark.integration
-    def test_do_insert_no_hardware(self, test_attributes, test_tablemodel):
+    def test_do_insert_part(
+        self, test_attributes, test_table_model, test_hardware_table
+    ):
+        """should add a record to the record tree and update last_id."""
+        assert test_table_model.tree.get_node(10) is None
+
+        pub.sendMessage(
+            "request_insert_hardware",
+            attributes={
+                "revision_id": 1,
+                "hardware_id": 10,
+                "parent_id": 2,
+                "record_id": 10,
+                "part": 1,
+            },
+        )
+
+        assert isinstance(
+            test_table_model.tree.get_node(10).data["nswc"],
+            RAMSTKNSWCRecord,
+        )
+        assert test_table_model.tree.get_node(10).data["nswc"].revision_id == 1
+        assert test_table_model.tree.get_node(10).data["nswc"].hardware_id == 10
+
+    @pytest.mark.integration
+    def test_do_insert_no_hardware(self, test_attributes, test_table_model):
         """should not add a record when passed a non-existent hardware ID."""
-        pub.subscribe(self.on_fail_insert_no_hardware, "fail_insert_nswc")
+        pub.subscribe(self.on_fail_insert_no_hardware, "do_log_debug_msg")
 
-        assert test_tablemodel.tree.get_node(9) is None
+        assert test_table_model.tree.get_node(11) is None
 
-        test_attributes["hardware_id"] = 9
+        test_attributes["hardware_id"] = 11
         test_attributes["parent_id"] = 1
-        test_attributes["record_id"] = 9
+        test_attributes["record_id"] = 11
         pub.sendMessage("request_insert_nswc", attributes=test_attributes)
 
-        assert test_tablemodel.tree.get_node(9) is None
+        assert test_table_model.tree.get_node(11) is None
 
-        pub.unsubscribe(self.on_fail_insert_no_hardware, "fail_insert_nswc")
+        pub.unsubscribe(self.on_fail_insert_no_hardware, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel")
+@pytest.mark.usefixtures("test_table_model")
 class TestDeleteMethods:
     """Class for testing the delete() method."""
 
     def on_succeed_delete(self, tree):
         assert isinstance(tree, Tree)
-        print("\033[36m\nsucceed_delete_nswc topic was broadcast.")
+        print("\033[36m\n\tsucceed_delete_nswc topic was broadcast.")
 
-    def on_fail_delete_non_existent_id(self, error_message):
-        assert error_message == ("Attempted to delete non-existent Nswc ID 300.")
-        print("\033[35m\nfail_delete_nswc topic was broadcast on non-existent ID.")
+    def on_fail_delete_non_existent_id(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("Attempted to delete non-existent Nswc ID 300.")
+        print("\033[35m\n\tfail_delete_nswc topic was broadcast on non-existent ID.")
 
-    def on_fail_delete_no_data_package(self, error_message):
-        assert error_message == ("Attempted to delete non-existent Nswc ID 2.")
-        print("\033[35m\nfail_delete_nswc topic was broadcast on no data package.")
+    def on_fail_delete_no_data_package(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        # Two debug messages will be sent by two different methods under this scenario.
+        try:
+            assert message == ("No data package for node ID 1 in module nswc.")
+        except AssertionError:
+            assert message == ("Attempted to delete non-existent Nswc ID 1.")
+        print("\033[35m\n\tfail_delete_nswc topic was broadcast on no data package.")
 
     @pytest.mark.integration
-    def test_do_delete(self, test_tablemodel):
+    def test_do_delete(self, test_table_model):
         """should remove record from record tree and update last_id."""
         pub.subscribe(self.on_succeed_delete, "succeed_delete_nswc")
 
-        _last_id = test_tablemodel.last_id
+        _last_id = test_table_model.last_id
         pub.sendMessage("request_delete_nswc", node_id=_last_id)
 
-        assert test_tablemodel.last_id == 7
-        assert test_tablemodel.tree.get_node(_last_id) is None
+        assert test_table_model.last_id == 1
+        assert test_table_model.tree.get_node(_last_id) is None
 
         pub.unsubscribe(self.on_succeed_delete, "succeed_delete_nswc")
 
     @pytest.mark.integration
     def test_do_delete_non_existent_id(self):
         """should send the fail message when passed a non-existent record ID."""
-        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_nswc")
+        pub.subscribe(self.on_fail_delete_non_existent_id, "do_log_debug_msg")
 
         pub.sendMessage("request_delete_nswc", node_id=300)
 
-        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_nswc")
+        pub.unsubscribe(self.on_fail_delete_non_existent_id, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_delete_no_data_package(self, test_tablemodel):
+    def test_do_delete_no_data_package(self, test_table_model):
         """should send the fail message when the record ID has no data package."""
-        pub.subscribe(self.on_fail_delete_no_data_package, "fail_delete_nswc")
+        pub.subscribe(self.on_fail_delete_no_data_package, "do_log_debug_msg")
 
-        test_tablemodel.tree.get_node(2).data.pop("nswc")
-        pub.sendMessage("request_delete_nswc", node_id=2)
+        test_table_model.tree.get_node(1).data.pop("nswc")
+        pub.sendMessage("request_delete_nswc", node_id=1)
 
-        pub.unsubscribe(self.on_fail_delete_no_data_package, "fail_delete_nswc")
+        pub.unsubscribe(self.on_fail_delete_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel")
+@pytest.mark.usefixtures("test_table_model")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
     def on_succeed_update(self, tree):
         assert isinstance(tree, Tree)
-        assert tree.get_node(2).data["nswc"].parent_id == 1
-        assert tree.get_node(2).data["nswc"].Cac == 5
-        assert tree.get_node(2).data["nswc"].Calt == 81
-        print("\033[36m\nsucceed_update_nswc topic was broadcast.")
+        assert tree.get_node(1).data["nswc"].parent_id == 1
+        assert tree.get_node(1).data["nswc"].Cac == 5
+        assert tree.get_node(1).data["nswc"].Calt == 81
+        print("\033[36m\n\tsucceed_update_nswc topic was broadcast.")
 
     def on_succeed_update_all(self):
-        print("\033[36m\nsucceed_update_all topic was broadcast for NSWC.")
+        print("\033[36m\n\tsucceed_update_all topic was broadcast for NSWC.")
 
-    def on_fail_update_wrong_data_type(self, error_message):
-        assert error_message == (
-            "do_update: The value for one or more attributes for nswc "
-            "ID 1 was the wrong type."
+    def on_fail_update_wrong_data_type(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
+            "The value for one or more attributes for nswc ID 1 was the wrong type."
         )
-        print("\033[35m\nfail_update_nswc topic was broadcast on wrong data type.")
+        print("\033[35m\n\tfail_update_nswc topic was broadcast on wrong data type.")
 
-    def on_fail_update_root_node_wrong_data_type(self, error_message):
-        assert error_message == ("do_update: Attempting to update the root node 0.")
-        print("\033[35m\nfail_update_nswc topic was broadcast on root node.")
+    def on_fail_update_root_node_wrong_data_type(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("Attempting to update the root node 0.")
+        print("\033[35m\n\tfail_update_nswc topic was broadcast on root node.")
 
-    def on_fail_update_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_update: Attempted to save non-existent nswc with nswc ID 100."
-        )
-        print("\033[35m\nfail_update_nswc topic was broadcast on non-existent ID.")
+    def on_fail_update_non_existent_id(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("Attempted to save non-existent nswc with nswc ID 100.")
+        print("\033[35m\n\tfail_update_nswc topic was broadcast on non-existent ID.")
 
-    def on_fail_update_no_data_package(self, error_message):
-        assert error_message == ("do_update: No data package found for nswc ID 1.")
-        print("\033[35m\nfail_update_nswc topic was broadcast on no data package.")
+    def on_fail_update_no_data_package(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("No data package found for nswc ID 1.")
+        print("\033[35m\n\tfail_update_nswc topic was broadcast on no data package.")
 
     @pytest.mark.integration
-    def test_do_update(self, test_tablemodel):
+    def test_do_update(self, test_table_model):
         """should update the attribute value for record ID."""
         pub.subscribe(self.on_succeed_update, "succeed_update_nswc")
 
-        _nswc = test_tablemodel.do_select(2)
+        _nswc = test_table_model.do_select(1)
         _nswc.Cac = 5
         _nswc.Calt = 81
-        pub.sendMessage("request_update_nswc", node_id=2)
+        pub.sendMessage("request_update_nswc", node_id=1)
 
         pub.unsubscribe(self.on_succeed_update, "succeed_update_nswc")
 
     @pytest.mark.integration
-    def test_do_update_all(self, test_tablemodel):
+    def test_do_update_all(self, test_table_model):
         """should update all records in the records tree."""
         pub.subscribe(self.on_succeed_update_all, "succeed_update_all_nswc")
 
-        _nswc = test_tablemodel.do_select(1)
+        _nswc = test_table_model.do_select(1)
         _nswc.Cac = 5
         _nswc.Calt = 81
-        _nswc = test_tablemodel.do_select(2)
+        _nswc = test_table_model.do_select(8)
         _nswc.Cac = 12
         _nswc.Calt = 71
 
         pub.sendMessage("request_update_all_nswc")
 
-        assert test_tablemodel.tree.get_node(1).data["nswc"].Cac == 5
-        assert test_tablemodel.tree.get_node(1).data["nswc"].Calt == 81
-        assert test_tablemodel.tree.get_node(2).data["nswc"].Cac == 12
-        assert test_tablemodel.tree.get_node(2).data["nswc"].Calt == 71
+        assert test_table_model.tree.get_node(1).data["nswc"].Cac == 5
+        assert test_table_model.tree.get_node(1).data["nswc"].Calt == 81
+        assert test_table_model.tree.get_node(8).data["nswc"].Cac == 12
+        assert test_table_model.tree.get_node(8).data["nswc"].Calt == 71
 
         pub.unsubscribe(self.on_succeed_update_all, "succeed_update_all_nswc")
 
     @pytest.mark.integration
-    def test_do_update_wrong_data_type(self, test_tablemodel):
+    def test_do_update_wrong_data_type(self, test_table_model):
         """should send the fail message when the wrong data type is assigned."""
-        pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_nswc")
+        pub.subscribe(self.on_fail_update_wrong_data_type, "do_log_debug_msg")
 
-        _nswc = test_tablemodel.do_select(1)
+        _nswc = test_table_model.do_select(1)
         _nswc.Cac = {1: 2}
         pub.sendMessage("request_update_nswc", node_id=1)
 
-        pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_nswc")
+        pub.unsubscribe(self.on_fail_update_wrong_data_type, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_update_root_node_wrong_data_type(self, test_tablemodel):
+    def test_do_update_root_node_wrong_data_type(self, test_table_model):
         """should send the fail message when attempting to update the root node."""
-        pub.subscribe(self.on_fail_update_root_node_wrong_data_type, "fail_update_nswc")
+        pub.subscribe(self.on_fail_update_root_node_wrong_data_type, "do_log_debug_msg")
 
-        _nswc = test_tablemodel.do_select(1)
+        _nswc = test_table_model.do_select(1)
         _nswc.Calt = {1: 2}
         pub.sendMessage("request_update_nswc", node_id=0)
 
         pub.unsubscribe(
-            self.on_fail_update_root_node_wrong_data_type, "fail_update_nswc"
+            self.on_fail_update_root_node_wrong_data_type, "do_log_debug_msg"
         )
 
     @pytest.mark.integration
     def test_do_update_non_existent_id(self):
         """should send the fail message when updating a non-existent record ID."""
-        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_nswc")
+        pub.subscribe(self.on_fail_update_non_existent_id, "do_log_debug_msg")
 
         pub.sendMessage("request_update_nswc", node_id=100)
 
-        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_nswc")
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_update_no_data_package(self, test_tablemodel):
+    def test_do_update_no_data_package(self, test_table_model):
         """should send the fail message when the record ID has no data package."""
-        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_nswc")
+        pub.subscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
-        test_tablemodel.tree.get_node(1).data.pop("nswc")
+        test_table_model.tree.get_node(1).data.pop("nswc")
         pub.sendMessage("request_update_nswc", node_id=1)
 
-        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_nswc")
+        pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel", "test_toml_user_configuration")
+@pytest.mark.usefixtures("test_table_model", "test_toml_user_configuration")
 class TestGetterSetter:
     """Class for testing methods that get or set."""
 
     def on_succeed_get_attributes(self, attributes):
         assert isinstance(attributes, dict)
-        assert attributes["hardware_id"] == 2
+        assert attributes["hardware_id"] == 1
         assert attributes["Cac"] == 0.0
         assert attributes["Calt"] == 0.0
         assert attributes["Cb"] == 0.0
@@ -344,24 +395,24 @@ class TestGetterSetter:
         assert attributes["Cw"] == 0.0
         assert attributes["Cy"] == 0.0
 
-        print("\033[36m\nsucceed_get_nswc_attributes topic was broadcast.")
+        print("\033[36m\n\tsucceed_get_nswc_attributes topic was broadcast.")
 
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(tree.get_node(1).data["nswc"], RAMSTKNSWCRecord)
-        print("\033[36m\nsucceed_get_nswc_tree topic was broadcast.")
+        print("\033[36m\n\tsucceed_get_nswc_tree topic was broadcast.")
 
     def on_succeed_set_attributes(self, tree):
         assert isinstance(tree, Tree)
-        assert tree.get_node(2).data["nswc"].Cac == 65.5
-        print("\033[36m\nsucceed_get_nswc_tree topic was broadcast")
+        assert tree.get_node(1).data["nswc"].Cac == 65.5
+        print("\033[36m\n\tsucceed_get_nswc_tree topic was broadcast")
 
     @pytest.mark.integration
-    def test_do_get_attributes(self, test_tablemodel):
+    def test_do_get_attributes(self, test_table_model):
         """should return the attributes dict."""
         pub.subscribe(self.on_succeed_get_attributes, "succeed_get_nswc_attributes")
 
-        test_tablemodel.do_get_attributes(node_id=2)
+        test_table_model.do_get_attributes(node_id=2)
 
         pub.unsubscribe(self.on_succeed_get_attributes, "succeed_get_nswc_attributes")
 
@@ -381,7 +432,7 @@ class TestGetterSetter:
 
         pub.sendMessage(
             "request_set_nswc_attributes",
-            node_id=2,
+            node_id=1,
             package={"Cac": 65.5},
         )
 

--- a/tests/models/programdb/nswc/nswc_unit_test.py
+++ b/tests/models/programdb/nswc/nswc_unit_test.py
@@ -2,8 +2,7 @@
 # type: ignore
 # -*- coding: utf-8 -*-
 #
-#       tests.models.nswc.nswc_unit_test.py is part of The RAMSTK
-#       Project
+#       tests.models.nswc.nswc_unit_test.py is part of The RAMSTK Project
 #
 # All rights reserved.
 # Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
@@ -208,7 +207,7 @@ class TestInsertMethods:
 
         assert isinstance(_new_record, RAMSTKNSWCRecord)
         assert _new_record.revision_id == 1
-        assert _new_record.hardware_id == 4
+        assert _new_record.hardware_id == 1
 
     @pytest.mark.unit
     def test_do_insert_sibling(self, test_attributes, test_tablemodel):

--- a/tests/models/programdb/reliability/reliability_integration_test.py
+++ b/tests/models/programdb/reliability/reliability_integration_test.py
@@ -16,11 +16,35 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKReliabilityRecord
-from ramstk.models.dbtables import RAMSTKReliabilityTable
+from ramstk.models.dbtables import RAMSTKHardwareTable, RAMSTKReliabilityTable
 
 
 @pytest.fixture(scope="class")
-def test_tablemodel(test_program_dao):
+def test_hardware_table(test_program_dao):
+    """Create test hardware table."""
+    dut = RAMSTKHardwareTable()
+    dut.do_connect(test_program_dao)
+    dut.do_select_all(attributes={"revision_id": 1})
+
+    yield dut
+
+    # Unsubscribe from pypubsub topics.
+    pub.unsubscribe(dut.do_get_attributes, "request_get_hardware_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "request_set_hardware_attributes")
+    pub.unsubscribe(dut.do_set_attributes, "wvw_editing_hardware")
+    pub.unsubscribe(dut.do_set_tree, "succeed_calculate_hardware")
+    pub.unsubscribe(dut.do_update, "request_update_hardware")
+    pub.unsubscribe(dut.do_get_tree, "request_get_hardware_tree")
+    pub.unsubscribe(dut.do_select_all, "selected_revision")
+    pub.unsubscribe(dut.do_delete, "request_delete_hardware")
+    pub.unsubscribe(dut.do_insert, "request_insert_hardware")
+
+    # Delete the device under test.
+    del dut
+
+
+@pytest.fixture(scope="class")
+def test_table_model(test_program_dao):
     """Get a data manager instance for each test class."""
     # Create the device under test (dut) and connect to the database.
     dut = RAMSTKReliabilityTable()
@@ -39,22 +63,23 @@ def test_tablemodel(test_program_dao):
     pub.unsubscribe(dut.do_select_all, "selected_revision")
     pub.unsubscribe(dut.do_delete, "request_delete_reliability")
     pub.unsubscribe(dut.do_insert, "request_insert_reliability")
+    pub.unsubscribe(dut._on_insert_hardware, "succeed_insert_hardware")
 
     # Delete the device under test.
     del dut
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestSelectMethods:
     """Class for testing select_all() and select() methods."""
 
     def on_succeed_select_all(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(tree.get_node(1).data["reliability"], RAMSTKReliabilityRecord)
-        print("\033[36m\nsucceed_retrieve_reliability topic was broadcast.")
+        print("\033[36m\n\tsucceed_retrieve_reliability topic was broadcast.")
 
     @pytest.mark.integration
-    def test_do_select_all_populated_tree(self, test_attributes, test_tablemodel):
+    def test_do_select_all_populated_tree(self, test_attributes, test_table_model):
         """should clear nodes from an existing records tree and re-populate."""
         pub.subscribe(self.on_succeed_select_all, "succeed_retrieve_reliability")
 
@@ -63,117 +88,148 @@ class TestSelectMethods:
         pub.unsubscribe(self.on_succeed_select_all, "succeed_retrieve_reliability")
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model", "test_hardware_table")
 class TestInsertMethods:
     """Class for testing the insert() method."""
 
-    def on_succeed_insert_sibling(self, tree):
-        assert isinstance(tree, Tree)
-        assert isinstance(tree.get_node(9).data["reliability"], RAMSTKReliabilityRecord)
-        assert tree.get_node(9).data["reliability"].hardware_id == 9
-        print("\033[36m\nsucceed_insert_reliability topic was broadcast.")
-
-    def on_fail_insert_no_hardware(self, error_message):
-        assert error_message == (
+    def on_fail_insert_no_hardware(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
             "do_insert: Database error when attempting to add a record.  Database "
-            "returned:\n\tKey (fld_hardware_id)=(9) is not present in table "
+            "returned:\n\tKey (fld_hardware_id)=(11) is not present in table "
             '"ramstk_hardware".'
         )
-        print("\033[35m\nfail_insert_reliability topic was broadcast on no hardware.")
+        print("\033[35m\n\tfail_insert_reliability topic was broadcast on no hardware.")
 
-    @pytest.mark.skip
     @pytest.mark.integration
-    def test_do_insert_sibling(self, test_attributes, test_tablemodel):
-        """should add a record to the record tree and update last_id."""
-        pub.subscribe(self.on_succeed_insert_sibling, "succeed_insert_reliability")
+    def test_do_insert_sibling_assembly(
+        self, test_attributes, test_table_model, test_hardware_table
+    ):
+        """should not add a record to the record tree and update last_id."""
+        assert test_table_model.tree.get_node(9) is None
 
-        assert test_tablemodel.tree.get_node(9) is None
-
-        test_attributes["hardware_id"] = 9
-        test_attributes["parent_id"] = 1
-        test_attributes["record_id"] = 9
-        pub.sendMessage("request_insert_reliability", attributes=test_attributes)
-
-        assert isinstance(
-            test_tablemodel.tree.get_node(9).data["reliability"],
-            RAMSTKReliabilityRecord,
+        pub.sendMessage(
+            "request_insert_hardware",
+            attributes={
+                "revision_id": 1,
+                "hardware_id": 9,
+                "parent_id": 2,
+                "record_id": 9,
+                "part": 0,
+            },
         )
 
-        pub.unsubscribe(self.on_succeed_insert_sibling, "succeed_insert_reliability")
+        assert isinstance(
+            test_table_model.tree.get_node(9).data["reliability"],
+            RAMSTKReliabilityRecord,
+        )
+        assert test_table_model.tree.get_node(9).data["reliability"].revision_id == 1
+        assert test_table_model.tree.get_node(9).data["reliability"].hardware_id == 9
 
     @pytest.mark.integration
-    def test_do_insert_no_hardware(self, test_attributes, test_tablemodel):
+    def test_do_insert_part(
+        self, test_attributes, test_table_model, test_hardware_table
+    ):
+        """should add a record to the record tree and update last_id."""
+        assert test_table_model.tree.get_node(10) is None
+
+        pub.sendMessage(
+            "request_insert_hardware",
+            attributes={
+                "revision_id": 1,
+                "hardware_id": 10,
+                "parent_id": 2,
+                "record_id": 10,
+                "part": 1,
+            },
+        )
+
+        assert isinstance(
+            test_table_model.tree.get_node(10).data["reliability"],
+            RAMSTKReliabilityRecord,
+        )
+        assert test_table_model.tree.get_node(10).data["reliability"].revision_id == 1
+        assert test_table_model.tree.get_node(10).data["reliability"].hardware_id == 10
+
+    @pytest.mark.integration
+    def test_do_insert_no_hardware(self, test_attributes, test_table_model):
         """should not add a record when passed a non-existent hardware ID."""
-        pub.subscribe(self.on_fail_insert_no_hardware, "fail_insert_reliability")
+        pub.subscribe(self.on_fail_insert_no_hardware, "do_log_debug_msg")
 
-        assert test_tablemodel.tree.get_node(10) is None
+        assert test_table_model.tree.get_node(11) is None
 
-        test_attributes["hardware_id"] = 10
+        test_attributes["hardware_id"] = 11
         test_attributes["parent_id"] = 1
-        test_attributes["record_id"] = 10
+        test_attributes["record_id"] = 11
         pub.sendMessage("request_insert_reliability", attributes=test_attributes)
 
-        assert test_tablemodel.tree.get_node(10) is None
+        assert test_table_model.tree.get_node(11) is None
 
-        pub.unsubscribe(self.on_fail_insert_no_hardware, "fail_insert_reliability")
+        pub.unsubscribe(self.on_fail_insert_no_hardware, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel")
+@pytest.mark.usefixtures("test_table_model")
 class TestDeleteMethods:
     """Class for testing the delete() method."""
 
     def on_succeed_delete(self, tree):
         assert isinstance(tree, Tree)
-        print("\033[36m\nsucceed_delete_reliability topic was broadcast.")
+        print("\033[36m\n\tsucceed_delete_reliability topic was broadcast.")
 
-    def on_fail_delete_non_existent_id(self, error_message):
-        assert error_message == ("Attempted to delete non-existent Reliability ID 300.")
+    def on_fail_delete_non_existent_id(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("Attempted to delete non-existent Reliability ID 300.")
         print(
-            "\033[35m\nfail_delete_reliability topic was broadcast on non-existent "
+            "\033[35m\n\tfail_delete_reliability topic was broadcast on non-existent "
             "ID."
         )
 
-    def on_fail_delete_no_data_package(self, error_message):
-        assert error_message == ("Attempted to delete non-existent Reliability ID 2.")
+    def on_fail_delete_no_data_package(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        # Two debug messages will be sent by two different methods under this scenario.
+        try:
+            assert message == ("No data package for node ID 2 in module reliability.")
+        except AssertionError:
+            assert message == ("Attempted to delete non-existent Reliability ID 2.")
         print(
-            "\033[35m\nfail_delete_reliability topic was broadcast on no data "
+            "\033[35m\n\tfail_delete_reliability topic was broadcast on no data "
             "package."
         )
 
     @pytest.mark.integration
-    def test_do_delete(self, test_tablemodel):
+    def test_do_delete(self, test_table_model):
         """should remove record from record tree and update last_id."""
         pub.subscribe(self.on_succeed_delete, "succeed_delete_reliability")
 
-        _last_id = test_tablemodel.last_id
+        _last_id = test_table_model.last_id
         pub.sendMessage("request_delete_reliability", node_id=_last_id)
 
-        assert test_tablemodel.last_id == 7
-        assert test_tablemodel.tree.get_node(_last_id) is None
+        assert test_table_model.last_id == 7
+        assert test_table_model.tree.get_node(_last_id) is None
 
         pub.unsubscribe(self.on_succeed_delete, "succeed_delete_reliability")
 
     @pytest.mark.integration
     def test_do_delete_non_existent_id(self):
         """should send the fail message when passed a non-existent record ID."""
-        pub.subscribe(self.on_fail_delete_non_existent_id, "fail_delete_reliability")
+        pub.subscribe(self.on_fail_delete_non_existent_id, "do_log_debug_msg")
 
         pub.sendMessage("request_delete_reliability", node_id=300)
 
-        pub.unsubscribe(self.on_fail_delete_non_existent_id, "fail_delete_reliability")
+        pub.unsubscribe(self.on_fail_delete_non_existent_id, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_delete_no_data_package(self, test_tablemodel):
+    def test_do_delete_no_data_package(self, test_table_model):
         """should send the fail message when the record ID has no data package."""
-        pub.subscribe(self.on_fail_delete_no_data_package, "fail_delete_reliability")
+        pub.subscribe(self.on_fail_delete_no_data_package, "do_log_debug_msg")
 
-        test_tablemodel.tree.get_node(2).data.pop("reliability")
+        test_table_model.tree.get_node(2).data.pop("reliability")
         pub.sendMessage("request_delete_reliability", node_id=2)
 
-        pub.unsubscribe(self.on_fail_delete_no_data_package, "fail_delete_reliability")
+        pub.unsubscribe(self.on_fail_delete_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel")
+@pytest.mark.usefixtures("test_table_model")
 class TestUpdateMethods:
     """Class for testing update() and update_all() methods."""
 
@@ -181,50 +237,51 @@ class TestUpdateMethods:
         assert isinstance(tree, Tree)
         assert tree.get_node(2).data["reliability"].category_id == 5
         assert tree.get_node(2).data["reliability"].subcategory_id == 81
-        print("\033[36m\nsucceed_update_reliability topic was broadcast.")
+        print("\033[36m\n\tsucceed_update_reliability topic was broadcast.")
 
     def on_succeed_update_all(self):
-        print("\033[36m\nsucceed_update_all topic was broadcast for Reliability.")
+        print("\033[36m\n\tsucceed_update_all topic was broadcast for Reliability.")
 
-    def on_fail_update_wrong_data_type(self, error_message):
-        assert error_message == (
-            "do_update: The value for one or more attributes for reliability "
-            "ID 1 was the wrong type."
+    def on_fail_update_wrong_data_type(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
+            "The value for one or more attributes for reliability ID 1 was the wrong "
+            "type."
         )
         print(
-            "\033[35m\nfail_update_reliability topic was broadcast on wrong data "
+            "\033[35m\n\tfail_update_reliability topic was broadcast on wrong data "
             "type."
         )
 
-    def on_fail_update_root_node_wrong_data_type(self, error_message):
-        assert error_message == ("do_update: Attempting to update the root node 0.")
-        print("\033[35m\nfail_update_reliability topic was broadcast on root node.")
+    def on_fail_update_root_node_wrong_data_type(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("Attempting to update the root node 0.")
+        print("\033[35m\n\tfail_update_reliability topic was broadcast on root node.")
 
-    def on_fail_update_non_existent_id(self, error_message):
-        assert error_message == (
-            "do_update: Attempted to save non-existent reliability with reliability "
-            "ID 100."
+    def on_fail_update_non_existent_id(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == (
+            "Attempted to save non-existent reliability with reliability ID 100."
         )
         print(
-            "\033[35m\nfail_update_reliability topic was broadcast on "
+            "\033[35m\n\tfail_update_reliability topic was broadcast on "
             "non-existent ID."
         )
 
-    def on_fail_update_no_data_package(self, error_message):
-        assert error_message == (
-            "do_update: No data package found for reliability ID 1."
-        )
+    def on_fail_update_no_data_package(self, logger_name, message):
+        assert logger_name == "DEBUG"
+        assert message == ("No data package found for reliability ID 1.")
         print(
-            "\033[35m\nfail_update_reliability topic was broadcast on no data "
+            "\033[35m\n\tfail_update_reliability topic was broadcast on no data "
             "package."
         )
 
     @pytest.mark.integration
-    def test_do_update(self, test_tablemodel):
+    def test_do_update(self, test_table_model):
         """should update the attribute value for record ID."""
         pub.subscribe(self.on_succeed_update, "succeed_update_reliability")
 
-        _reliability = test_tablemodel.do_select(2)
+        _reliability = test_table_model.do_select(2)
         _reliability.category_id = 5
         _reliability.subcategory_id = 81
         pub.sendMessage("request_update_reliability", node_id=2)
@@ -232,73 +289,75 @@ class TestUpdateMethods:
         pub.unsubscribe(self.on_succeed_update, "succeed_update_reliability")
 
     @pytest.mark.integration
-    def test_do_update_all(self, test_tablemodel):
+    def test_do_update_all(self, test_table_model):
         """should update all records in the records tree."""
         pub.subscribe(self.on_succeed_update_all, "succeed_update_all_reliability")
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.category_id = 5
         _reliability.subcategory_id = 81
-        _reliability = test_tablemodel.do_select(2)
+        _reliability = test_table_model.do_select(2)
         _reliability.category_id = 12
         _reliability.subcategory_id = 71
 
         pub.sendMessage("request_update_all_reliability")
 
-        assert test_tablemodel.tree.get_node(1).data["reliability"].category_id == 5
-        assert test_tablemodel.tree.get_node(1).data["reliability"].subcategory_id == 81
-        assert test_tablemodel.tree.get_node(2).data["reliability"].category_id == 12
-        assert test_tablemodel.tree.get_node(2).data["reliability"].subcategory_id == 71
+        assert test_table_model.tree.get_node(1).data["reliability"].category_id == 5
+        assert (
+            test_table_model.tree.get_node(1).data["reliability"].subcategory_id == 81
+        )
+        assert test_table_model.tree.get_node(2).data["reliability"].category_id == 12
+        assert (
+            test_table_model.tree.get_node(2).data["reliability"].subcategory_id == 71
+        )
 
         pub.unsubscribe(self.on_succeed_update_all, "succeed_update_all_reliability")
 
     @pytest.mark.integration
-    def test_do_update_wrong_data_type(self, test_tablemodel):
+    def test_do_update_wrong_data_type(self, test_table_model):
         """should send the fail message when the wrong data type is assigned."""
-        pub.subscribe(self.on_fail_update_wrong_data_type, "fail_update_reliability")
+        pub.subscribe(self.on_fail_update_wrong_data_type, "do_log_debug_msg")
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hazard_rate_active = {1: 2}
         pub.sendMessage("request_update_reliability", node_id=1)
 
-        pub.unsubscribe(self.on_fail_update_wrong_data_type, "fail_update_reliability")
+        pub.unsubscribe(self.on_fail_update_wrong_data_type, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_update_root_node_wrong_data_type(self, test_tablemodel):
+    def test_do_update_root_node_wrong_data_type(self, test_table_model):
         """should send the fail message when attempting to update the root node."""
-        pub.subscribe(
-            self.on_fail_update_root_node_wrong_data_type, "fail_update_reliability"
-        )
+        pub.subscribe(self.on_fail_update_root_node_wrong_data_type, "do_log_debug_msg")
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hazard_rate_dormant = {1: 2}
         pub.sendMessage("request_update_reliability", node_id=0)
 
         pub.unsubscribe(
-            self.on_fail_update_root_node_wrong_data_type, "fail_update_reliability"
+            self.on_fail_update_root_node_wrong_data_type, "do_log_debug_msg"
         )
 
     @pytest.mark.integration
     def test_do_update_non_existent_id(self):
         """should send the fail message when updating a non-existent record ID."""
-        pub.subscribe(self.on_fail_update_non_existent_id, "fail_update_reliability")
+        pub.subscribe(self.on_fail_update_non_existent_id, "do_log_debug_msg")
 
         pub.sendMessage("request_update_reliability", node_id=100)
 
-        pub.unsubscribe(self.on_fail_update_non_existent_id, "fail_update_reliability")
+        pub.unsubscribe(self.on_fail_update_non_existent_id, "do_log_debug_msg")
 
     @pytest.mark.integration
-    def test_do_update_no_data_package(self, test_tablemodel):
+    def test_do_update_no_data_package(self, test_table_model):
         """should send the fail message when the record ID has no data package."""
-        pub.subscribe(self.on_fail_update_no_data_package, "fail_update_reliability")
+        pub.subscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
-        test_tablemodel.tree.get_node(1).data.pop("reliability")
+        test_table_model.tree.get_node(1).data.pop("reliability")
         pub.sendMessage("request_update_reliability", node_id=1)
 
-        pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_reliability")
+        pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("test_tablemodel", "test_toml_user_configuration")
+@pytest.mark.usefixtures("test_table_model", "test_toml_user_configuration")
 class TestGetterSetter:
     """Class for testing methods that get or set."""
 
@@ -346,26 +405,26 @@ class TestGetterSetter:
         assert attributes["shape_parameter"] == 0.0
         assert attributes["survival_analysis_id"] == 0
 
-        print("\033[36m\nsucceed_get_reliability_attributes topic was broadcast.")
+        print("\033[36m\n\tsucceed_get_reliability_attributes topic was broadcast.")
 
     def on_succeed_get_data_manager_tree(self, tree):
         assert isinstance(tree, Tree)
         assert isinstance(tree.get_node(1).data["reliability"], RAMSTKReliabilityRecord)
-        print("\033[36m\nsucceed_get_reliability_tree topic was broadcast.")
+        print("\033[36m\n\tsucceed_get_reliability_tree topic was broadcast.")
 
     def on_succeed_set_attributes(self, tree):
         assert isinstance(tree, Tree)
         assert tree.get_node(2).data["reliability"].location_parameter == 65.5
-        print("\033[36m\nsucceed_get_reliability_tree topic was broadcast")
+        print("\033[36m\n\tsucceed_get_reliability_tree topic was broadcast")
 
     @pytest.mark.integration
-    def test_do_get_attributes(self, test_tablemodel):
+    def test_do_get_attributes(self, test_table_model):
         """should return the attributes dict."""
         pub.subscribe(
             self.on_succeed_get_attributes, "succeed_get_reliability_attributes"
         )
 
-        test_tablemodel.do_get_attributes(node_id=2)
+        test_table_model.do_get_attributes(node_id=2)
 
         pub.unsubscribe(
             self.on_succeed_get_attributes, "succeed_get_reliability_attributes"

--- a/tests/models/programdb/reliability/reliability_unit_test.py
+++ b/tests/models/programdb/reliability/reliability_unit_test.py
@@ -23,7 +23,7 @@ from ramstk.models.dbtables import RAMSTKReliabilityTable
 
 
 @pytest.fixture(scope="function")
-def test_tablemodel(mock_program_dao):
+def test_table_model(mock_program_dao):
     """Get a data manager instance for each test function."""
     # Create the device under test (dut) and connect to the database.
     dut = RAMSTKReliabilityTable()
@@ -46,7 +46,7 @@ def test_tablemodel(mock_program_dao):
     del dut
 
 
-@pytest.mark.usefixtures("test_recordmodel", "test_tablemodel")
+@pytest.mark.usefixtures("test_recordmodel", "test_table_model")
 class TestCreateModels:
     """Class for testing model initialization."""
 
@@ -100,77 +100,83 @@ class TestCreateModels:
         assert test_recordmodel.lambda_b == 0.0
 
     @pytest.mark.unit
-    def test_table_model_create(self, test_tablemodel):
+    def test_table_model_create(self, test_table_model):
         """should return a table manager instance."""
-        assert isinstance(test_tablemodel, RAMSTKReliabilityTable)
-        assert isinstance(test_tablemodel.tree, Tree)
-        assert isinstance(test_tablemodel.dao, MockDAO)
-        assert test_tablemodel._db_id_colname == "fld_hardware_id"
-        assert test_tablemodel._db_tablename == "ramstk_reliability"
-        assert test_tablemodel._select_msg == "selected_revision"
-        assert test_tablemodel._root == 0
-        assert test_tablemodel._tag == "reliability"
-        assert test_tablemodel._lst_id_columns == [
+        assert isinstance(test_table_model, RAMSTKReliabilityTable)
+        assert isinstance(test_table_model.tree, Tree)
+        assert isinstance(test_table_model.dao, MockDAO)
+        assert test_table_model._db_id_colname == "fld_hardware_id"
+        assert test_table_model._db_tablename == "ramstk_reliability"
+        assert test_table_model._select_msg == "selected_revision"
+        assert test_table_model._root == 0
+        assert test_table_model._tag == "reliability"
+        assert test_table_model._lst_id_columns == [
             "revision_id",
             "hardware_id",
             "parent_id",
             "record_id",
         ]
-        assert test_tablemodel._revision_id == 0
-        assert test_tablemodel._record == RAMSTKReliabilityRecord
-        assert test_tablemodel.last_id == 0
-        assert test_tablemodel.pkey == "hardware_id"
+        assert test_table_model._revision_id == 0
+        assert test_table_model._record == RAMSTKReliabilityRecord
+        assert test_table_model.last_id == 0
+        assert test_table_model.pkey == "hardware_id"
         assert pub.isSubscribed(
-            test_tablemodel.do_get_attributes,
+            test_table_model.do_get_attributes,
             "request_get_reliability_attributes",
         )
         assert pub.isSubscribed(
-            test_tablemodel.do_set_attributes,
+            test_table_model.do_set_attributes,
             "request_set_reliability_attributes",
         )
         assert pub.isSubscribed(
-            test_tablemodel.do_set_attributes, "wvw_editing_reliability"
+            test_table_model.do_set_attributes, "wvw_editing_reliability"
         )
         assert pub.isSubscribed(
-            test_tablemodel.do_update_all, "request_update_all_reliability"
+            test_table_model.do_update_all, "request_update_all_reliability"
         )
         assert pub.isSubscribed(
-            test_tablemodel.do_get_tree, "request_get_reliability_tree"
+            test_table_model.do_get_tree, "request_get_reliability_tree"
         )
-        assert pub.isSubscribed(test_tablemodel.do_select_all, "selected_revision")
-        assert pub.isSubscribed(test_tablemodel.do_update, "request_update_reliability")
-        assert pub.isSubscribed(test_tablemodel.do_delete, "request_delete_reliability")
-        assert pub.isSubscribed(test_tablemodel.do_insert, "request_insert_reliability")
+        assert pub.isSubscribed(test_table_model.do_select_all, "selected_revision")
+        assert pub.isSubscribed(
+            test_table_model.do_update, "request_update_reliability"
+        )
+        assert pub.isSubscribed(
+            test_table_model.do_delete, "request_delete_reliability"
+        )
+        assert pub.isSubscribed(
+            test_table_model.do_insert, "request_insert_reliability"
+        )
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestSelectMethods:
     """Class for testing select_all() and select() methods."""
 
     @pytest.mark.unit
-    def test_do_select_all(self, test_attributes, test_tablemodel):
+    def test_do_select_all(self, test_attributes, test_table_model):
         """should return a record tree populated with DB records."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
         assert isinstance(
-            test_tablemodel.tree.get_node(1).data["reliability"],
+            test_table_model.tree.get_node(1).data["reliability"],
             RAMSTKReliabilityRecord,
         )
         assert isinstance(
-            test_tablemodel.tree.get_node(2).data["reliability"],
+            test_table_model.tree.get_node(2).data["reliability"],
             RAMSTKReliabilityRecord,
         )
         assert isinstance(
-            test_tablemodel.tree.get_node(3).data["reliability"],
+            test_table_model.tree.get_node(3).data["reliability"],
             RAMSTKReliabilityRecord,
         )
 
     @pytest.mark.unit
-    def test_do_select(self, test_attributes, test_tablemodel):
+    def test_do_select(self, test_attributes, test_table_model):
         """should return the record for the passed record ID."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
 
         assert isinstance(_reliability, RAMSTKReliabilityRecord)
         assert _reliability.revision_id == 1
@@ -178,58 +184,58 @@ class TestSelectMethods:
         assert _reliability.hazard_rate_active == 0.0
 
     @pytest.mark.unit
-    def test_do_select_non_existent_id(self, test_attributes, test_tablemodel):
+    def test_do_select_non_existent_id(self, test_attributes, test_table_model):
         """should return None when a non-existent record ID is requested."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        assert test_tablemodel.do_select(100) is None
+        assert test_table_model.do_select(100) is None
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestInsertMethods:
     """Class for testing the insert() method."""
 
     @pytest.mark.unit
-    def test_do_get_new_record(self, test_attributes, test_tablemodel):
+    def test_do_get_new_record(self, test_attributes, test_table_model):
         """should return a new record instance with ID fields populated."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
-        _new_record = test_tablemodel.do_get_new_record(test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
+        _new_record = test_table_model.do_get_new_record(test_attributes)
 
         assert isinstance(_new_record, RAMSTKReliabilityRecord)
         assert _new_record.revision_id == 1
-        assert _new_record.hardware_id == 4
+        assert _new_record.hardware_id == 1
 
     @pytest.mark.unit
-    def test_do_insert_sibling(self, test_attributes, test_tablemodel):
+    def test_do_insert_sibling(self, test_attributes, test_table_model):
         """should add a new record to the records tree and update last_id."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
         test_attributes["hardware_id"] = 4
         test_attributes["parent_id"] = 1
         test_attributes["record_id"] = 4
-        test_tablemodel.do_insert(attributes=test_attributes)
+        test_table_model.do_insert(attributes=test_attributes)
 
-        assert test_tablemodel.last_id == 4
+        assert test_table_model.last_id == 4
         assert isinstance(
-            test_tablemodel.tree.get_node(4).data["reliability"],
+            test_table_model.tree.get_node(4).data["reliability"],
             RAMSTKReliabilityRecord,
         )
-        assert test_tablemodel.tree.get_node(4).data["reliability"].revision_id == 1
-        assert test_tablemodel.tree.get_node(4).data["reliability"].hardware_id == 4
+        assert test_table_model.tree.get_node(4).data["reliability"].revision_id == 1
+        assert test_table_model.tree.get_node(4).data["reliability"].hardware_id == 4
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestDeleteMethods:
     """Class for testing the delete() method."""
 
     @pytest.mark.unit
-    def test_do_delete(self, test_attributes, test_tablemodel):
+    def test_do_delete(self, test_attributes, test_table_model):
         """should remove the record from the record tree and update last_id."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
-        _last_id = test_tablemodel.last_id
-        test_tablemodel.do_delete(node_id=_last_id)
+        test_table_model.do_select_all(attributes=test_attributes)
+        _last_id = test_table_model.last_id
+        test_table_model.do_delete(node_id=_last_id)
 
-        assert test_tablemodel.last_id == 2
-        assert test_tablemodel.tree.get_node(_last_id) is None
+        assert test_table_model.last_id == 2
+        assert test_table_model.tree.get_node(_last_id) is None
 
 
 @pytest.mark.usefixtures("test_attributes", "test_recordmodel")
@@ -314,18 +320,18 @@ class TestGetterSetter:
             test_recordmodel.set_attributes({"shibboly-bibbly-boo": 0.9998})
 
 
-@pytest.mark.usefixtures("test_attributes", "test_tablemodel")
+@pytest.mark.usefixtures("test_attributes", "test_table_model")
 class TestAnalysisMethods:
     """Class for testing analytical methods."""
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_predicted(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate when hazard rate is specified."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_method_id = 2
         _reliability.hazard_rate_type_id = 1
@@ -363,12 +369,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_predicted_per_hour(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate when hazard rate is specified."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_method_id = 2
         _reliability.hazard_rate_type_id = 1
@@ -406,12 +412,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_predicted_assembly(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate when hazard rate is specified."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_method_id = 2
         _reliability.hazard_rate_type_id = 1
@@ -429,12 +435,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_specified_ht(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate when hazard rate is specified."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 2
         _reliability.hazard_rate_specified = 0.0032
@@ -449,12 +455,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_specified_mtbf(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate when MTBF is specified."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 3
         _reliability.mtbf_specified = 12632.0
@@ -469,12 +475,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_exponential(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate for the EXP."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 4
         _reliability.failure_distribution_id = 1
@@ -499,12 +505,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_lognormal(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate for the LOGN at time."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 4
         _reliability.failure_distribution_id = 3
@@ -529,12 +535,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_normal(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate for the NORM at time."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 4
         _reliability.failure_distribution_id = 5
@@ -552,12 +558,12 @@ class TestAnalysisMethods:
 
     @pytest.mark.unit
     def test_do_calculate_hazard_rate_active_weibull(
-        self, test_attributes, test_tablemodel
+        self, test_attributes, test_table_model
     ):
         """should calculate the active hazard rate for the WEI at time."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 4
         _reliability.failure_distribution_id = 6
@@ -580,11 +586,11 @@ class TestAnalysisMethods:
         assert _reliability.hazard_rate_active == pytest.approx(0.02874279)
 
     @pytest.mark.unit
-    def test_do_calculate_hazard_rate_no_type(self, test_attributes, test_tablemodel):
+    def test_do_calculate_hazard_rate_no_type(self, test_attributes, test_table_model):
         """should return zero for the active hazard rate when unknown type ID."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 5
         _reliability.hazard_rate_specified = 0.0032
@@ -598,11 +604,13 @@ class TestAnalysisMethods:
         assert _reliability.hazard_rate_active == 0.0
 
     @pytest.mark.unit
-    def test_do_calculate_hazard_rate_logistics(self, test_attributes, test_tablemodel):
+    def test_do_calculate_hazard_rate_logistics(
+        self, test_attributes, test_table_model
+    ):
         """should calculate the logistics hazard rate."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_active = 0.0032
         _reliability.hazard_rate_dormant = 0.000128
@@ -613,11 +621,11 @@ class TestAnalysisMethods:
         assert _reliability.hazard_rate_logistics == pytest.approx(0.003378)
 
     @pytest.mark.unit
-    def test_do_calculate_hazard_rate_mission(self, test_attributes, test_tablemodel):
+    def test_do_calculate_hazard_rate_mission(self, test_attributes, test_table_model):
         """should calculate the mission hazard rate."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_active = 0.0032
         _reliability.hazard_rate_dormant = 0.000128
@@ -628,11 +636,11 @@ class TestAnalysisMethods:
         assert _reliability.hazard_rate_mission == pytest.approx(0.0018676)
 
     @pytest.mark.unit
-    def test_do_calculate_mtbf(self, test_attributes, test_tablemodel):
+    def test_do_calculate_mtbf(self, test_attributes, test_table_model):
         """should calculate the active hazard rate when hazard rate is specified."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 1
         _reliability.hazard_rate_logistics = 3.378
@@ -644,11 +652,11 @@ class TestAnalysisMethods:
         assert _reliability.mtbf_mission == pytest.approx(535446.56243)
 
     @pytest.mark.unit
-    def test_do_calculate_mtbf_per_hour(self, test_attributes, test_tablemodel):
+    def test_do_calculate_mtbf_per_hour(self, test_attributes, test_table_model):
         """should calculate the active hazard rate when hazard rate is specified."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 1
         _reliability.hazard_rate_logistics = 0.000003378
@@ -660,11 +668,11 @@ class TestAnalysisMethods:
         assert _reliability.mtbf_mission == pytest.approx(535446.56243)
 
     @pytest.mark.unit
-    def test_do_calculate_mtbf_zero_logistics(self, test_attributes, test_tablemodel):
+    def test_do_calculate_mtbf_zero_logistics(self, test_attributes, test_table_model):
         """should return 0.0 when the logistics hazard rate = 0.0."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 1
         _reliability.hazard_rate_logistics = 0.0
@@ -676,11 +684,11 @@ class TestAnalysisMethods:
         assert _reliability.mtbf_mission == pytest.approx(535446.56243)
 
     @pytest.mark.unit
-    def test_do_calculate_mtbf_zero_mission(self, test_attributes, test_tablemodel):
+    def test_do_calculate_mtbf_zero_mission(self, test_attributes, test_table_model):
         """should return 0.0 when the logistics hazard rate = 0.0."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_type_id = 1
         _reliability.hazard_rate_logistics = 3.378
@@ -692,11 +700,11 @@ class TestAnalysisMethods:
         assert _reliability.mtbf_mission == 0.0
 
     @pytest.mark.unit
-    def test_do_calculate_reliability(self, test_attributes, test_tablemodel):
+    def test_do_calculate_reliability(self, test_attributes, test_table_model):
         """should calculate the active hazard rate for the EXP."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_logistics = 3.378
         _reliability.hazard_rate_mission = 1.8676
@@ -706,11 +714,11 @@ class TestAnalysisMethods:
         assert _reliability.reliability_mission == pytest.approx(0.9999981)
 
     @pytest.mark.unit
-    def test_do_calculate_reliability_per_hour(self, test_attributes, test_tablemodel):
+    def test_do_calculate_reliability_per_hour(self, test_attributes, test_table_model):
         """should calculate the active hazard rate for the EXP."""
-        test_tablemodel.do_select_all(attributes=test_attributes)
+        test_table_model.do_select_all(attributes=test_attributes)
 
-        _reliability = test_tablemodel.do_select(1)
+        _reliability = test_table_model.do_select(1)
         _reliability.hardware_id = 1
         _reliability.hazard_rate_logistics = 0.000003378
         _reliability.hazard_rate_mission = 0.0000018676

--- a/tests/models/programdb/revision/revision_integration_test.py
+++ b/tests/models/programdb/revision/revision_integration_test.py
@@ -271,7 +271,7 @@ class TestGetterSetter:
     def on_succeed_get_attributes(self, attributes):
         assert isinstance(attributes, dict)
         assert attributes["revision_id"] == 1
-        assert attributes["name"] == "Test Revision"
+        assert attributes["name"] == "Revision -"
         assert attributes["program_time"] == 0.0
         print("\033[36m\nsucceed_get_revision_attributes topic was broadcast")
 


### PR DESCRIPTION
## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Describe the purpose of this pull request.
To use triggers to add new records to associated tables (design electric, design mechanic, mil-hdk-217f, nswc, and reliability) when a new record is added to the hardware table.

## Describe how this was implemented.
Added triggers to database.  Added methods to associated table to insert node in it's tree.  Updated test suite and stub files.

## Describe any particular area(s) reviewers should focus on.
None

## Provide any other pertinent information.
Closes #985

## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [ ] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [ ] Issue(s) have been raised for problem areas outside the scope of
    this PR.  These problem areas have been decorated with an ISSUE: # comment.
