### PR TITLE
test: add test suite logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,3 +445,7 @@ select = [
 ignore = [
 	"PLR2004",	# Magic value used in comparison.
 ]
+
+[tool.ruff.lint.pylint]
+max-args = 12
+max-positional-args = 6

--- a/tests/models/commondb/category/category_integration_test.py
+++ b/tests/models/commondb/category/category_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKCategoryRecord
-from ramstk.models.dbtables import RAMSTKCategoryTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectCategory(SystemTestSelectMethods):
     """Class for testing Category table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectCategory(SystemTestSelectMethods):
     _tag = "category"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateCategory:
     """Class for testing Category table do_update() and do_update_all() methods."""
 
@@ -203,7 +204,10 @@ class TestUpdateCategory:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterCategory(SystemTestGetterSetterMethods):
     """Class for testing Category table getter and setter methods."""
 

--- a/tests/models/commondb/condition/condition_integration_test.py
+++ b/tests/models/commondb/condition/condition_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKConditionRecord
-from ramstk.models.dbtables import RAMSTKConditionTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectCondition(SystemTestSelectMethods):
     """Class for testing Condition table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectCondition(SystemTestSelectMethods):
     _tag = "condition"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateCondition:
     """Class for testing Condition table do_update() and do_update_all() methods."""
 
@@ -203,7 +204,10 @@ class TestUpdateCondition:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_condition")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterCondition(SystemTestGetterSetterMethods):
     """Class for testing Condition table getter and setter methods."""
 

--- a/tests/models/commondb/failure_mode/failure_mode_integration_test.py
+++ b/tests/models/commondb/failure_mode/failure_mode_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKFailureModeRecord
-from ramstk.models.dbtables import RAMSTKFailureModeTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectFailureMode(SystemTestSelectMethods):
     """Class for testing Failure Mode table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectFailureMode(SystemTestSelectMethods):
     _tag = "failure_mode"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateFailureMode:
     """Class for testing Failure Mode table do_update() and do_update_all() methods."""
 
@@ -213,7 +214,10 @@ class TestUpdateFailureMode:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_failure_mode")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterFailureMode(SystemTestGetterSetterMethods):
     """Class for testing Failure Mode table getter and setter methods."""
 

--- a/tests/models/commondb/group/group_integration_test.py
+++ b/tests/models/commondb/group/group_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKGroupRecord
-from ramstk.models.dbtables import RAMSTKGroupTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectGroup(SystemTestSelectMethods):
     """Class for testing Group table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectGroup(SystemTestSelectMethods):
     _tag = "group"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateGroup:
     """Class for testing Group table do_update() and do_update_all() methods."""
 
@@ -193,7 +194,10 @@ class TestUpdateGroup:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_group")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterGroup(SystemTestGetterSetterMethods):
     """Class for testing Group table getter and setter methods."""
 

--- a/tests/models/commondb/hazards/hazards_integration_test.py
+++ b/tests/models/commondb/hazards/hazards_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKHazardsRecord
-from ramstk.models.dbtables import RAMSTKHazardsTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectHazards(SystemTestSelectMethods):
     """Class for testing Hazards table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectHazards(SystemTestSelectMethods):
     _tag = "hazards"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateHazards:
     """Class for testing Hazards table do_update() and do_update_all() methods."""
 
@@ -207,7 +208,10 @@ class TestUpdateHazards:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_hazards")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterHazards(SystemTestGetterSetterMethods):
     """Class for testing Hazards table getter and setter methods."""
 

--- a/tests/models/commondb/load_history/load_history_integration_test.py
+++ b/tests/models/commondb/load_history/load_history_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKLoadHistoryRecord
-from ramstk.models.dbtables import RAMSTKLoadHistoryTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectLoadHistory(SystemTestSelectMethods):
     """Class for testing Load History table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectLoadHistory(SystemTestSelectMethods):
     _tag = "load_history"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateLoadHistory:
     """Class for testing Load History table do_update() and do_update_all() methods."""
 
@@ -188,7 +189,10 @@ class TestUpdateLoadHistory:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_load_history")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterLoadHistory(SystemTestGetterSetterMethods):
     """Class for testing Load History table getter and setter methods."""
 

--- a/tests/models/commondb/manufacturer/manufacturer_integration_test.py
+++ b/tests/models/commondb/manufacturer/manufacturer_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKManufacturerRecord
-from ramstk.models.dbtables import RAMSTKManufacturerTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectManufacturer(SystemTestSelectMethods):
     """Class for testing Manufacturer table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectManufacturer(SystemTestSelectMethods):
     _tag = "manufacturer"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateManufacturer:
     """Class for testing Manufacturer table do_update() and do_update_all() methods."""
 
@@ -207,7 +208,10 @@ class TestUpdateManufacturer:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_manufacturer")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterManufacturer(SystemTestGetterSetterMethods):
     """Class for testing Manufacturer table getter and setter methods."""
 

--- a/tests/models/commondb/measurement/measurement_integration_test.py
+++ b/tests/models/commondb/measurement/measurement_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKMeasurementRecord
-from ramstk.models.dbtables import RAMSTKMeasurementTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectMeasurement(SystemTestSelectMethods):
     """Class for testing Measurement table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectMeasurement(SystemTestSelectMethods):
     _tag = "measurement"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMeasurement:
     """Class for testing Measurement table do_update() and do_update_all() methods."""
 
@@ -203,7 +204,10 @@ class TestUpdateMeasurement:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_measurement")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMeasurement(SystemTestGetterSetterMethods):
     """Class for testing Measurement table getter and setter methods."""
 

--- a/tests/models/commondb/method/method_integration_test.py
+++ b/tests/models/commondb/method/method_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKMethodRecord
-from ramstk.models.dbtables import RAMSTKMethodTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectMethod(SystemTestSelectMethods):
     """Class for testing Method table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectMethod(SystemTestSelectMethods):
     _tag = "method"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMethod:
     """Class for testing Method table do_update() and do_update_all() methods."""
 
@@ -176,7 +177,10 @@ class TestUpdateMethod:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_method")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMethod(SystemTestGetterSetterMethods):
     """Class for testing Method table getter and setter methods."""
 

--- a/tests/models/commondb/model/model_integration_test.py
+++ b/tests/models/commondb/model/model_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKModelRecord
-from ramstk.models.dbtables import RAMSTKModelTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectModel(SystemTestSelectMethods):
     """Class for testing Model table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectModel(SystemTestSelectMethods):
     _tag = "model"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateModel:
     """Class for testing Model table do_update() and do_update_all() methods."""
 
@@ -180,7 +181,10 @@ class TestUpdateModel:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_model")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterModel(SystemTestGetterSetterMethods):
     """Class for testing Model table getter and setter methods."""
 

--- a/tests/models/commondb/rpn/rpn_integration_test.py
+++ b/tests/models/commondb/rpn/rpn_integration_test.py
@@ -15,16 +15,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKRPNRecord
-from ramstk.models.dbtables import RAMSTKRPNTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectRPN(SystemTestSelectMethods):
     """Class for testing RPN table do_select() and do_select_all() methods."""
 
@@ -35,7 +33,10 @@ class TestSelectRPN(SystemTestSelectMethods):
     _tag = "rpn"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateRPN:
     """Class for testing RPN table do_update() and do_update_all() methods."""
 
@@ -170,7 +171,10 @@ class TestUpdateRPN:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_rpn")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterRPN(SystemTestGetterSetterMethods):
     """Class for testing RPN table getter and setter methods."""
 

--- a/tests/models/commondb/site_info/site_info_integration_test.py
+++ b/tests/models/commondb/site_info/site_info_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKSiteInfoRecord
-from ramstk.models.dbtables import RAMSTKSiteInfoTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectSiteInformation(SystemTestSelectMethods):
     """Class for testing Site Info table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectSiteInformation(SystemTestSelectMethods):
     _tag = "option"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateSiteInfo:
     """Class for testing Site Info table do_update() and do_update_all() methods."""
 
@@ -199,7 +200,10 @@ class TestUpdateSiteInfo:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_option")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterSiteInfo(SystemTestGetterSetterMethods):
     """Class for testing Site Info table getter and setter methods."""
 

--- a/tests/models/commondb/stakeholders/stakeholders_integration_test.py
+++ b/tests/models/commondb/stakeholders/stakeholders_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKStakeholdersRecord
-from ramstk.models.dbtables import RAMSTKStakeholdersTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectStakeholders(SystemTestSelectMethods):
     """Class for testing Stakeholders table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectStakeholders(SystemTestSelectMethods):
     _tag = "stakeholders"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateStakeholders:
     """Class for testing Stakeholders table do_update() and do_update_all() methods."""
 
@@ -176,7 +177,10 @@ class TestUpdateStakeholders:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_stakeholders")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterStakeholders(SystemTestGetterSetterMethods):
     """Class for testing Stakeholders table getter and setter methods."""
 

--- a/tests/models/commondb/status/status_integration_test.py
+++ b/tests/models/commondb/status/status_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKStatusRecord
-from ramstk.models.dbtables import RAMSTKStatusTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectStatus(SystemTestSelectMethods):
     """Class for testing Status table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectStatus(SystemTestSelectMethods):
     _tag = "status"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateStatus:
     """Class for testing Status table do_update() and do_update_all() methods."""
 
@@ -176,7 +177,10 @@ class TestUpdateStatus:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_status")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterStatus(SystemTestGetterSetterMethods):
     """Class for testing Status table getter and setter methods."""
 

--- a/tests/models/commondb/subcategory/subcategory_integration_test.py
+++ b/tests/models/commondb/subcategory/subcategory_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKSubCategoryRecord
-from ramstk.models.dbtables import RAMSTKSubCategoryTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectSubcategory(SystemTestSelectMethods):
     """Class for testing Subcategory table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectSubcategory(SystemTestSelectMethods):
     _tag = "subcategory"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateSubcategory:
     """Class for testing Subcategory table do_update() and do_update_all() methods."""
 
@@ -188,7 +189,10 @@ class TestUpdateSubcategory:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_subcategory")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterSubcategory(SystemTestGetterSetterMethods):
     """Class for testing Subcategory table getter and setter methods."""
 

--- a/tests/models/commondb/test_common_manager.py
+++ b/tests/models/commondb/test_common_manager.py
@@ -66,6 +66,7 @@ def on_fail_read_license(error_message):
     "test_license_file",
     "test_toml_site_configuration",
     "test_toml_user_configuration",
+    "test_suite_logger",
 )
 class TestCommonManager:
     """Class for testing functions to load common variables."""

--- a/tests/models/commondb/type/type_integration_test.py
+++ b/tests/models/commondb/type/type_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKTypeRecord
-from ramstk.models.dbtables import RAMSTKTypeTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectType(SystemTestSelectMethods):
     """Class for testing Type table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectType(SystemTestSelectMethods):
     _tag = "type"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateType:
     """Class for testing Type table do_update() and do_update_all() methods."""
 
@@ -171,7 +172,10 @@ class TestUpdateType:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_type")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterType(SystemTestGetterSetterMethods):
     """Class for testing Type table getter and setter methods."""
 

--- a/tests/models/commondb/user/user_integration_test.py
+++ b/tests/models/commondb/user/user_integration_test.py
@@ -16,16 +16,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKUserRecord
-from ramstk.models.dbtables import RAMSTKUserTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectUser(SystemTestSelectMethods):
     """Class for testing User table do_select() and do_select_all() methods."""
 
@@ -36,7 +34,10 @@ class TestSelectUser(SystemTestSelectMethods):
     _tag = "user"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateUser:
     """Class for testing User table do_update() and do_update_all() methods."""
 
@@ -172,7 +173,10 @@ class TestUpdateUser:
         pub.unsubscribe(self.on_fail_update_no_data_package, "fail_update_user")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterUser(SystemTestGetterSetterMethods):
     """Class for testing User table getter and setter methods."""
 

--- a/tests/models/programdb/action/action_integration_test.py
+++ b/tests/models/programdb/action/action_integration_test.py
@@ -10,12 +10,9 @@
 
 # Third Party Imports
 import pytest
-from pubsub import pub
-from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKActionRecord
-from ramstk.models.dbtables import RAMSTKActionTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +22,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectAction(SystemTestSelectMethods):
     """Class for testing Action table do_select() and do_select_all() methods."""
 
@@ -37,7 +38,11 @@ class TestSelectAction(SystemTestSelectMethods):
     _tag = "action"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertAction(SystemTestInsertMethods):
     """Class for testing Action table do_insert() method."""
 
@@ -58,7 +63,10 @@ class TestInsertAction(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteAction(SystemTestDeleteMethods):
     """Class for testing Action table do_delete() method."""
 
@@ -75,7 +83,10 @@ class TestDeleteAction(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateAction(SystemTestUpdateMethods):
     """Class for testing Action table do_update() and do_update_all() methods."""
 
@@ -89,7 +100,10 @@ class TestUpdateAction(SystemTestUpdateMethods):
     _update_value_obj = "Get a clue"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterAction(SystemTestGetterSetterMethods):
     """Class for testing Action table getter and setter methods."""
 

--- a/tests/models/programdb/allocation/allocation_integration_test.py
+++ b/tests/models/programdb/allocation/allocation_integration_test.py
@@ -16,17 +16,19 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKAllocationRecord
-from ramstk.models.dbtables import RAMSTKAllocationTable, RAMSTKHardwareTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
     SystemTestSelectMethods,
     SystemTestUpdateMethods,
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectAllocation(SystemTestSelectMethods):
     """Class for testing Allocation table do_select() and do_select_all() methods."""
 
@@ -39,7 +41,10 @@ class TestSelectAllocation(SystemTestSelectMethods):
 
 
 @pytest.mark.usefixtures(
-    "test_attributes", "integration_test_table_model", "test_hardware_table_model"
+    "test_attributes",
+    "integration_test_table_model",
+    "test_hardware_table_model",
+    "test_suite_logger",
 )
 class TestInsertAllocation:
     """Class for testing the Allocation do_insert() method."""
@@ -108,7 +113,10 @@ class TestInsertAllocation:
         assert integration_test_table_model.tree.get_node(10) is None
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteAllocation(SystemTestDeleteMethods):
     """Class for testing Allocation table do_delete() method."""
 
@@ -120,7 +128,10 @@ class TestDeleteAllocation(SystemTestDeleteMethods):
     _tag = "allocation"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateAllocation(SystemTestUpdateMethods):
     """Class for testing Allocation update() and update_all() methods."""
 
@@ -135,7 +146,10 @@ class TestUpdateAllocation(SystemTestUpdateMethods):
     _update_value_obj = 0.9832
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterAllocation(SystemTestGetterSetterMethods):
     """Class for testing Allocation table getter and setter methods."""
 
@@ -147,7 +161,11 @@ class TestGetterSetterAllocation(SystemTestGetterSetterMethods):
     _test_id = 1
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestAnalysisAllocation:
     """Class for testing Allocation analytical methods."""
 

--- a/tests/models/programdb/cause/cause_integration_test.py
+++ b/tests/models/programdb/cause/cause_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKCauseRecord
-from ramstk.models.dbtables import RAMSTKCauseTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectCause(SystemTestSelectMethods):
     """Class for testing Cause table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectCause(SystemTestSelectMethods):
     _tag = "cause"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertCause(SystemTestInsertMethods):
     """Class for testing Cause table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertCause(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteCause(SystemTestDeleteMethods):
     """Class for testing Cause table do_delete() method."""
 
@@ -75,7 +85,10 @@ class TestDeleteCause(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateCause:
     """Class for testing Cause table do_update() and do_update_all() methods."""
 
@@ -241,7 +254,10 @@ class TestUpdateCause:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterCause(SystemTestGetterSetterMethods):
     """Class for testing Cause table getter and setter methods."""
 
@@ -253,7 +269,11 @@ class TestGetterSetterCause(SystemTestGetterSetterMethods):
     _test_id = 3
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestCauseAnalysisMethods:
     """Class for testing Cause analytical methods."""
 

--- a/tests/models/programdb/control/control_integration_test.py
+++ b/tests/models/programdb/control/control_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKControlRecord
-from ramstk.models.dbtables import RAMSTKControlTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectControl(SystemTestSelectMethods):
     """Class for testing Control table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectControl(SystemTestSelectMethods):
     _tag = "control"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertControl(SystemTestInsertMethods):
     """Class for testing Control table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertControl(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteControl(SystemTestDeleteMethods):
     """Class for testing Control table do_delete() method."""
 
@@ -75,7 +85,10 @@ class TestDeleteControl(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateControl:
     """Class for testing Control update() and update_all() methods."""
 
@@ -241,7 +254,10 @@ class TestUpdateControl:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterControl(SystemTestGetterSetterMethods):
     """Class for testing Control table getter and setter methods."""
 

--- a/tests/models/programdb/design_electric/design_electric_integration_test.py
+++ b/tests/models/programdb/design_electric/design_electric_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKDesignElectricRecord
-from ramstk.models.dbtables import RAMSTKDesignElectricTable, RAMSTKHardwareTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectDesignElectric(SystemTestSelectMethods):
     """Class for testing Design Electric do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectDesignElectric(SystemTestSelectMethods):
     _tag = "design_electric"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertDesignElectric(SystemTestInsertMethods):
     """Class for testing Design Electric table do_insert() method."""
 
@@ -131,7 +138,10 @@ class TestInsertDesignElectric(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteDesignElectric(SystemTestDeleteMethods):
     """Class for testing Design Electric table do_delete() method."""
 
@@ -147,17 +157,15 @@ class TestDeleteDesignElectric(SystemTestDeleteMethods):
         pass
 
     @pytest.mark.skip(reason="Design Electric records are deleted by database.")
-    def test_do_delete_with_child(self, integration_test_table_model):
-        """Should not run because Design Electric are deleted by database."""
-        pass
-
-    @pytest.mark.skip(reason="Design Electric records are deleted by database.")
     def test_do_delete_non_existent_id(self):
         """Should not run because Design Electric are deleted by database."""
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateDesignElectric:
     """Class for testing Design Electric update() and update_all() methods."""
 
@@ -318,7 +326,10 @@ class TestUpdateDesignElectric:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterDesignElectric(SystemTestGetterSetterMethods):
     """Class for testing Design Electric table getter and setter methods."""
 
@@ -330,7 +341,11 @@ class TestGetterSetterDesignElectric(SystemTestGetterSetterMethods):
     _test_id = 8
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDesignElectricAnalysisMethods:
     """Class for testing Design Electric analytical methods."""
 

--- a/tests/models/programdb/design_mechanic/design_mechanic_integration_test.py
+++ b/tests/models/programdb/design_mechanic/design_mechanic_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKDesignMechanicRecord
-from ramstk.models.dbtables import RAMSTKDesignMechanicTable, RAMSTKHardwareTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectDesignMechanic(SystemTestSelectMethods):
     """Class for testing Design Mechanic do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectDesignMechanic(SystemTestSelectMethods):
     _tag = "design_mechanic"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertDesignMechanic(SystemTestInsertMethods):
     """Class for testing Design Mechanic table do_insert() method."""
 
@@ -131,7 +138,10 @@ class TestInsertDesignMechanic(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteDesignMechanic(SystemTestDeleteMethods):
     """Class for testing Design Mechanic table do_delete() method."""
 
@@ -147,17 +157,15 @@ class TestDeleteDesignMechanic(SystemTestDeleteMethods):
         pass
 
     @pytest.mark.skip(reason="Design Mechanic records are deleted by database.")
-    def test_do_delete_with_child(self, integration_test_table_model):
-        """Should not run because Design Mechanic are deleted by database."""
-        pass
-
-    @pytest.mark.skip(reason="Design Mechanic records are deleted by database.")
     def test_do_delete_non_existent_id(self):
         """Should not run because Design Mechanic are deleted by database."""
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMethodsDesignMechanic:
     """Class for testing Design Mechanic update() and update_all() methods."""
 
@@ -331,7 +339,10 @@ class TestUpdateMethodsDesignMechanic:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterDesignMechanic(SystemTestGetterSetterMethods):
     """Class for testing Design Mechanic table getter and setter methods."""
 

--- a/tests/models/programdb/environment/environment_integration_test.py
+++ b/tests/models/programdb/environment/environment_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKEnvironmentRecord
-from ramstk.models.dbtables import RAMSTKEnvironmentTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectEnvironment(SystemTestSelectMethods):
     """Class for testing Environment do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectEnvironment(SystemTestSelectMethods):
     _tag = "environment"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertEnvironment(SystemTestInsertMethods):
     """Class for testing Environment table do_insert() method."""
 
@@ -68,7 +75,10 @@ class TestInsertEnvironment(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteEnvironment(SystemTestDeleteMethods):
     """Class for testing Environment table do_delete() method."""
 
@@ -94,7 +104,10 @@ class TestDeleteEnvironment(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateEnvironment:
     """Class for testing Environment update() and update_all() methods."""
 
@@ -230,7 +243,10 @@ class TestUpdateEnvironment:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterEnvironment(SystemTestGetterSetterMethods):
     """Class for testing Environment table getter and setter methods."""
 

--- a/tests/models/programdb/failure_definition/failure_definition_integration_test.py
+++ b/tests/models/programdb/failure_definition/failure_definition_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKFailureDefinitionRecord
-from ramstk.models.dbtables import RAMSTKFailureDefinitionTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectFailureDefinition(SystemTestSelectMethods):
     """Class for testing Failure Definition do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectFailureDefinition(SystemTestSelectMethods):
     _tag = "definition"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertFailureDefinition(SystemTestInsertMethods):
     """Class for testing Failure Definition table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertFailureDefinition(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteFailureDefinition(SystemTestDeleteMethods):
     """Class for testing Failure Definition table do_delete() method."""
 
@@ -74,7 +84,10 @@ class TestDeleteFailureDefinition(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateFailureDefinition:
     """Class for testing Failure Definition update() and update_all() methods."""
 
@@ -223,7 +236,10 @@ class TestUpdateFailureDefinition:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterFailureDefinition(SystemTestGetterSetterMethods):
     """Class for testing Failure Definition table getter and setter methods."""
 

--- a/tests/models/programdb/fmea/fmea_integration_test.py
+++ b/tests/models/programdb/fmea/fmea_integration_test.py
@@ -22,7 +22,6 @@ from ramstk.models.dbrecords import (
     RAMSTKMechanismRecord,
     RAMSTKModeRecord,
 )
-from ramstk.models.dbviews import RAMSTKFMEAView
 
 TEST_IDS = {
     "mode": "6",
@@ -40,6 +39,7 @@ TEST_IDS = {
     "test_cause_table_model",
     "test_control_table_model",
     "test_action_table_model",
+    "test_suite_logger",
 )
 class TestSelectFMEA:
     """Class for testing do_select() and do_select_all() methods."""
@@ -249,6 +249,7 @@ class TestSelectFMEA:
     "test_cause_table_model",
     "test_control_table_model",
     "test_action_table_model",
+    "test_suite_logger",
 )
 class TestInsertFMEA:
     """Class for testing the FMEA do_insert() method."""
@@ -405,6 +406,7 @@ class TestInsertFMEA:
     "test_cause_table_model",
     "test_control_table_model",
     "test_action_table_model",
+    "test_suite_logger",
 )
 class TestDeleteFMEA:
     """Class for testing the FMEA do_delete() method."""

--- a/tests/models/programdb/function/function_integration_test.py
+++ b/tests/models/programdb/function/function_integration_test.py
@@ -10,13 +10,9 @@
 
 # Third Party Imports
 import pytest
-import treelib
-from pubsub import pub
-from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKFunctionRecord
-from ramstk.models.dbtables import RAMSTKFunctionTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -26,7 +22,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectFunction(SystemTestSelectMethods):
     """Class for testing Function table do_select() and do_select_all() methods."""
 
@@ -38,7 +38,11 @@ class TestSelectFunction(SystemTestSelectMethods):
     _tag = "function"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertFunction(SystemTestInsertMethods):
     """Class for testing Function table do_insert() method."""
 
@@ -49,7 +53,10 @@ class TestInsertFunction(SystemTestInsertMethods):
     _tag = "function"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteFunction(SystemTestDeleteMethods):
     """Class for testing Function table do_delete() method."""
 
@@ -61,7 +68,10 @@ class TestDeleteFunction(SystemTestDeleteMethods):
     _tag = "function"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateFunction(SystemTestUpdateMethods):
     """Class for testing Function table do_update() and do_update_all() methods."""
 
@@ -75,7 +85,10 @@ class TestUpdateFunction(SystemTestUpdateMethods):
     _update_value_obj = "Test Function"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterFunction(SystemTestGetterSetterMethods):
     """Class for testing Function table getter and setter methods."""
 

--- a/tests/models/programdb/hardware/hardware_integration_test.py
+++ b/tests/models/programdb/hardware/hardware_integration_test.py
@@ -96,7 +96,11 @@ def test_viewmodel():
     del dut
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectHardware(SystemTestSelectMethods):
     """Class for testing Hardware table do_select() and do_select_all() methods."""
 
@@ -108,7 +112,11 @@ class TestSelectHardware(SystemTestSelectMethods):
     _tag = "hardware"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertHardware(SystemTestInsertMethods):
     """Class for testing Hardware table do_insert() method."""
 
@@ -119,7 +127,10 @@ class TestInsertHardware(SystemTestInsertMethods):
     _tag = "hardware"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteHardware(SystemTestDeleteMethods):
     """Class for testing Hardware table do_delete() method."""
 
@@ -131,7 +142,10 @@ class TestDeleteHardware(SystemTestDeleteMethods):
     _tag = "hardware"
 
 
-@pytest.mark.usefixtures("test_tablemodel")
+@pytest.mark.usefixtures(
+    "test_tablemodel",
+    "test_suite_logger",
+)
 class TestUpdateHardware(SystemTestUpdateMethods):
     """Class for testing Hardware table update() and update_all() methods."""
 
@@ -150,7 +164,10 @@ class TestUpdateHardware(SystemTestUpdateMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterHardware(SystemTestGetterSetterMethods):
     """Class for testing Hardware table getter and setter methods."""
 
@@ -171,6 +188,7 @@ class TestGetterSetterHardware(SystemTestGetterSetterMethods):
     "test_milhdbk217f",
     "test_nswc",
     "test_reliability",
+    "test_suite_logger",
 )
 class TestSelectHardwareBoM:
     """Class for testing Hardware BoM select_all() and select() methods."""
@@ -354,6 +372,7 @@ class TestSelectHardwareBoM:
     "test_milhdbk217f",
     "test_nswc",
     "test_reliability",
+    "test_suite_logger",
 )
 class TestInsertHardwareBoM:
     """Class for testing the Hardware BoM insert() method."""
@@ -417,6 +436,7 @@ class TestInsertHardwareBoM:
     "test_milhdbk217f",
     "test_nswc",
     "test_reliability",
+    "test_suite_logger",
 )
 class TestDeleteHardwareBoM:
     """Class for testing the Hardware BoM do_delete() method."""
@@ -473,6 +493,7 @@ class TestDeleteHardwareBoM:
     "test_nswc",
     "test_reliability",
     "test_toml_user_configuration",
+    "test_suite_logger",
 )
 class TestHardwareBoMAnalyses:
     """Class for testing Hardware BoM analytical methods."""

--- a/tests/models/programdb/hazard/hazard_integration_test.py
+++ b/tests/models/programdb/hazard/hazard_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKHazardRecord
-from ramstk.models.dbtables import RAMSTKHazardTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectHazard(SystemTestSelectMethods):
     """Class for testing Hazard table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectHazard(SystemTestSelectMethods):
     _tag = "hazard"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertHazard(SystemTestInsertMethods):
     """Class for testing Hazard table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertHazard(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteHazard(SystemTestDeleteMethods):
     """Class for testing Hazard table do_delete() method."""
 
@@ -75,7 +85,10 @@ class TestDeleteHazard(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateHazard:
     """Class for testing Hazard table do_update() and do_update_all() methods."""
 
@@ -219,7 +232,10 @@ class TestUpdateHazard:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterHazard(SystemTestGetterSetterMethods):
     """Class for testing Hazard table getter and setter methods."""
 
@@ -231,7 +247,10 @@ class TestGetterSetterHazard(SystemTestGetterSetterMethods):
     _test_id = 1
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestHazardAnalysisMethods:
     """Class for testing Hazard analytical methods."""
 

--- a/tests/models/programdb/matrix/matrix_integration_test.py
+++ b/tests/models/programdb/matrix/matrix_integration_test.py
@@ -10,12 +10,9 @@
 
 # Third Party Imports
 import pytest
-from pubsub import pub
-from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKMatrixRecord
-from ramstk.models.dbtables import RAMSTKMatrixTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +22,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectMatrix(SystemTestSelectMethods):
     """Class for testing Matrix table do_select() and do_select_all() methods."""
 
@@ -37,7 +38,11 @@ class TestSelectMatrix(SystemTestSelectMethods):
     _tag = "matrix"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertMatrix(SystemTestInsertMethods):
     """Class for testing Matrix table do_insert() method."""
 
@@ -58,7 +63,10 @@ class TestInsertMatrix(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteMatrix(SystemTestDeleteMethods):
     """Class for testing Matrix table do_delete() method."""
 
@@ -75,7 +83,10 @@ class TestDeleteMatrix(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMatrix(SystemTestUpdateMethods):
     """Class for testing Matrix table do_update() and do_update_all() methods."""
 
@@ -89,7 +100,10 @@ class TestUpdateMatrix(SystemTestUpdateMethods):
     _update_value_obj = "Get a clue"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMatrix(SystemTestGetterSetterMethods):
     """Class for testing Matrix table getter and setter methods."""
 

--- a/tests/models/programdb/mechanism/mechanism_integration_test.py
+++ b/tests/models/programdb/mechanism/mechanism_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKMechanismRecord
-from ramstk.models.dbtables import RAMSTKMechanismTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectMechanism(SystemTestSelectMethods):
     """Class for testing Mechanism table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectMechanism(SystemTestSelectMethods):
     _tag = "mechanism"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertMechanism(SystemTestInsertMethods):
     """Class for testing Mechanism table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertMechanism(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteMechanism(SystemTestDeleteMethods):
     """Class for testing Mechanism table do_delete() method."""
 
@@ -75,7 +85,10 @@ class TestDeleteMechanism(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMechanism:
     """Class for testing Mechanism table do_update() and do_update_all() methods."""
 
@@ -240,7 +253,10 @@ class TestUpdateMechanism:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMechanism(SystemTestGetterSetterMethods):
     """Class for testing Mechanism table getter and setter methods."""
 
@@ -252,7 +268,11 @@ class TestGetterSetterMechanism(SystemTestGetterSetterMethods):
     _test_id = 4
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestMechanismAnalysisMethods:
     """Class for testing Mechanism analytical methods."""
 

--- a/tests/models/programdb/milhdbk217f/milhdbk217f_integration_test.py
+++ b/tests/models/programdb/milhdbk217f/milhdbk217f_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKMilHdbk217FRecord
-from ramstk.models.dbtables import RAMSTKHardwareTable, RAMSTKMILHDBK217FTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectMILHDBK217F(SystemTestSelectMethods):
     """Class for testing MILHDBK217F table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectMILHDBK217F(SystemTestSelectMethods):
     _tag = "milhdbk217f"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertMILHDBK217F(SystemTestInsertMethods):
     """Class for testing MILHDBK217F table do_insert() method."""
 
@@ -137,7 +144,10 @@ class TestInsertMILHDBK217F(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteMILHDBK217F(SystemTestDeleteMethods):
     """Class for testing MILHDBK217F table do_delete() method."""
 
@@ -158,7 +168,10 @@ class TestDeleteMILHDBK217F(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMILHDBK217F:
     """Class for testing MILHDBK217F table do_update() and do_update_all() methods."""
 
@@ -315,7 +328,10 @@ class TestUpdateMILHDBK217F:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMILHDBK217F(SystemTestGetterSetterMethods):
     """Class for testing MILHDBK217F table getter and setter methods."""
 

--- a/tests/models/programdb/mission/mission_integration_test.py
+++ b/tests/models/programdb/mission/mission_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKMissionRecord
-from ramstk.models.dbtables import RAMSTKMissionTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectMission(SystemTestSelectMethods):
     """Class for testing Mission table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectMission(SystemTestSelectMethods):
     _tag = "mission"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertMission(SystemTestInsertMethods):
     """Class for testing Mission table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertMission(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteMission(SystemTestDeleteMethods):
     """Class for testing Mission table do_delete() method."""
 
@@ -74,7 +84,10 @@ class TestDeleteMission(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMission:
     """Class for testing Mission table do_update() and do_update_all() methods."""
 
@@ -210,7 +223,10 @@ class TestUpdateMission:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMission(SystemTestGetterSetterMethods):
     """Class for testing Mission table getter and setter methods."""
 

--- a/tests/models/programdb/mission_phase/mission_phase_integration_test.py
+++ b/tests/models/programdb/mission_phase/mission_phase_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKMissionPhaseRecord
-from ramstk.models.dbtables import RAMSTKMissionPhaseTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -27,7 +26,11 @@ from tests import (
 _test_name = "Big test mission phase"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectMissionPhase(SystemTestSelectMethods):
     """Class for testing Mission Phase do_select() and do_select_all() methods."""
 
@@ -39,7 +42,11 @@ class TestSelectMissionPhase(SystemTestSelectMethods):
     _tag = "mission_phase"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertMissionPhase(SystemTestInsertMethods):
     """Class for testing Mission Phase table do_insert() method."""
 
@@ -60,7 +67,10 @@ class TestInsertMissionPhase(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteMissionPhase(SystemTestDeleteMethods):
     """Class for testing Mission Phase table do_delete() method."""
 
@@ -76,7 +86,10 @@ class TestDeleteMissionPhase(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMissionPhase:
     """Class for testing Mission Phase do_update() and do_update_all() methods."""
 
@@ -243,7 +256,10 @@ class TestUpdateMissionPhase:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMissionPhase(SystemTestGetterSetterMethods):
     """Class for testing Mission Phase table getter and setter methods."""
 

--- a/tests/models/programdb/mode/mode_integration_test.py
+++ b/tests/models/programdb/mode/mode_integration_test.py
@@ -15,7 +15,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKModeRecord
-from ramstk.models.dbtables import RAMSTKModeTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -24,7 +23,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectMode(SystemTestSelectMethods):
     """Class for testing failure Mode table do_select() and do_select_all() methods."""
 
@@ -36,7 +39,11 @@ class TestSelectMode(SystemTestSelectMethods):
     _tag = "mode"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertMode(SystemTestInsertMethods):
     """Class for testing failure Mode table do_insert() method."""
 
@@ -57,7 +64,10 @@ class TestInsertMode(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteMode(SystemTestDeleteMethods):
     """Class for testing failure Mode table do_delete() method."""
 
@@ -73,7 +83,10 @@ class TestDeleteMode(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateMode:
     """Class for testing failure Mode table do_update() and do_update_all() methods."""
 
@@ -229,7 +242,10 @@ class TestUpdateMode:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterMode(SystemTestGetterSetterMethods):
     """Class for testing failure Mode table getter and setter methods."""
 
@@ -241,7 +257,11 @@ class TestGetterSetterMode(SystemTestGetterSetterMethods):
     _test_id = 4
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestModeAnalysisMethods:
     """Class for testing failure Mode table model analytical methods."""
 

--- a/tests/models/programdb/nswc/nswc_integration_test.py
+++ b/tests/models/programdb/nswc/nswc_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKNSWCRecord
-from ramstk.models.dbtables import RAMSTKHardwareTable, RAMSTKNSWCTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectNSWC(SystemTestSelectMethods):
     """Class for testing NSWC table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectNSWC(SystemTestSelectMethods):
     _tag = "nswc"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertNSWC(SystemTestInsertMethods):
     """Class for testing NSWC table do_insert() method."""
 
@@ -116,7 +123,10 @@ class TestInsertNSWC(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteNSWC(SystemTestDeleteMethods):
     """Class for testing NSWC table do_delete() method."""
 
@@ -137,7 +147,10 @@ class TestDeleteNSWC(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateNSWC:
     """Class for testing NSWC table do_update() and do_update_all() methods."""
 
@@ -294,7 +307,10 @@ class TestUpdateNSWC:
         pub.unsubscribe(self.on_fail_update_no_data_package, "do_log_debug_msg")
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterNSWC(SystemTestGetterSetterMethods):
     """Class for testing NSWC table getter and setter methods."""
 

--- a/tests/models/programdb/opload/opload_integration_test.py
+++ b/tests/models/programdb/opload/opload_integration_test.py
@@ -15,7 +15,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKOpLoadRecord
-from ramstk.models.dbtables import RAMSTKOpLoadTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -24,7 +23,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectOpLoad(SystemTestSelectMethods):
     """Class for testing OpLoad table do_select() and do_select_all() methods."""
 
@@ -36,7 +39,11 @@ class TestSelectOpLoad(SystemTestSelectMethods):
     _tag = "opload"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertOpLoad(SystemTestInsertMethods):
     """Class for testing Operating Load table do_insert() method."""
 
@@ -57,7 +64,10 @@ class TestInsertOpLoad(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteOpLoad(SystemTestDeleteMethods):
     """Class for testing Operating Load table do_delete() method."""
 
@@ -73,7 +83,10 @@ class TestDeleteOpLoad(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateOpLoad:
     """Class for testing OpLoad table do_update() and do_update_all() methods."""
 
@@ -248,7 +261,10 @@ class TestUpdateOpLoad:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterOpLoad(SystemTestGetterSetterMethods):
     """Class for testing Operating Load table getter and setter methods."""
 

--- a/tests/models/programdb/opstress/opstress_integration_test.py
+++ b/tests/models/programdb/opstress/opstress_integration_test.py
@@ -15,7 +15,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKOpStressRecord
-from ramstk.models.dbtables import RAMSTKOpStressTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -24,7 +23,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectOpStress(SystemTestSelectMethods):
     """Class for testing OpStress table do_select() and do_select_all() methods."""
 
@@ -36,7 +39,11 @@ class TestSelectOpStress(SystemTestSelectMethods):
     _tag = "opstress"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertOpStress(SystemTestInsertMethods):
     """Class for testing Operating Stress table do_insert() method."""
 
@@ -57,7 +64,10 @@ class TestInsertOpStress(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteOpStress(SystemTestDeleteMethods):
     """Class for testing Operating Stress table do_delete() method."""
 
@@ -73,7 +83,10 @@ class TestDeleteOpStress(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateOpStress:
     """Class for testing Opstress table do_update() and do_update_all() methods."""
 
@@ -229,7 +242,10 @@ class TestUpdateOpStress:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterOpStress(SystemTestGetterSetterMethods):
     """Class for testing Operating Stress table getter and setter methods."""
 

--- a/tests/models/programdb/pof/pof_integration_test.py
+++ b/tests/models/programdb/pof/pof_integration_test.py
@@ -20,13 +20,6 @@ from ramstk.models.dbrecords import (
     RAMSTKOpStressRecord,
     RAMSTKTestMethodRecord,
 )
-from ramstk.models.dbtables import (
-    RAMSTKMechanismTable,
-    RAMSTKOpLoadTable,
-    RAMSTKOpStressTable,
-    RAMSTKTestMethodTable,
-)
-from ramstk.models.dbviews import RAMSTKPoFView
 
 
 @pytest.mark.usefixtures(
@@ -35,6 +28,7 @@ from ramstk.models.dbviews import RAMSTKPoFView
     "test_opload_table_model",
     "test_opstress_table_model",
     "test_test_method_table_model",
+    "test_suite_logger",
 )
 class TestSelectPoF:
     """Class for testing PoF on_select_all() methods."""
@@ -225,6 +219,7 @@ class TestSelectPoF:
     "test_opload_table_model",
     "test_opstress_table_model",
     "test_test_method_table_model",
+    "test_suite_logger",
 )
 class TestInsertPoF:
     """Class for testing the PoF do_insert() method."""
@@ -386,6 +381,7 @@ class TestInsertPoF:
     "test_opload_table_model",
     "test_opstress_table_model",
     "test_test_method_table_model",
+    "test_suite_logger",
 )
 class TestDeletePoF:
     """Class for testing the PoF do_delete() method."""

--- a/tests/models/programdb/program_info/program_info_integration_test.py
+++ b/tests/models/programdb/program_info/program_info_integration_test.py
@@ -9,8 +9,6 @@
 # Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Program Information integrations."""
 
-# Standard Library Imports
-from datetime import date
 
 # Third Party Imports
 import pytest
@@ -19,16 +17,14 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKProgramInfoRecord
-from ramstk.models.dbtables import RAMSTKProgramInfoTable
-from tests import (
-    SystemTestDeleteMethods,
-    SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
-    SystemTestSelectMethods,
+from tests import SystemTestGetterSetterMethods, SystemTestSelectMethods
+
+
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
 )
-
-
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
 class TestSelectProgramInfo(SystemTestSelectMethods):
     """Class for testing ProgramInfo table do_select() and do_select_all() methods."""
 
@@ -40,7 +36,10 @@ class TestSelectProgramInfo(SystemTestSelectMethods):
     _tag = "preference"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateProgramInfo:
     """Class for testing ProgramInfo table do_update() and do_update_all() methods."""
 
@@ -232,7 +231,10 @@ class TestUpdateProgramInfo:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterProgramInfo(SystemTestGetterSetterMethods):
     """Class for testing Program Information table getter and setter methods."""
 

--- a/tests/models/programdb/program_status/program_status_integration_test.py
+++ b/tests/models/programdb/program_status/program_status_integration_test.py
@@ -28,7 +28,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectProgramStatus(SystemTestSelectMethods):
     """Class for testing Prog Status table do_select() and do_select_all() methods."""
 
@@ -40,7 +44,11 @@ class TestSelectProgramStatus(SystemTestSelectMethods):
     _tag = "program_status"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertProgramStatus(SystemTestInsertMethods):
     """Class for testing Program Status table do_insert() method."""
 
@@ -100,7 +108,10 @@ class TestInsertProgramStatus(SystemTestInsertMethods):
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteProgramStatus(SystemTestDeleteMethods):
     """Class for testing Program Status table do_delete() method."""
 
@@ -116,7 +127,10 @@ class TestDeleteProgramStatus(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateProgramStatus:
     """Class for testing Prog Status table do_update() and do_update_all() methods."""
 
@@ -299,9 +313,12 @@ class TestUpdateProgramStatus:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterProgramStatus(SystemTestGetterSetterMethods):
-    """Class for testing ProgramS tatus table getter and setter methods."""
+    """Class for testing ProgramStatus table getter and setter methods."""
 
     __test__ = True
 

--- a/tests/models/programdb/reliability/reliability_integration_test.py
+++ b/tests/models/programdb/reliability/reliability_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKReliabilityRecord
-from ramstk.models.dbtables import RAMSTKHardwareTable, RAMSTKReliabilityTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectReliability(SystemTestSelectMethods):
     """Class for testing Reliability table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectReliability(SystemTestSelectMethods):
     _tag = "reliability"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertReliability(SystemTestInsertMethods):
     """Class for testing Reliability table do_insert() method."""
 
@@ -128,7 +135,10 @@ class TestInsertReliability(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteReliability(SystemTestDeleteMethods):
     """Class for testing Reliability table do_delete() method."""
 
@@ -149,7 +159,10 @@ class TestDeleteReliability(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateReliability:
     """Class for testing Reliability table do_update() and do_update_all() methods."""
 
@@ -355,7 +368,10 @@ class TestUpdateReliability:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterReliability(SystemTestGetterSetterMethods):
     """Class for testing Reliability table getter and setter methods."""
 

--- a/tests/models/programdb/requirement/requirement_integration_test.py
+++ b/tests/models/programdb/requirement/requirement_integration_test.py
@@ -9,8 +9,6 @@
 # Copyright since 2007 Doyle "weibullguy" Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing Requirement module integrations."""
 
-# Standard Library Imports
-from datetime import date
 
 # Third Party Imports
 import pytest
@@ -19,7 +17,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKRequirementRecord
-from ramstk.models.dbtables import RAMSTKRequirementTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -28,7 +25,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectRequirement(SystemTestSelectMethods):
     """Class for testing Requirement table do_select() and do_select_all() methods."""
 
@@ -40,7 +41,11 @@ class TestSelectRequirement(SystemTestSelectMethods):
     _tag = "requirement"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertRequirement(SystemTestInsertMethods):
     """Class for testing Requirement table do_insert() method."""
 
@@ -51,7 +56,10 @@ class TestInsertRequirement(SystemTestInsertMethods):
     _tag = "requirement"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteRequirement(SystemTestDeleteMethods):
     """Class for testing Requirement table do_delete() method."""
 
@@ -63,7 +71,10 @@ class TestDeleteRequirement(SystemTestDeleteMethods):
     _tag = "requirement"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateRequirement:
     """Class for testing Requirement table do_update() and do_update_all() methods."""
 
@@ -249,7 +260,10 @@ class TestUpdateRequirement:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterRequirement(SystemTestGetterSetterMethods):
     """Class for testing Requirement table getter and setter methods."""
 

--- a/tests/models/programdb/revision/revision_integration_test.py
+++ b/tests/models/programdb/revision/revision_integration_test.py
@@ -25,7 +25,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectRevision(SystemTestSelectMethods):
     """Class for testing Revision table do_select() and do_select_all() methods."""
 
@@ -37,7 +41,11 @@ class TestSelectRevision(SystemTestSelectMethods):
     _tag = "revision"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertRevision(SystemTestInsertMethods):
     """Class for testing Revision table do_insert() method."""
 
@@ -84,8 +92,8 @@ class TestInsertRevision(SystemTestInsertMethods):
             "do_log_debug_msg",
         )
 
-        DUT = RAMSTKRevisionTable()
-        DUT.do_insert(attributes=test_attributes)
+        dut = RAMSTKRevisionTable()
+        dut.do_insert(attributes=test_attributes)
 
         pub.unsubscribe(
             self.on_fail_insert_no_database,
@@ -93,7 +101,10 @@ class TestInsertRevision(SystemTestInsertMethods):
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteRevision(SystemTestDeleteMethods):
     """Class for testing Revisions table do_delete() method."""
 
@@ -109,7 +120,10 @@ class TestDeleteRevision(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateRevision:
     """Class for testing Revision table do_update() and do_update_all() methods."""
 
@@ -295,7 +309,10 @@ class TestUpdateRevision:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterRevision(SystemTestGetterSetterMethods):
     """Class for testing Revision table getter and setter methods."""
 

--- a/tests/models/programdb/similar_item/similar_item_integration_test.py
+++ b/tests/models/programdb/similar_item/similar_item_integration_test.py
@@ -16,16 +16,18 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKSimilarItemRecord
-from ramstk.models.dbtables import RAMSTKHardwareTable, RAMSTKSimilarItemTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
-    SystemTestInsertMethods,
     SystemTestSelectMethods,
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectSimilarItem(SystemTestSelectMethods):
     """Class for testing Similar Item table do_select() and do_select_all() methods."""
 
@@ -38,7 +40,10 @@ class TestSelectSimilarItem(SystemTestSelectMethods):
 
 
 @pytest.mark.usefixtures(
-    "test_attributes", "integration_test_table_model", "test_hardware_table_model"
+    "test_attributes",
+    "integration_test_table_model",
+    "test_hardware_table_model",
+    "test_suite_logger",
 )
 class TestInsertSimilarItem:
     """Class for testing the Similar Item do_insert() method."""
@@ -101,7 +106,10 @@ class TestInsertSimilarItem:
         assert integration_test_table_model.tree.get_node(10) is None
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteSimilarItem(SystemTestDeleteMethods):
     """Class for testing Similar Item table do_delete() method."""
 
@@ -113,7 +121,10 @@ class TestDeleteSimilarItem(SystemTestDeleteMethods):
     _tag = "similar_item"
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateSimilarItem:
     """Class for testing SimilarItem update() and update_all() methods."""
 
@@ -335,7 +346,10 @@ class TestUpdateSimilarItem:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterSimilarItem(SystemTestGetterSetterMethods):
     """Class for testing Similar Item table getter and setter methods."""
 
@@ -347,7 +361,11 @@ class TestGetterSetterSimilarItem(SystemTestGetterSetterMethods):
     _test_id = 1
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSimilarItemAnalysisMethods:
     """Class for Similar Item analytical methods test suite."""
 

--- a/tests/models/programdb/stakeholder/stakeholder_integration_test.py
+++ b/tests/models/programdb/stakeholder/stakeholder_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKStakeholderRecord
-from ramstk.models.dbtables import RAMSTKStakeholderTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectStakeholder(SystemTestSelectMethods):
     """Class for testing Stakeholder table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectStakeholder(SystemTestSelectMethods):
     _tag = "stakeholder"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertStakeholder(SystemTestInsertMethods):
     """Class for testing Stakeholder table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertStakeholder(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteStakeholder(SystemTestDeleteMethods):
     """Class for testing Stakeholder table do_delete() method."""
 
@@ -74,7 +84,10 @@ class TestDeleteStakeholder(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateStakeholder:
     """Class for testing Stakeholder table do_update() and do_update_all() methods."""
 
@@ -271,7 +284,10 @@ class TestUpdateStakeholder:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterStakeholder(SystemTestGetterSetterMethods):
     """Class for testing Stakeholder table getter and setter methods."""
 
@@ -283,7 +299,10 @@ class TestGetterSetterStakeholder(SystemTestGetterSetterMethods):
     _test_id = 1
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestAnalysisStakeholder:
     """Class for testing Stakeholder analytical methods."""
 

--- a/tests/models/programdb/test_method/test_method_integration_test.py
+++ b/tests/models/programdb/test_method/test_method_integration_test.py
@@ -16,7 +16,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKTestMethodRecord
-from ramstk.models.dbtables import RAMSTKTestMethodTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -25,7 +24,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectTestMethod(SystemTestSelectMethods):
     """Class for testing Test Method table do_select() and do_select_all() methods."""
 
@@ -37,7 +40,11 @@ class TestSelectTestMethod(SystemTestSelectMethods):
     _tag = "test_method"
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestInsertTestMethod(SystemTestInsertMethods):
     """Class for testing Test Method table do_insert() method."""
 
@@ -58,7 +65,10 @@ class TestInsertTestMethod(SystemTestInsertMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestDeleteTestMethod(SystemTestDeleteMethods):
     """Class for testing Test Method table do_delete() method."""
 
@@ -74,7 +84,10 @@ class TestDeleteTestMethod(SystemTestDeleteMethods):
         pass
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestUpdateTestMethod:
     """Class for testing Test Method table do_update() and do_update_all() methods."""
 
@@ -256,7 +269,10 @@ class TestUpdateTestMethod:
         )
 
 
-@pytest.mark.usefixtures("integration_test_table_model")
+@pytest.mark.usefixtures(
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestGetterSetterTestMethod(SystemTestGetterSetterMethods):
     """Class for testing Test Method table getter and setter methods."""
 

--- a/tests/models/programdb/test_program_manager.py
+++ b/tests/models/programdb/test_program_manager.py
@@ -44,6 +44,7 @@ def test_datamanager():
     "test_program_dao",
     "test_toml_user_configuration",
     "test_bald_dao",
+    "test_suite_logger",
 )
 class TestProgramManager:
     """Test class for the RAMSTK Program Manager."""

--- a/tests/models/programdb/usage_profile/usage_profile_integration_test.py
+++ b/tests/models/programdb/usage_profile/usage_profile_integration_test.py
@@ -20,7 +20,6 @@ from ramstk.models.dbrecords import (
     RAMSTKMissionPhaseRecord,
     RAMSTKMissionRecord,
 )
-from ramstk.models.dbviews import RAMSTKUsageProfileView
 
 
 @pytest.mark.usefixtures(
@@ -28,6 +27,7 @@ from ramstk.models.dbviews import RAMSTKUsageProfileView
     "test_mission_table_model",
     "test_mission_phase_table_model",
     "test_environment_table_model",
+    "test_suite_logger",
 )
 class TestSelectUsageProfile:
     """Class for testing Usage Profile do_select() and do_select_all() methods."""
@@ -163,6 +163,7 @@ class TestSelectUsageProfile:
     "test_mission_table_model",
     "test_mission_phase_table_model",
     "test_environment_table_model",
+    "test_suite_logger",
 )
 class TestInsertUsageProfile:
     """Class for testing the Usage Profile on_insert() method."""
@@ -310,6 +311,7 @@ class TestInsertUsageProfile:
     "test_mission_table_model",
     "test_mission_phase_table_model",
     "test_environment_table_model",
+    "test_suite_logger",
 )
 class TestDeleteUsageProfile:
     """Class for testing the Usage Profile do_delete() method."""

--- a/tests/models/programdb/validation/validation_integration_test.py
+++ b/tests/models/programdb/validation/validation_integration_test.py
@@ -20,7 +20,6 @@ from treelib import Tree
 
 # RAMSTK Package Imports
 from ramstk.models.dbrecords import RAMSTKValidationRecord
-from ramstk.models.dbtables import RAMSTKValidationTable
 from tests import (
     SystemTestDeleteMethods,
     SystemTestGetterSetterMethods,
@@ -29,7 +28,11 @@ from tests import (
 )
 
 
-@pytest.mark.usefixtures("test_attributes", "integration_test_table_model")
+@pytest.mark.usefixtures(
+    "test_attributes",
+    "integration_test_table_model",
+    "test_suite_logger",
+)
 class TestSelectValidation(SystemTestSelectMethods):
     """Class for testing Validation table do_select() and do_select_all() methods."""
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,12 +5,11 @@
 #       tests.test_utilities.py is part of The RAMSTK Project
 #
 # All rights reserved.
-# Copyright 2007 - 2017 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
+# Copyright since 2007 Doyle Rowland doyle.rowland <AT> reliaqual <DOT> com
 """Test class for testing the Utilities module algorithms and models."""
 
 # Standard Library Imports
 import logging
-import os
 
 # Third Party Imports
 import pytest
@@ -56,7 +55,11 @@ class TestLogManager:
         assert pub.isSubscribed(test_logger.do_log_critical, "do_log_critical_msg")
 
     @pytest.mark.unit
-    def test_do_log_debug(self, test_logger, test_log_file):
+    def test_do_log_debug(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should be called when the do_log_debug_msg message is broadcast."""
         test_logger.do_create_logger("DEBUG", "DEBUG", True)
 
@@ -75,7 +78,11 @@ class TestLogManager:
         )
 
     @pytest.mark.unit
-    def test_do_log_info(self, test_logger, test_log_file):
+    def test_do_log_info(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should be called when the do_log_info_msg message is broadcast."""
         test_logger.do_create_logger("INFO", "INFO", True)
 
@@ -94,7 +101,11 @@ class TestLogManager:
         )
 
     @pytest.mark.unit
-    def test_do_log_info_ignore_debug(self, test_logger, test_log_file):
+    def test_do_log_info_ignore_debug(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should not be called when the do_log_debug_msg message is broadcast."""
         test_logger.do_create_logger("INFO", "INFO", True)
 
@@ -111,7 +122,11 @@ class TestLogManager:
         assert _lines == []
 
     @pytest.mark.unit
-    def test_do_log_info_higher_level_messages(self, test_logger, test_log_file):
+    def test_do_log_info_higher_level_messages(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should log WARN, ERROR, and CRITICAL level information an INFO manager."""
         test_logger.do_create_logger("INFO", "INFO")
 
@@ -138,15 +153,19 @@ class TestLogManager:
         assert _lines[0].split(":", 5)[-1].strip() == (
             "Test WARN message sent and logged."
         )
-        assert _lines[1].split(":", 5)[-1].strip() == (
+        assert _lines[2].split(":", 5)[-1].strip() == (
             "Test ERROR message sent and logged."
         )
-        assert _lines[2].split(":", 5)[-1].strip() == (
+        assert _lines[4].split(":", 5)[-1].strip() == (
             "Test CRITICAL message sent and logged."
         )
 
     @pytest.mark.unit
-    def test_do_log_warning(self, test_logger, test_log_file):
+    def test_do_log_warning(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should be called when the do_log_warning_msg message is broadcast."""
         test_logger.do_create_logger("WARN", "WARN", True)
 
@@ -165,7 +184,11 @@ class TestLogManager:
         )
 
     @pytest.mark.unit
-    def test_do_log_warning_ignore_debug_info(self, test_logger, test_log_file):
+    def test_do_log_warning_ignore_debug_info(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should not log a debug or info message."""
         test_logger.do_create_logger("WARN", "WARN", True)
 
@@ -187,7 +210,11 @@ class TestLogManager:
         assert _lines == []
 
     @pytest.mark.unit
-    def test_do_log_error(self, test_logger, test_log_file):
+    def test_do_log_error(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should be called when the do_log_error_msg message is broadcast."""
         test_logger.do_create_logger("ERROR", "ERROR", True)
 
@@ -206,7 +233,11 @@ class TestLogManager:
         )
 
     @pytest.mark.unit
-    def test_do_log_error_ignore_debug_info_warning(self, test_logger, test_log_file):
+    def test_do_log_error_ignore_debug_info_warning(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should not log a debug, info, or warning message."""
         test_logger.do_create_logger("ERROR", "ERROR", True)
 
@@ -233,7 +264,11 @@ class TestLogManager:
         assert _lines == []
 
     @pytest.mark.unit
-    def test_do_log_critical(self, test_logger, test_log_file):
+    def test_do_log_critical(
+        self,
+        test_logger,
+        test_log_file,
+    ):
         """Should be called when the do_log_critical_msg message is broadcast."""
         test_logger.do_create_logger("CRITICAL", "CRITICAL", True)
 
@@ -253,7 +288,9 @@ class TestLogManager:
 
     @pytest.mark.unit
     def test_do_log_critical_ignore_debug_info_warning_error(
-        self, test_logger, test_log_file
+        self,
+        test_logger,
+        test_log_file,
     ):
         """do_log_warning() should not log a debug, info, warning, or error message."""
         test_logger.do_create_logger("CRITICAL", "CRITICAL", True)


### PR DESCRIPTION
## Does this pull request introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If yes, describe the impact and migration path below. -->

## Purpose of this pull request
To add a test suite logger for logging all pubsub messages issued in the course of the test run.

## Benefits of the pull request
Helpful to ensure pubsub messages are being sent and logged.  Can be used to troubleshoot test failures.

## Any particular area(s) reviewers should focus on
None

## Any other pertinent information
<!-- Provide any other information that is important to this PR such as
screenshots if this impacts the GUI. -->


## Pull Request Checklist

- Code Style
  - [x] Code is following code style guidelines.

- Static Checks
  - [x] Failing static checks are only applicable to code outside the scope of
   this PR.

- Tests
  - [x] At least one test for all newly created functions/methods?

- Chores
  - [x] Issue(s) have been raised for problem areas outside the scope of
    this PR.  These problem areas have been decorated with an ISSUE: # comment.

## Summary by Sourcery

Adds a test suite logger to log all pubsub messages issued during test runs. This will help troubleshoot test failures and ensure messages are being sent and logged.

New Features:
- Adds a test suite logger to log all pubsub messages issued during test runs, which can be used to troubleshoot test failures and ensure messages are being sent and logged.

Tests:
- Adds a test suite logger fixture to conftest.py.
- Adds the test suite logger fixture to all integration tests.